### PR TITLE
Add `Object.entries()` feature

### DIFF
--- a/feature-group-definitions/object-entries.yml
+++ b/feature-group-definitions/object-entries.yml
@@ -1,0 +1,4 @@
+spec: https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.entries
+caniuse: object-entries
+compat_features:
+  - javascript.builtins.Object.entries


### PR DESCRIPTION
Corresponds to https://caniuse.com/object-entries

Now that I've done something like this a few times: I wonder if it would be a good idea to a have shorthand for "there is a one-to-one correspondence between this a BCD key and a caniuse key."

---

This is a new feature. Here are some ideas for reviewing it:

- Is this a recognizable web feature to web developers? (caniuse features are often made by request, so it's likely, but let's double check our work here.)
- Is this a reasonable identifier for the feature?
- Does this have a reasonable spec link?
- Does this have a reasonable caniuse reference?
- Are the [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) features plausible pieces of the feature as a whole?
- Are any pieces missing?
- Are any of the listed features later additions, part of a distinct sub feature, or otherwise excludable?
