### PR TITLE
`b*` features: set Baseline status

### DIFF
--- a/feature-group-definitions/background-fetch.yml
+++ b/feature-group-definitions/background-fetch.yml
@@ -1,4 +1,10 @@
 spec: https://wicg.github.io/background-fetch/
+status:
+  baseline: false
+  support:
+    chrome: "74"
+    chrome_android: "74"
+    edge: "79"
 compat_features:
   - api.BackgroundFetchEvent
   - api.BackgroundFetchEvent.BackgroundFetchEvent

--- a/feature-group-definitions/bigint.yml
+++ b/feature-group-definitions/bigint.yml
@@ -1,5 +1,16 @@
 spec: https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint-objects
 caniuse: bigint
+status:
+  baseline: high
+  baseline_low_date: 2020-09-16
+  support:
+    chrome: "67"
+    chrome_android: "67"
+    edge: "79"
+    firefox: "68"
+    firefox_android: "68"
+    safari: "14"
+    safari_ios: "14"
 compat_features:
   - javascript.builtins.BigInt
   # TODO: use a wildcard for these features, once implemented

--- a/feature-group-definitions/broadcast-channel.yml
+++ b/feature-group-definitions/broadcast-channel.yml
@@ -1,6 +1,17 @@
 spec: https://html.spec.whatwg.org/multipage/web-messaging.html#broadcasting-to-other-browsing-contexts
 caniuse: broadcastchannel
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1447
+status:
+  baseline: low
+  baseline_low_date: 2022-03-15
+  support:
+    chrome: "60"
+    chrome_android: "60"
+    edge: "79"
+    firefox: "57"
+    firefox_android: "57"
+    safari: "15.4"
+    safari_ios: "15.4"
 compat_features:
   - api.BroadcastChannel
   - api.BroadcastChannel.BroadcastChannel


### PR DESCRIPTION
## background-fetch

| Key                                                           | Baseline | Since | Versions                                                                                                       |
| :------------------------------------------------------------ | :------: | :---- | -------------------------------------------------------------------------------------------------------------- |
| **background-fetch**                                          |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchEvent                                      |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchEvent.BackgroundFetchEvent                 |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchEvent.registration                         |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchManager                                    |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchManager                                    |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchManager.fetch                              |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchManager.get                                |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchManager.getIds                             |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchRecord                                     |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchRecord.request                             |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchRecord.responseReady                       |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchRegistration.abort                         |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchRegistration.downloaded                    |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchRegistration.downloadTotal                 |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchRegistration.failureReason                 |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchRegistration.id                            |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchRegistration.match                         |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchRegistration.matchAll                      |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchRegistration.progress_event                |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchRegistration.recordsAvailable              |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchRegistration.result                        |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchRegistration.uploaded                      |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchRegistration.uploadTotal                   |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchUpdateUIEvent                              |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchUpdateUIEvent.BackgroundFetchUpdateUIEvent |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.BackgroundFetchUpdateUIEvent.updateUI                     |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.ServiceWorkerGlobalScope.backgroundfetchabort_event       |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.ServiceWorkerGlobalScope.backgroundfetchclick_event       |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.ServiceWorkerGlobalScope.backgroundfetchfail_event        |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.ServiceWorkerGlobalScope.backgroundfetchsuccess_event     |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| api.ServiceWorkerRegistration.backgroundFetch                 |     ❌    |       | Chrome 74<br>Chrome Android 74<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |

## bigint

| Key                                       | Baseline | Since      | Versions                                                                                                                |
| :---------------------------------------- | :------: | :--------- | ----------------------------------------------------------------------------------------------------------------------- |
| **bigint**                                |     ✅    | 2020-09-16 | Chrome 67<br>Chrome Android 67<br>Edge 79<br>Firefox 68<br>Firefox for Android 68<br>Safari 14 🔑💎<br>Safari on iOS 14 |
| javascript.builtins.BigInt                |     ✅    | 2020-09-16 | Chrome 67<br>Chrome Android 67<br>Edge 79<br>Firefox 68<br>Firefox for Android 68<br>Safari 14 🔑💎<br>Safari on iOS 14 |
| javascript.builtins.BigInt.asIntN         |     ✅    | 2020-09-16 | Chrome 67<br>Chrome Android 67<br>Edge 79<br>Firefox 68<br>Firefox for Android 68<br>Safari 14 🔑💎<br>Safari on iOS 14 |
| javascript.builtins.BigInt.asUintN        |     ✅    | 2020-09-16 | Chrome 67<br>Chrome Android 67<br>Edge 79<br>Firefox 68<br>Firefox for Android 68<br>Safari 14 🔑💎<br>Safari on iOS 14 |
| javascript.builtins.BigInt.BigInt         |     ✅    | 2020-09-16 | Chrome 67<br>Chrome Android 67<br>Edge 79<br>Firefox 68<br>Firefox for Android 68<br>Safari 14 🔑💎<br>Safari on iOS 14 |
| javascript.builtins.BigInt.toLocaleString |     ✅    | 2020-09-16 | Chrome 67<br>Chrome Android 67<br>Edge 79<br>Firefox 68<br>Firefox for Android 68<br>Safari 14 🔑💎<br>Safari on iOS 14 |
| javascript.builtins.BigInt.toString       |     ✅    | 2020-09-16 | Chrome 67<br>Chrome Android 67<br>Edge 79<br>Firefox 68<br>Firefox for Android 68<br>Safari 14 🔑💎<br>Safari on iOS 14 |
| javascript.builtins.BigInt.valueOf        |     ✅    | 2020-09-16 | Chrome 67<br>Chrome Android 67<br>Edge 79<br>Firefox 68<br>Firefox for Android 68<br>Safari 14 🔑💎<br>Safari on iOS 14 |

## broadcast-channel

| Key                                     | Baseline | Since      | Versions                                                                                                                    |
| :-------------------------------------- | :------: | :--------- | --------------------------------------------------------------------------------------------------------------------------- |
| **broadcast-channel**                   |    🔵    | 2022-03-15 | Chrome 60<br>Chrome Android 60<br>Edge 79<br>Firefox 57<br>Firefox for Android 57<br>Safari 15.4 🔑💎<br>Safari on iOS 15.4 |
| api.BroadcastChannel                    |    🔵    | 2022-03-15 | Chrome 54<br>Chrome Android 54<br>Edge 79<br>Firefox 38<br>Firefox for Android 38<br>Safari 15.4 🔑💎<br>Safari on iOS 15.4 |
| api.BroadcastChannel.BroadcastChannel   |    🔵    | 2022-03-15 | Chrome 54<br>Chrome Android 54<br>Edge 79<br>Firefox 38<br>Firefox for Android 38<br>Safari 15.4 🔑💎<br>Safari on iOS 15.4 |
| api.BroadcastChannel.close              |    🔵    | 2022-03-15 | Chrome 54<br>Chrome Android 54<br>Edge 79<br>Firefox 38<br>Firefox for Android 38<br>Safari 15.4 🔑💎<br>Safari on iOS 15.4 |
| api.BroadcastChannel.message_event      |    🔵    | 2022-03-15 | Chrome 54<br>Chrome Android 54<br>Edge 79<br>Firefox 38<br>Firefox for Android 38<br>Safari 15.4 🔑💎<br>Safari on iOS 15.4 |
| api.BroadcastChannel.messageerror_event |    🔵    | 2022-03-15 | Chrome 60<br>Chrome Android 60<br>Edge 79<br>Firefox 57<br>Firefox for Android 57<br>Safari 15.4 🔑💎<br>Safari on iOS 15.4 |
| api.BroadcastChannel.name               |    🔵    | 2022-03-15 | Chrome 54<br>Chrome Android 54<br>Edge 79<br>Firefox 38<br>Firefox for Android 38<br>Safari 15.4 🔑💎<br>Safari on iOS 15.4 |
| api.BroadcastChannel.postMessage        |    🔵    | 2022-03-15 | Chrome 54<br>Chrome Android 54<br>Edge 79<br>Firefox 38<br>Firefox for Android 38<br>Safari 15.4 🔑💎<br>Safari on iOS 15.4 |