### PR TITLE
Add `viewport-relative-units`

### DIFF
--- a/feature-group-definitions/viewport-relative-unit-variants.yml
+++ b/feature-group-definitions/viewport-relative-unit-variants.yml
@@ -1,0 +1,18 @@
+spec:
+  - https://drafts.csswg.org/css-values-4/#viewport-variants
+  - https://drafts.csswg.org/css-values-4/#viewport-relative-lengths
+caniuse: viewport-unit-variants
+status:
+  is_baseline: true
+  since: "2023-01-12"
+  support:
+    chrome: "108"
+    edge: "108"
+    firefox: "101"
+    safari: "15.4"
+compat_features:
+  - css.types.length.vb
+  - css.types.length.vi
+  - css.types.length.viewport_percentage_units_dynamic # BCD combines features: dvb, dvh, dvi, dvmax, dvmin, dvw
+  - css.types.length.viewport_percentage_units_large # BCD combines features: lvb, lvh, lvi, lvmax, lvmin, lvw
+  - css.types.length.viewport_percentage_units_small # BCD combines features: svb, svh, svi, svmax, svmin, svw

--- a/feature-group-definitions/viewport-relative-units.yml
+++ b/feature-group-definitions/viewport-relative-units.yml
@@ -1,0 +1,25 @@
+spec:
+  - https://drafts.csswg.org/css-values-4/#viewport-relative-lengths
+  - https://drafts.csswg.org/css-values-4/#viewport-variants
+caniuse:
+  - viewport-units
+  - viewport-unit-variants
+status:
+  is_baseline: true
+  since: "2023-01-12"
+  support:
+    chrome: "108"
+    edge: "108"
+    firefox: "101"
+    safari: "15.4"
+compat_features:
+  - css.types.length.viewport_percentage_units_dynamic # BCD combines features: dvb, dvh, dvi, dvmax, dvmin, dvw
+  - css.types.length.viewport_percentage_units_large # BCD combines features: lvb, lvh, lvi, lvmax, lvmin, lvw
+  - css.types.length.viewport_percentage_units_small # BCD combines features: svb, svh, svi, svmax, svmin, svw
+  # BCD *does not* combine these into (one would assume) `viewport_percentage_units` or `viewport_percentage_units_default`
+  - css.types.length.vb
+  - css.types.length.vh
+  - css.types.length.vi
+  - css.types.length.vmax
+  - css.types.length.vmin
+  - css.types.length.vw

--- a/feature-group-definitions/viewport-relative-units.yml
+++ b/feature-group-definitions/viewport-relative-units.yml
@@ -1,25 +1,16 @@
-spec:
-  - https://drafts.csswg.org/css-values-4/#viewport-relative-lengths
-  - https://drafts.csswg.org/css-values-4/#viewport-variants
-caniuse:
-  - viewport-units
-  - viewport-unit-variants
+spec: https://drafts.csswg.org/css-values-4/#viewport-relative-lengths
+caniuse: viewport-units
 status:
   is_baseline: true
-  since: "2023-01-12"
+  since: "2018-04-30"
   support:
-    chrome: "108"
-    edge: "108"
-    firefox: "101"
-    safari: "15.4"
+    chrome: "26"
+    edge: "16"
+    firefox: "102"
+    safari: "7"
 compat_features:
-  - css.types.length.viewport_percentage_units_dynamic # BCD combines features: dvb, dvh, dvi, dvmax, dvmin, dvw
-  - css.types.length.viewport_percentage_units_large # BCD combines features: lvb, lvh, lvi, lvmax, lvmin, lvw
-  - css.types.length.viewport_percentage_units_small # BCD combines features: svb, svh, svi, svmax, svmin, svw
-  # BCD *does not* combine these into (one would assume) `viewport_percentage_units` or `viewport_percentage_units_default`
-  - css.types.length.vb
+  # Excludes `vb` and `vi` because they were introduced later (see `viewport-relative-unit-variants`)
   - css.types.length.vh
-  - css.types.length.vi
   - css.types.length.vmax
   - css.types.length.vmin
   - css.types.length.vw


### PR DESCRIPTION
Here's a fun one that tests the limits of the schema: viewport relative units, such as `vw`, `lvw`, `svw`, `dvw`, and friends.

Some thoughts on this one:

- I nearly made (and still might have) two separate groups here: one for (most of) the older user-agent default viewport lengths and one for the newer small, large, and dynamic lengths. I opted for one group for a bunch little reasons:

    - a weird gap in the spec and support for the original units (`vi`), which was only resolved at the introduction of the new units
    - a want for a good name for the new units
    - my own (mostly-incorrect) understanding that the original units _weren't_ widely supported until recently
    
  Taken together, I made an editorial decision that viewport-relative units weren't really "done" until recently and could be safely grouped together. This is a place where a subject matter expert review would be valuable.

- This covers _two_ caniuse groups (which is perhaps the strongest argument _against_ grouping these together). But perhaps this does imply we ought to have the `caniuse` field permit arrays. This is also another instance where it'd be useful to have two spec URLs.

- I've discovered yet another BCD quirk: some values are grouped, others aren't, which makes writing the feature list tedious. In most cases, I think BCD ought to have separate features for each keyword/token—it'd be a lot easier to look them up that way. I'd settle for some sort of "see also" structure in BCD though.