### PR TITLE
Add `:read-write` and `:read-only` pseudo-classes

### DIFF
--- a/feature-group-definitions/read-write-pseudo-classes.yml
+++ b/feature-group-definitions/read-write-pseudo-classes.yml
@@ -1,0 +1,7 @@
+spec:
+  - https://html.spec.whatwg.org/multipage/semantics-other.html#selector-read-only
+  - https://drafts.csswg.org/selectors-4/#rw-pseudos
+caniuse: css-read-only-write
+compat_features:
+  - css.selectors.read-only
+  - css.selectors.read-write


### PR DESCRIPTION
Corresponds to https://caniuse.com/css-read-only-write

This is a new feature. Here are some ideas for reviewing it:

- Is this a reasonable identifier for the feature?
- Does this have a reasonable spec link?
- Does this have a reasonable caniuse reference?
- Are the [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) features plausible pieces of the feature as a whole?
- Are any pieces missing?
- Are any of the listed features later additions, part of a distinct sub feature, or otherwise excludable?
