### PR TITLE
Add `const` and `let` features

### DIFF
--- a/feature-group-definitions/const.yml
+++ b/feature-group-definitions/const.yml
@@ -1,0 +1,4 @@
+spec: https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-let-and-const-declarations
+caniuse: const
+compat_features:
+  - javascript.statements.const

--- a/feature-group-definitions/let.yml
+++ b/feature-group-definitions/let.yml
@@ -1,0 +1,4 @@
+spec: https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-let-and-const-declarations
+caniuse: let
+compat_features:
+  - javascript.statements.let


### PR DESCRIPTION
At some point, I'll be making an ES6 group, so these will eventually join that group. Otherwise, these would feel pretty trivial.

These correspond to:

- https://caniuse.com/const
- https://caniuse.com/let

---

This is a new feature. Here are some ideas for reviewing it:

- Is this a recognizable web feature to web developers? (caniuse features are often made by request, so it's likely, but let's double check our work here.)
- Is this a reasonable identifier for the feature?
- Does this have a reasonable spec link?
- Does this have a reasonable caniuse reference?
- Are the [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) features plausible pieces of the feature as a whole?
- Are any pieces missing?
- Are any of the listed features later additions, part of a distinct sub feature, or otherwise excludable?
