### PR TITLE
`async-await`: set Baseline status

### DIFF
--- a/feature-group-definitions/async-await.yml
+++ b/feature-group-definitions/async-await.yml
@@ -1,5 +1,16 @@
 spec: https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-async-function-definitions
 caniuse: async-functions
+status:
+  baseline: high
+  baseline_low_date: 2017-04-05
+  support:
+    chrome: "55"
+    chrome_android: "55"
+    edge: "15"
+    firefox: "52"
+    firefox_android: "52"
+    safari: "10.1"
+    safari_ios: "10.3"
 compat_features:
   - javascript.builtins.AsyncFunction
   - javascript.builtins.AsyncFunction.AsyncFunction


### PR DESCRIPTION
## async-await

| Key                                             | Baseline | Since      | Versions                                                                                                                    |
| :---------------------------------------------- | :------: | :--------- | --------------------------------------------------------------------------------------------------------------------------- |
| **async-await**                                 |     ✅    | 2017-04-05 | Chrome 55<br>Chrome Android 55<br>Edge 15 🔑💎<br>Firefox 52<br>Firefox for Android 52<br>Safari 10.1<br>Safari on iOS 10.3 |
| javascript.builtins.AsyncFunction               |     ✅    | 2017-04-05 | Chrome 55<br>Chrome Android 55<br>Edge 15 🔑💎<br>Firefox 52<br>Firefox for Android 52<br>Safari 10.1<br>Safari on iOS 10.3 |
| javascript.builtins.AsyncFunction.AsyncFunction |     ✅    | 2017-04-05 | Chrome 55<br>Chrome Android 55<br>Edge 15 🔑💎<br>Firefox 52<br>Firefox for Android 52<br>Safari 10.1<br>Safari on iOS 10.3 |
| javascript.operators.async_function             |     ✅    | 2017-04-05 | Chrome 55<br>Chrome Android 55<br>Edge 15 🔑💎<br>Firefox 52<br>Firefox for Android 52<br>Safari 10.1<br>Safari on iOS 10.3 |
| javascript.operators.await                      |     ✅    | 2017-03-27 | Chrome 55<br>Chrome Android 55<br>Edge 14<br>Firefox 52<br>Firefox for Android 52<br>Safari 10.1 🔑💎<br>Safari on iOS 10.3 |
| javascript.statements.async_function            |     ✅    | 2017-04-05 | Chrome 55<br>Chrome Android 55<br>Edge 15 🔑💎<br>Firefox 52<br>Firefox for Android 52<br>Safari 10.1<br>Safari on iOS 10.3 |