### PR TITLE
`c*` features: set Baseline status (and correct feature list)

### DIFF
--- a/feature-group-definitions/class-syntax.yml
+++ b/feature-group-definitions/class-syntax.yml
@@ -1,5 +1,16 @@
 caniuse: es6-class
 spec: https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions
+status:
+  baseline: high
+  baseline_low_date: 2017-03-27
+  support:
+    chrome: "42"
+    chrome_android: "42"
+    edge: "13"
+    firefox: "45"
+    firefox_android: "45"
+    safari: "10.1"
+    safari_ios: "10.3"
 compat_features:
   - javascript.classes
   - javascript.classes.constructor

--- a/feature-group-definitions/constraint-validation.yml
+++ b/feature-group-definitions/constraint-validation.yml
@@ -1,5 +1,16 @@
 spec: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api
 caniuse: constraint-validation
+status:
+  baseline: low
+  baseline_low_date: 2023-03-27
+  support:
+    chrome: "77"
+    chrome_android: "77"
+    edge: "79"
+    firefox: "98"
+    firefox_android: "98"
+    safari: "16.4"
+    safari_ios: "16.4"
 compat_features:
   - api.ElementInternals.checkValidity
   - api.ElementInternals.reportValidity

--- a/feature-group-definitions/content-visibility.yml
+++ b/feature-group-definitions/content-visibility.yml
@@ -1,7 +1,13 @@
 spec: https://drafts.csswg.org/css-contain-2/#content-visibility
 caniuse: css-content-visibility
+status:
+  baseline: false
+  support:
+    chrome: "108"
+    chrome_android: "108"
+    edge: "108"
 compat_features:
-  - api.ContentVisibilityAutoStateChangeEvent.ContentVisibilityAutoStateChangeEvent
-  - api.ContentVisibilityAutoStateChangeEvent.ContentVisibilityAutoStateChangeEvent.skipped
   - api.ContentVisibilityAutoStateChangeEvent
+  - api.ContentVisibilityAutoStateChangeEvent.ContentVisibilityAutoStateChangeEvent
+  - api.ContentVisibilityAutoStateChangeEvent.skipped
   - css.properties.content-visibility

--- a/feature-group-definitions/custom-elements.yml
+++ b/feature-group-definitions/custom-elements.yml
@@ -1,5 +1,11 @@
 spec: https://html.spec.whatwg.org/multipage/custom-elements.html
 caniuse: custom-elementsv1
+status:
+  baseline: false
+  support:
+    chrome: "73"
+    chrome_android: "73"
+    edge: "79"
 compat_features:
   - api.CustomElementRegistry
   - api.CustomElementRegistry.builtin_element_support

--- a/feature-group-definitions/custom-properties.yml
+++ b/feature-group-definitions/custom-properties.yml
@@ -1,5 +1,16 @@
 spec: https://drafts.csswg.org/css-variables-1/
 caniuse: css-variables
+status:
+  baseline: high
+  baseline_low_date: 2017-04-05
+  support:
+    chrome: "49"
+    chrome_android: "49"
+    edge: "15"
+    firefox: "31"
+    firefox_android: "31"
+    safari: "9.1"
+    safari_ios: "9.3"
 compat_features:
   - css.properties.custom-property
   - css.properties.custom-property.var


### PR DESCRIPTION
## class-syntax

| Key                            | Baseline | Since      | Versions                                                                                                                    |
| :----------------------------- | :------: | :--------- | --------------------------------------------------------------------------------------------------------------------------- |
| **class-syntax**               |     ✅    | 2017-03-27 | Chrome 42<br>Chrome Android 42<br>Edge 13<br>Firefox 45<br>Firefox for Android 45<br>Safari 10.1 🔑💎<br>Safari on iOS 10.3 |
| javascript.classes             |     ✅    | 2016-03-08 | Chrome 42<br>Chrome Android 42<br>Edge 13<br>Firefox 45 🔑💎<br>Firefox for Android 45<br>Safari 9<br>Safari on iOS 9       |
| javascript.classes.constructor |     ✅    | 2016-03-08 | Chrome 42<br>Chrome Android 42<br>Edge 13<br>Firefox 45 🔑💎<br>Firefox for Android 45<br>Safari 9<br>Safari on iOS 9       |
| javascript.classes.extends     |     ✅    | 2016-03-08 | Chrome 42<br>Chrome Android 42<br>Edge 13<br>Firefox 45 🔑💎<br>Firefox for Android 45<br>Safari 9<br>Safari on iOS 9       |
| javascript.classes.static      |     ✅    | 2016-03-08 | Chrome 42<br>Chrome Android 42<br>Edge 13<br>Firefox 45 🔑💎<br>Firefox for Android 45<br>Safari 9<br>Safari on iOS 9       |
| javascript.statements.class    |     ✅    | 2017-03-27 | Chrome 42<br>Chrome Android 42<br>Edge 13<br>Firefox 45<br>Firefox for Android 45<br>Safari 10.1 🔑💎<br>Safari on iOS 10.3 |

## constraint-validation

| Key                                       | Baseline | Since      | Versions                                                                                                                    |
| :---------------------------------------- | :------: | :--------- | --------------------------------------------------------------------------------------------------------------------------- |
| **constraint-validation**                 |    🔵    | 2023-03-27 | Chrome 77<br>Chrome Android 77<br>Edge 79<br>Firefox 98<br>Firefox for Android 98<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| api.ElementInternals.checkValidity        |    🔵    | 2023-03-27 | Chrome 77<br>Chrome Android 77<br>Edge 79<br>Firefox 98<br>Firefox for Android 98<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| api.ElementInternals.reportValidity       |    🔵    | 2023-03-27 | Chrome 77<br>Chrome Android 77<br>Edge 79<br>Firefox 98<br>Firefox for Android 98<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| api.ElementInternals.setValidity          |    🔵    | 2023-03-27 | Chrome 77<br>Chrome Android 77<br>Edge 79<br>Firefox 98<br>Firefox for Android 98<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| api.ElementInternals.validationMessage    |    🔵    | 2023-03-27 | Chrome 77<br>Chrome Android 77<br>Edge 79<br>Firefox 98<br>Firefox for Android 98<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| api.ElementInternals.validity             |    🔵    | 2023-03-27 | Chrome 77<br>Chrome Android 77<br>Edge 79<br>Firefox 98<br>Firefox for Android 98<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| api.ElementInternals.willValidate         |    🔵    | 2023-03-27 | Chrome 77<br>Chrome Android 77<br>Edge 79<br>Firefox 98<br>Firefox for Android 98<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| api.HTMLButtonElement.checkValidity       |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |
| api.HTMLButtonElement.reportValidity      |     ✅    | 2018-12-11 | Chrome 40<br>Chrome Android 40<br>Edge 17<br>Firefox 49<br>Firefox for Android 64 🔑💎<br>Safari 10.1<br>Safari on iOS 10.3 |
| api.HTMLButtonElement.setCustomValidity   |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |
| api.HTMLButtonElement.validationMessage   |     ✅    | 2015-07-28 | Chrome 5<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 4          |
| api.HTMLButtonElement.validity            |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 4          |
| api.HTMLButtonElement.willValidate        |     ✅    | 2015-07-28 | Chrome 2<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 4<br>Safari on iOS 3          |
| api.HTMLFieldSetElement.checkValidity     |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |
| api.HTMLFieldSetElement.reportValidity    |     ✅    | 2018-12-11 | Chrome 40<br>Chrome Android 40<br>Edge 17<br>Firefox 49<br>Firefox for Android 64 🔑💎<br>Safari 10.1<br>Safari on iOS 10.3 |
| api.HTMLFieldSetElement.setCustomValidity |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |
| api.HTMLFieldSetElement.validationMessage |     ✅    | 2015-07-28 | Chrome 5<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 4          |
| api.HTMLFieldSetElement.validity          |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 4          |
| api.HTMLFieldSetElement.willValidate      |     ✅    | 2015-07-28 | Chrome 2<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 4<br>Safari on iOS 3          |
| api.HTMLFormElement.checkValidity         |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 4          |
| api.HTMLFormElement.reportValidity        |     ✅    | 2018-04-30 | Chrome 40<br>Chrome Android 40<br>Edge 17 🔑💎<br>Firefox 49<br>Firefox for Android 49<br>Safari 10.1<br>Safari on iOS 10.3 |
| api.HTMLInputElement.checkValidity        |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 4          |
| api.HTMLInputElement.reportValidity       |     ✅    | 2018-12-11 | Chrome 40<br>Chrome Android 40<br>Edge 17<br>Firefox 49<br>Firefox for Android 64 🔑💎<br>Safari 10.1<br>Safari on iOS 10.3 |
| api.HTMLInputElement.setCustomValidity    |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 4          |
| api.HTMLInputElement.validationMessage    |     ✅    | 2015-07-28 | Chrome 5<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 4          |
| api.HTMLInputElement.validity             |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 4          |
| api.HTMLInputElement.willValidate         |     ✅    | 2015-07-28 | Chrome 2<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 4<br>Safari on iOS 3          |
| api.HTMLObjectElement.checkValidity       |     ✅    | 2015-07-28 | Chrome 10<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5.1<br>Safari on iOS 5       |
| api.HTMLObjectElement.reportValidity      |     ✅    | 2018-10-02 | Chrome 40<br>Chrome Android 40<br>Edge 18 🔑💎<br>Firefox 49<br>Firefox for Android 49<br>Safari 10.1<br>Safari on iOS 10.3 |
| api.HTMLObjectElement.setCustomValidity   |     ✅    | 2015-07-28 | Chrome 10<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5.1<br>Safari on iOS 5       |
| api.HTMLObjectElement.validationMessage   |     ✅    | 2015-07-28 | Chrome 10<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5.1<br>Safari on iOS 5       |
| api.HTMLObjectElement.validity            |     ✅    | 2015-07-28 | Chrome 10<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5.1<br>Safari on iOS 5       |
| api.HTMLObjectElement.willValidate        |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 4          |
| api.HTMLOutputElement.checkValidity       |     ✅    | 2016-08-02 | Chrome 9<br>Chrome Android 18<br>Edge 14 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5.1<br>Safari on iOS 5        |
| api.HTMLOutputElement.reportValidity      |     ✅    | 2017-03-27 | Chrome 40<br>Chrome Android 40<br>Edge 14<br>Firefox 49<br>Firefox for Android 49<br>Safari 10.1 🔑💎<br>Safari on iOS 10.3 |
| api.HTMLOutputElement.setCustomValidity   |     ✅    | 2016-08-02 | Chrome 9<br>Chrome Android 18<br>Edge 14 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5.1<br>Safari on iOS 5        |
| api.HTMLOutputElement.validationMessage   |     ✅    | 2016-08-02 | Chrome 9<br>Chrome Android 18<br>Edge 14 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5.1<br>Safari on iOS 5        |
| api.HTMLOutputElement.validity            |     ✅    | 2016-08-02 | Chrome 9<br>Chrome Android 18<br>Edge 14 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5.1<br>Safari on iOS 5        |
| api.HTMLOutputElement.willValidate        |     ✅    | 2016-08-02 | Chrome 9<br>Chrome Android 18<br>Edge 14 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5.1<br>Safari on iOS 5        |
| api.HTMLSelectElement.checkValidity       |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 4          |
| api.HTMLSelectElement.reportValidity      |     ✅    | 2018-12-11 | Chrome 40<br>Chrome Android 40<br>Edge 17<br>Firefox 49<br>Firefox for Android 64 🔑💎<br>Safari 10.1<br>Safari on iOS 10.3 |
| api.HTMLSelectElement.setCustomValidity   |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 4          |
| api.HTMLSelectElement.validationMessage   |     ✅    | 2015-07-28 | Chrome 5<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 4          |
| api.HTMLSelectElement.validity            |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 4          |
| api.HTMLSelectElement.willValidate        |     ✅    | 2015-07-28 | Chrome 2<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 4<br>Safari on iOS 3          |
| api.HTMLTextAreaElement.checkValidity     |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |
| api.HTMLTextAreaElement.reportValidity    |     ✅    | 2018-12-11 | Chrome 40<br>Chrome Android 40<br>Edge 17<br>Firefox 49<br>Firefox for Android 64 🔑💎<br>Safari 10.1<br>Safari on iOS 10.3 |
| api.HTMLTextAreaElement.setCustomValidity |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |
| api.HTMLTextAreaElement.validationMessage |     ✅    | 2015-07-28 | Chrome 5<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |
| api.HTMLTextAreaElement.validity          |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |
| api.HTMLTextAreaElement.willValidate      |     ✅    | 2015-07-28 | Chrome 2<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 4<br>Safari on iOS 3.2        |
| api.ValidityState                         |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |
| api.ValidityState.badInput                |     ✅    | 2018-12-11 | Chrome 25<br>Chrome Android 25<br>Edge 12<br>Firefox 29<br>Firefox for Android 64 🔑💎<br>Safari 7<br>Safari on iOS 7       |
| api.ValidityState.customError             |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |
| api.ValidityState.patternMismatch         |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |
| api.ValidityState.rangeOverflow           |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |
| api.ValidityState.rangeUnderflow          |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |
| api.ValidityState.stepMismatch            |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |
| api.ValidityState.tooLong                 |     ✅    | 2018-12-11 | Chrome 4<br>Chrome Android 18<br>Edge 12<br>Firefox 4<br>Firefox for Android 64 🔑💎<br>Safari 5<br>Safari on iOS 5         |
| api.ValidityState.tooShort                |     ✅    | 2018-12-11 | Chrome 40<br>Chrome Android 40<br>Edge 17<br>Firefox 51<br>Firefox for Android 64 🔑💎<br>Safari 10<br>Safari on iOS 10     |
| api.ValidityState.typeMismatch            |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |
| api.ValidityState.valid                   |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |
| api.ValidityState.valueMissing            |     ✅    | 2015-07-28 | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5          |

## content-visibility

| Key                                                                             | Baseline | Since | Versions                                                                                                             |
| :------------------------------------------------------------------------------ | :------: | :---- | -------------------------------------------------------------------------------------------------------------------- |
| **content-visibility**                                                          |     ❌    |       | Chrome 108<br>Chrome Android 108<br>Edge 108<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| api.ContentVisibilityAutoStateChangeEvent                                       |     ❌    |       | Chrome 108<br>Chrome Android 108<br>Edge 108<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| api.ContentVisibilityAutoStateChangeEvent.ContentVisibilityAutoStateChangeEvent |     ❌    |       | Chrome 108<br>Chrome Android 108<br>Edge 108<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| api.ContentVisibilityAutoStateChangeEvent.skipped                               |     ❌    |       | Chrome 108<br>Chrome Android 108<br>Edge 108<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| css.properties.content-visibility                                               |     ❌    |       | Chrome 85<br>Chrome Android 85<br>Edge 85<br>Firefox preview<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |

## custom-elements

| Key                                               | Baseline | Since      | Versions                                                                                                                    |
| :------------------------------------------------ | :------: | :--------- | --------------------------------------------------------------------------------------------------------------------------- |
| **custom-elements**                               |     ❌    |            | Chrome 73<br>Chrome Android 73<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌              |
| api.CustomElementRegistry                         |     ✅    | 2020-01-15 | Chrome 54<br>Chrome Android 54<br>Edge 79 🔑💎<br>Firefox 63<br>Firefox for Android 63<br>Safari 10.1<br>Safari on iOS 10.3 |
| api.CustomElementRegistry.builtin_element_support |     ❌    |            | Chrome 67<br>Chrome Android 67<br>Edge 79<br>Firefox 63<br>Firefox for Android 63<br>Safari ❌<br>Safari on iOS ❌            |
| api.CustomElementRegistry.define                  |     ✅    | 2020-01-15 | Chrome 54<br>Chrome Android 54<br>Edge 79 🔑💎<br>Firefox 63<br>Firefox for Android 63<br>Safari 10.1<br>Safari on iOS 10.3 |
| api.Window.customElements                         |     ✅    | 2020-01-15 | Chrome 54<br>Chrome Android 54<br>Edge 79 🔑💎<br>Firefox 63<br>Firefox for Android 63<br>Safari 10.1<br>Safari on iOS 10.3 |
| css.selectors.defined                             |     ✅    | 2020-01-15 | Chrome 54<br>Chrome Android 54<br>Edge 79 🔑💎<br>Firefox 63<br>Firefox for Android 63<br>Safari 10<br>Safari on iOS 10     |
| css.selectors.host                                |     ✅    | 2020-01-15 | Chrome 54<br>Chrome Android 54<br>Edge 79 🔑💎<br>Firefox 63<br>Firefox for Android 63<br>Safari 10<br>Safari on iOS 10     |
| css.selectors.host-context                        |     ❌    |            | Chrome 54<br>Chrome Android 54<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌              |
| css.selectors.part                                |     ✅    | 2020-07-28 | Chrome 73<br>Chrome Android 73<br>Edge 79<br>Firefox 72<br>Firefox for Android 79 🔑💎<br>Safari 13.1<br>Safari on iOS 13.4 |

## custom-properties

| Key                                | Baseline | Since      | Versions                                                                                                                  |
| :--------------------------------- | :------: | :--------- | ------------------------------------------------------------------------------------------------------------------------- |
| **custom-properties**              |     ✅    | 2017-04-05 | Chrome 49<br>Chrome Android 49<br>Edge 15 🔑💎<br>Firefox 31<br>Firefox for Android 31<br>Safari 9.1<br>Safari on iOS 9.3 |
| css.properties.custom-property     |     ✅    | 2017-04-05 | Chrome 49<br>Chrome Android 49<br>Edge 15 🔑💎<br>Firefox 31<br>Firefox for Android 31<br>Safari 9.1<br>Safari on iOS 9.3 |
| css.properties.custom-property.var |     ✅    | 2017-04-05 | Chrome 49<br>Chrome Android 49<br>Edge 15 🔑💎<br>Firefox 31<br>Firefox for Android 31<br>Safari 9.1<br>Safari on iOS 9.3 |