### PR TITLE
Add `Element.scrollIntoView()` feature

### DIFF
--- a/feature-group-definitions/scrollintoview.yml
+++ b/feature-group-definitions/scrollintoview.yml
@@ -1,0 +1,5 @@
+spec: https://drafts.csswg.org/cssom-view-1/#dom-element-scrollintoview
+caniuse: scrollintoview
+compat_features:
+  - api.Element.scrollIntoView
+  - api.Element.scrollIntoView.options_parameter


### PR DESCRIPTION
Corresponds to https://caniuse.com/scrollintoview

This is a new feature. Here are some ideas for reviewing it:

- Is this a recognizable web feature to web developers? (caniuse features are often made by request, so it's likely, but let's double check our work here.)
- Is this a reasonable identifier for the feature?
- Does this have a reasonable spec link?
- Does this have a reasonable caniuse reference?
- Are the [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) features plausible pieces of the feature as a whole?
- Are any pieces missing?
- Are any of the listed features later additions, part of a distinct sub feature, or otherwise excludable?
