### PR TITLE
Add `maxlength` attributes feature

### DIFF
--- a/feature-group-definitions/maxlength.yml
+++ b/feature-group-definitions/maxlength.yml
@@ -1,0 +1,10 @@
+spec:
+  - https://html.spec.whatwg.org/multipage/input.html#the-maxlength-and-minlength-attributes
+  - https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-maxlength
+  - https://html.spec.whatwg.org/multipage/input.html#dom-input-maxlength
+caniuse: maxlength
+compat_features:
+  - api.HTMLInputElement.maxLength
+  - api.HTMLTextAreaElement.maxLength
+  - html.elements.input.maxlength
+  - html.elements.textarea.maxlength


### PR DESCRIPTION

🖐 On hold. This ought to be merged with a forms feature. 🖐

---

Corresponds to https://caniuse.com/maxlength

This is a new feature. Here are some ideas for reviewing it:

- Is this a recognizable web feature to web developers? (caniuse features are often made by request, so it's likely, but let's double check our work here.)
- Is this a reasonable identifier for the feature?
- Does this have a reasonable spec link?
- Does this have a reasonable caniuse reference?
- Are the [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) features plausible pieces of the feature as a whole?
- Are any pieces missing?
- Are any of the listed features later additions, part of a distinct sub feature, or otherwise excludable?
