### PR TITLE
`async-clipboard`: set Baseline status

### DIFF
--- a/feature-group-definitions/async-clipboard.yml
+++ b/feature-group-definitions/async-clipboard.yml
@@ -1,5 +1,8 @@
 spec: https://w3c.github.io/clipboard-apis/#async-clipboard-api
 caniuse: async-clipboard
+status:
+  baseline: false
+  support: {}
 compat_features:
   - api.Clipboard
   - api.Clipboard.read


### PR DESCRIPTION
| Key                                       | Baseline | Since      | Versions                                                                                                                    |
| :---------------------------------------- | :------: | :--------- | --------------------------------------------------------------------------------------------------------------------------- |
| **async-clipboard**                       |     ❌    |            | Chrome ❌<br>Chrome Android ❌<br>Edge ❌<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌                 |
| api.Clipboard                             |     ✅    | 2020-03-24 | Chrome 66<br>Chrome Android 66<br>Edge 79<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| api.Clipboard.read                        |     ❌    |            | Chrome ❌<br>Chrome Android ❌<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 13.1<br>Safari on iOS 13.4          |
| api.Clipboard.readText                    |     ❌    |            | Chrome 66<br>Chrome Android 66<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 13.1<br>Safari on iOS 13.4        |
| api.Clipboard.write                       |     ❌    |            | Chrome 66<br>Chrome Android 66<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 13.1<br>Safari on iOS 13.4        |
| api.Clipboard.writeText                   |     ✅    | 2020-03-24 | Chrome 66<br>Chrome Android 66<br>Edge 79<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| api.ClipboardEvent                        |     ✅    | 2017-03-27 | Chrome 41<br>Chrome Android 41<br>Edge 12<br>Firefox 22<br>Firefox for Android 22<br>Safari 10.1 🔑💎<br>Safari on iOS 10.3 |
| api.ClipboardEvent.ClipboardEvent         |     ✅    | 2018-04-30 | Chrome 58<br>Chrome Android 58<br>Edge 17 🔑💎<br>Firefox 22<br>Firefox for Android 22<br>Safari 10.1<br>Safari on iOS 10.3 |
| api.ClipboardEvent.clipboardData          |     ✅    | 2017-03-27 | Chrome 41<br>Chrome Android 41<br>Edge 12<br>Firefox 22<br>Firefox for Android 22<br>Safari 10.1 🔑💎<br>Safari on iOS 10.3 |
| api.ClipboardItem                         |     ❌    |            | Chrome 76<br>Chrome Android 84<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 13.1<br>Safari on iOS 13.4        |
| api.ClipboardItem.ClipboardItem           |     ❌    |            | Chrome 98<br>Chrome Android 98<br>Edge 98<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 13.1<br>Safari on iOS 13.4        |
| api.ClipboardItem.getType                 |     ❌    |            | Chrome 76<br>Chrome Android 84<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 13.1<br>Safari on iOS 13.4        |
| api.ClipboardItem.presentationStyle       |     ❌    |            | Chrome ❌<br>Chrome Android ❌<br>Edge ❌<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 13.1<br>Safari on iOS 13.4           |
| api.ClipboardItem.types                   |     ❌    |            | Chrome 76<br>Chrome Android 84<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 13.1<br>Safari on iOS 13.4        |
| api.Navigator.clipboard                   |     ✅    | 2020-03-24 | Chrome 66<br>Chrome Android 66<br>Edge 79<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| api.Permissions.permission_clipboard-read |     ❌    |            | Chrome 64<br>Chrome Android 64<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌              |