### PR TITLE
Add Set methods group

### DIFF
--- a/feature-group-definitions/set-methods.yml
+++ b/feature-group-definitions/set-methods.yml
@@ -1,0 +1,9 @@
+spec: https://tc39.es/proposal-set-methods/
+compat_features:
+  - javascript.builtins.Set.difference
+  - javascript.builtins.Set.intersection
+  - javascript.builtins.Set.isDisjointFrom
+  - javascript.builtins.Set.isSubsetOf
+  - javascript.builtins.Set.isSupersetOf
+  - javascript.builtins.Set.symmetricDifference
+  - javascript.builtins.Set.union


### PR DESCRIPTION
https://github.com/tc39/proposal-set-methods

Thoughts I had while creating this PR:

- Should I sort the `compat_feature` list alphabetically?
- It's all flat in one folder... Should this be in a javascript folder? hm, but there will be groups that will have features from various technologies, so maybe should it be categorized in some other way? In a 2023 folder? Maybe we don't need folders for now...