### PR TITLE
Add `modulepreload` feature for `<link rel="modulepreload">`

### DIFF
--- a/feature-group-definitions/modulepreload.yml
+++ b/feature-group-definitions/modulepreload.yml
@@ -1,0 +1,4 @@
+spec: https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload
+caniuse: link-rel-modulepreload
+compat_features:
+  - html.elements.link.modulepreload

--- a/feature-group-definitions/modulepreload.yml
+++ b/feature-group-definitions/modulepreload.yml
@@ -1,3 +1,4 @@
+name: '<link rel="modulepreload">'
 spec: https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload
 caniuse: link-rel-modulepreload
 compat_features:


### PR DESCRIPTION
Some ideas for reviewing this:

- Is this a reasonable identifier for the feature?
- Is this a reasonable spec link for the feature? Is it a reasonable caniuse reference?
- Are the [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) features plausible pieces of the feature as a whole?
- Are any pieces missing?
- Are any of the listed features later additions, part of a distinct sub feature, or otherwise excludable?
