### PR TITLE
Add `input` event feature

### DIFF
--- a/feature-group-definitions/input-event.yml
+++ b/feature-group-definitions/input-event.yml
@@ -2,3 +2,10 @@ spec: https://w3c.github.io/uievents/#event-type-input
 caniuse: input-event
 compat_features:
   - api.HTMLElement.input_event
+  - api.InputEvent
+  - api.InputEvent.InputEvent
+  - api.InputEvent.data
+  - api.InputEvent.dataTransfer
+  - api.InputEvent.getTargetRanges
+  - api.InputEvent.inputType
+  - api.InputEvent.isComposing

--- a/feature-group-definitions/input-event.yml
+++ b/feature-group-definitions/input-event.yml
@@ -1,0 +1,4 @@
+spec: https://w3c.github.io/uievents/#event-type-input
+caniuse: input-event
+compat_features:
+  - api.HTMLElement.input_event


### PR DESCRIPTION
Corresponds to https://caniuse.com/input-event

This is a new feature. Here are some ideas for reviewing it:

- Is this a recognizable web feature to web developers? (caniuse features are often made by request, so it's likely, but let's double check our work here.)
- Is this a reasonable identifier for the feature?
- Does this have a reasonable spec link?
- Does this have a reasonable caniuse reference?
- Are the [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) features plausible pieces of the feature as a whole?
- Are any pieces missing?
- Are any of the listed features later additions, part of a distinct sub feature, or otherwise excludable?
