### PR TITLE
Reject hidden caniuse features

### DIFF
--- a/scripts/caniuse.ts
+++ b/scripts/caniuse.ts
@@ -20,7 +20,12 @@ const mapping = new Map<string, string | null>(
     Object.keys(lite.features).sort().map(id => [id, null])
 );
 
-const hiddenCaniuseItems = new Set(Object.entries(lite.features).flatMap(([id, data]) => !lite.feature(data).shown ? [id] : []));
+const hiddenCaniuseItems = new Set<string>();
+for (const [id, data] of Object.entries(lite.features)) {
+    if (!lite.feature(data).shown) {
+        hiddenCaniuseItems.add(id);
+    }
+}
 
 for (const [id, data] of Object.entries(features)) {
     if (!('caniuse' in data)) {

--- a/scripts/caniuse.ts
+++ b/scripts/caniuse.ts
@@ -20,7 +20,7 @@ const mapping = new Map<string, string | null>(
     Object.keys(lite.features).sort().map(id => [id, null])
 );
 
-const hiddenCaniuseItems = Object.entries(lite.features).flatMap(([id, data]) => !lite.feature(data).shown ? [id] : []);
+const hiddenCaniuseItems = new Set(Object.entries(lite.features).flatMap(([id, data]) => !lite.feature(data).shown ? [id] : []));
 
 for (const [id, data] of Object.entries(features)) {
     if (!('caniuse' in data)) {
@@ -30,7 +30,7 @@ for (const [id, data] of Object.entries(features)) {
     if (!mapping.has(caniuseId)) {
         throw new Error(`Invalid caniuse ID used for ${id}: ${caniuseId}`);
     }
-    if (hiddenCaniuseItems.includes(caniuseId)) {
+    if (hiddenCaniuseItems.has(caniuseId)) {
         throw new Error(`The caniuse ID used for "${id}" ("${caniuseId}") is hidden on caniuse.com`);
     }
 
@@ -40,7 +40,7 @@ for (const [id, data] of Object.entries(features)) {
 let matched = 0;
 
 for (const [caniuseId, id] of mapping.entries()) {
-    const isHidden = hiddenCaniuseItems.includes(caniuseId);
+    const isHidden = hiddenCaniuseItems.has(caniuseId);
     const isComplete = id || isHidden;
 
     if (isComplete) {

--- a/scripts/caniuse.ts
+++ b/scripts/caniuse.ts
@@ -20,6 +20,14 @@ const mapping = new Map<string, string | null>(
     Object.keys(lite.features).sort().map(id => [id, null])
 );
 
+// Fix missing key-value in @types/caniuse-lite
+// TODO: remove this declaration when https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67330 lands
+declare module 'caniuse-lite' {
+    interface Feature {
+      shown: boolean;
+    }
+  }
+
 const hiddenCaniuseItems = new Set<string>();
 for (const [id, data] of Object.entries(lite.features)) {
     if (!lite.feature(data).shown) {


### PR DESCRIPTION
~~The build will fail on this PR because `@types/caniuse-lite`'s type definitions are out of date. See: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67330.~~ I've temporarily overridden the type so we can move on with this.

This PR checks that features' `caniuse` values point only to features that appear on caniuse.com. It disallows caniuse ID where the caniuse `shown` property is `false`.

This impacts the caniuse burndown list. I've chosen to mark them as complete, but also to note that they're hidden features.

This PR closes #275.