### PR TITLE
Add `<input type="file" accept="…">` feature

### DIFF
--- a/feature-group-definitions/input-file-accept-attribute.yml
+++ b/feature-group-definitions/input-file-accept-attribute.yml
@@ -1,0 +1,5 @@
+spec: https://html.spec.whatwg.org/multipage/input.html#attr-input-accept
+caniuse: input-file-accept
+compat_features:
+  - api.HTMLInputElement.accept
+  - html.elements.input.accept


### PR DESCRIPTION
Corresponds to https://caniuse.com/input-file-accept

This is a new feature. Here are some ideas for reviewing it:

- Is this a recognizable web feature to web developers? (caniuse features are often made by request, so it's likely, but let's double check our work here.)
- Is this a reasonable identifier for the feature?
- Does this have a reasonable spec link?
- Does this have a reasonable caniuse reference?
- Are the [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) features plausible pieces of the feature as a whole?
- Are any pieces missing?
- Are any of the listed features later additions, part of a distinct sub feature, or otherwise excludable?
