### PR TITLE
Add `<input type="search">` feature

### DIFF
--- a/feature-group-definitions/search-input-type.yml
+++ b/feature-group-definitions/search-input-type.yml
@@ -1,0 +1,4 @@
+spec: https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)
+caniuse: input-search
+compat_features:
+  - html.elements.input.type_search

--- a/feature-group-definitions/search-input-type.yml
+++ b/feature-group-definitions/search-input-type.yml
@@ -1,3 +1,4 @@
+name: '<input type="search">'
 spec: https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)
 caniuse: input-search
 compat_features:


### PR DESCRIPTION
Corresponds to https://caniuse.com/input-search

This is a new feature. Here are some ideas for reviewing it:

- Is this a recognizable web feature to web developers? (caniuse features are often made by request, so it's likely, but let's double check our work here.)
- Is this a reasonable identifier for the feature?
- Does this have a reasonable spec link?
- Does this have a reasonable caniuse reference?
- Are the [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) features plausible pieces of the feature as a whole?
- Are any pieces missing?
- Are any of the listed features later additions, part of a distinct sub feature, or otherwise excludable?
