### PR TITLE
Add `tabindex` global attribute feature

### DIFF
--- a/feature-group-definitions/tabindex.yml
+++ b/feature-group-definitions/tabindex.yml
@@ -1,0 +1,5 @@
+spec: https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex
+caniuse: tabindex-attr
+compat_features:
+  - api.HTMLElement.tabIndex
+  - html.global_attributes.tabindex


### PR DESCRIPTION
Corresponds to https://caniuse.com/tabindex-attr

This is a new feature. Here are some ideas for reviewing it:

- Is this a reasonable identifier for the feature?
- Does this have a reasonable spec link?
- Does this have a reasonable caniuse reference?
- Are the [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) features plausible pieces of the feature as a whole?
- Are any pieces missing?
- Are any of the listed features later additions, part of a distinct sub feature, or otherwise excludable?
