### PR TITLE
Add `:is()` pseudo-class feature

### DIFF
--- a/feature-group-definitions/is.yml
+++ b/feature-group-definitions/is.yml
@@ -1,5 +1,6 @@
 spec: https://drafts.csswg.org/selectors-4/#matches
 caniuse: css-matches-pseudo
+usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2322
 compat_features:
   - css.selectors.is
   - css.selectors.is.forgiving_selector_list

--- a/feature-group-definitions/is.yml
+++ b/feature-group-definitions/is.yml
@@ -1,0 +1,5 @@
+spec: https://drafts.csswg.org/selectors-4/#matches
+caniuse: css-matches-pseudo
+compat_features:
+  - css.selectors.is
+  - css.selectors.is.forgiving_selector_list


### PR DESCRIPTION
Corresponds to https://caniuse.com/css-matches-pseudo

This is a new feature. Here are some ideas for reviewing it:

- Is this a reasonable identifier for the feature?
- Does this have a reasonable spec link?
- Does this have a reasonable caniuse reference?
- Are the [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) features plausible pieces of the feature as a whole?
- Are any pieces missing?
- Are any of the listed features later additions, part of a distinct sub feature, or otherwise excludable?
