### PR TITLE
Create `svg2-script-html-equivalance` feature

### DIFF
--- a/feature-group-definitions/svg2-script-html-equivalance.yml
+++ b/feature-group-definitions/svg2-script-html-equivalance.yml
@@ -1,6 +1,5 @@
 spec: https://svgwg.org/svg2-draft/interact.html#ScriptElement
 compat_features:
-  - svg.elements.script
   - svg.elements.script.async
   - svg.elements.script.defer
   - svg.elements.script.module

--- a/feature-group-definitions/svg2-script-html-equivalance.yml
+++ b/feature-group-definitions/svg2-script-html-equivalance.yml
@@ -1,5 +1,7 @@
 spec: https://svgwg.org/svg2-draft/interact.html#ScriptElement
 compat_features:
+  - api.SVGScriptElement.async
+  - api.SVGScriptElement.defer
   - svg.elements.script.async
   - svg.elements.script.defer
   - svg.elements.script.module

--- a/feature-group-definitions/svg2-script-html-equivalance.yml
+++ b/feature-group-definitions/svg2-script-html-equivalance.yml
@@ -1,0 +1,6 @@
+spec: https://svgwg.org/svg2-draft/interact.html#ScriptElement
+compat_features:
+  - svg.elements.script
+  - svg.elements.script.async
+  - svg.elements.script.defer
+  - svg.elements.script.module

--- a/feature-group-definitions/svg2-script-html-equivalance.yml
+++ b/feature-group-definitions/svg2-script-html-equivalance.yml
@@ -4,4 +4,4 @@ compat_features:
   - api.SVGScriptElement.defer
   - svg.elements.script.async
   - svg.elements.script.defer
-  - svg.elements.script.module
+  - svg.elements.script.type.module


### PR DESCRIPTION
This captures the requirement for SVG `<script>` elements to operate equivalently to HTML's `<script>` elements, including `async`, `defer`, and `module`.

I borrowed from the spec to name it, so I don't know if it's a good name. `async-deferable-modular-scripts-in-svg` felt like a mouthful.

cc: @bsmth, @Elchi3 

See also: https://github.com/mdn/browser-compat-data/pull/20502/