### PR TITLE
Add `:default` pseudo class feature

### DIFF
--- a/feature-group-definitions/default.yml
+++ b/feature-group-definitions/default.yml
@@ -1,0 +1,4 @@
+spec: https://drafts.csswg.org/selectors-4/#the-default-pseudo
+caniuse: css-default-pseudo
+compat_features:
+  - css.selectors.default


### PR DESCRIPTION
Corresponding to https://caniuse.com/css-default-pseudo

This is a new feature. Here are some ideas for reviewing it:

- Is this a reasonable identifier for the feature?
- Does this have a reasonable spec link?
- Does this have a reasonable caniuse reference?
- Are the [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) features plausible pieces of the feature as a whole?
- Are any pieces missing?
- Are any of the listed features later additions, part of a distinct sub feature, or otherwise excludable?
