### PR TITLE
Add `:indeterminate` pseudo class feature

### DIFF
--- a/feature-group-definitions/indeterminate.yml
+++ b/feature-group-definitions/indeterminate.yml
@@ -3,7 +3,6 @@ spec:
   - https://html.spec.whatwg.org/multipage/semantics-other.html#selector-indeterminate
 caniuse: css-indeterminate-pseudo
 compat_features:
-  - api.HTMLInputElement.indeterminate
   - css.selectors.indeterminate
   - css.selectors.indeterminate.checkbox
   - css.selectors.indeterminate.progress

--- a/feature-group-definitions/indeterminate.yml
+++ b/feature-group-definitions/indeterminate.yml
@@ -1,0 +1,10 @@
+spec:
+  - https://drafts.csswg.org/selectors-4/#indeterminate
+  - https://html.spec.whatwg.org/multipage/semantics-other.html#selector-indeterminate
+caniuse: css-indeterminate-pseudo
+compat_features:
+  - api.HTMLInputElement.indeterminate
+  - css.selectors.indeterminate
+  - css.selectors.indeterminate.checkbox
+  - css.selectors.indeterminate.progress
+  - css.selectors.indeterminate.radio


### PR DESCRIPTION
Corresponds to https://caniuse.com/css-indeterminate-pseudo

This is a new feature. Here are some ideas for reviewing it:

- Is this a reasonable identifier for the feature?
- Does this have a reasonable spec link?
- Does this have a reasonable caniuse reference?
- Are the [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) features plausible pieces of the feature as a whole?
- Are any pieces missing?
- Are any of the listed features later additions, part of a distinct sub feature, or otherwise excludable?
