### PR TITLE
Add `font-variant-alternates` feature

### DIFF
--- a/feature-group-definitions/font-variant-alternates.yml
+++ b/feature-group-definitions/font-variant-alternates.yml
@@ -1,4 +1,4 @@
-spec: https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-alternates
+spec: https://drafts.csswg.org/css-fonts-4/#font-variant-alternates-prop
 caniuse: font-variant-alternates
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/738
 compat_features:

--- a/feature-group-definitions/font-variant-alternates.yml
+++ b/feature-group-definitions/font-variant-alternates.yml
@@ -1,5 +1,6 @@
 spec: https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-alternates
 caniuse: font-variant-alternates
+usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/738
 compat_features:
   - css.properties.font-variant-alternates
   - css.properties.font-variant-alternates.annotation

--- a/feature-group-definitions/font-variant-alternates.yml
+++ b/feature-group-definitions/font-variant-alternates.yml
@@ -1,0 +1,10 @@
+spec: https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-alternates
+caniuse: font-variant-alternates
+compat_features:
+  - css.properties.font-variant-alternates
+  - css.properties.font-variant-alternates.annotation
+  - css.properties.font-variant-alternates.character_variant
+  - css.properties.font-variant-alternates.ornaments
+  - css.properties.font-variant-alternates.styleset
+  - css.properties.font-variant-alternates.stylistic
+  - css.properties.font-variant-alternates.swash


### PR DESCRIPTION
Corresponds to https://caniuse.com/font-variant-alternates

I think caniuse might be slightly wrong about the support story here. It doesn't call out some [differences in Safari noted by BCD](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-alternates#browser_compatibility). Another one that may require work when we generate statuses.

<details>
<summary>This is a new feature. Expand for ideas for reviewing it.</summary>

- Is this a recognizable web feature to web developers? (caniuse features are often made by request, so it's likely, but let's double check our work here.)
- Is this a reasonable identifier for the feature?
- Does this have a reasonable spec link?
- Does this have a reasonable caniuse reference?
- Are the [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) features plausible pieces of the feature as a whole?
- Are any pieces missing?
- Are any of the listed features later additions, part of a distinct sub feature, or otherwise excludable?

</details>