### PR TITLE
Add `overflow` shorthand feature (with `clip` values)

### DIFF
--- a/feature-group-definitions/overflow-shorthand.yml
+++ b/feature-group-definitions/overflow-shorthand.yml
@@ -1,0 +1,15 @@
+spec: https://drafts.csswg.org/css-overflow-3/#propdef-overflow
+caniuse: css-overflow
+compat_features:
+  - css.properties.overflow-x
+  - css.properties.overflow-x.clip
+  - css.properties.overflow-y
+  - css.properties.overflow-y.clip
+  - css.properties.overflow
+  - css.properties.overflow.clip
+  - css.properties.overflow.multiple_keywords
+  # BCD appears to represent `<overflow>` values as both
+  # 1) keyword subfeatures on properties (above) and
+  # 2) a type (below)
+  - css.types.overflow
+  - css.types.overflow.clip


### PR DESCRIPTION
This corresponds to https://caniuse.com/css-overflow

This is a new feature. Here are some ideas for reviewing it:

- Is this a reasonable identifier for the feature?
- Does this have a reasonable spec link?
- Does this have a reasonable caniuse reference?
- Are the [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) features plausible pieces of the feature as a whole?
- Are any pieces missing?
- Are any of the listed features later additions, part of a distinct sub feature, or otherwise excludable?
