### PR TITLE
📦 Release web-features@0.5.0-alpha.0

### DIFF
--- a/packages/web-features/package-lock.json
+++ b/packages/web-features/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-features",
-  "version": "0.5.0",
+  "version": "0.5.1-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-features",
-      "version": "0.5.0",
+      "version": "0.5.1-0",
       "devDependencies": {
         "typescript": "^5.0.4"
       }

--- a/packages/web-features/package-lock.json
+++ b/packages/web-features/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-features",
-  "version": "0.4.2-0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-features",
-      "version": "0.4.2-0",
+      "version": "0.5.0",
       "devDependencies": {
         "typescript": "^5.0.4"
       }

--- a/packages/web-features/package-lock.json
+++ b/packages/web-features/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-features",
-  "version": "0.4.1",
+  "version": "0.4.2-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-features",
-      "version": "0.4.1",
+      "version": "0.4.2-0",
       "devDependencies": {
         "typescript": "^5.0.4"
       }

--- a/packages/web-features/package-lock.json
+++ b/packages/web-features/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-features",
-  "version": "0.5.1-0",
+  "version": "0.5.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-features",
-      "version": "0.5.1-0",
+      "version": "0.5.0-alpha.0",
       "devDependencies": {
         "typescript": "^5.0.4"
       }

--- a/packages/web-features/package.json
+++ b/packages/web-features/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-features",
   "description": "Curated list of Web platform features",
-  "version": "0.5.0",
+  "version": "0.5.1-0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/web-features/package.json
+++ b/packages/web-features/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-features",
   "description": "Curated list of Web platform features",
-  "version": "0.4.2-0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/web-features/package.json
+++ b/packages/web-features/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-features",
   "description": "Curated list of Web platform features",
-  "version": "0.4.1",
+  "version": "0.4.2-0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/web-features/package.json
+++ b/packages/web-features/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-features",
   "description": "Curated list of Web platform features",
-  "version": "0.5.1-0",
+  "version": "0.5.0-alpha.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
⚠ Caution! Merging this PR triggers a release. Continue reading before merging. ⚠

```diff
--- /var/folders/5v/mzyz10hs433586qr7xtrqth00000gn/T/web-features-sL0hyu/index.released.pretty.json	2023-11-30 15:56:09.000000000 +0100
+++ /var/folders/5v/mzyz10hs433586qr7xtrqth00000gn/T/web-features-sL0hyu/index.prepared.pretty.json	2023-11-30 15:56:12.000000000 +0100
@@ -32,7 +32,50 @@
       "javascript.operators.await",
       "javascript.statements.async_function"
     ],
-    "spec": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-async-function-definitions"
+    "spec": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-async-function-definitions",
+    "status": {
+      "baseline": "high",
+      "baseline_low_date": "2017-04-05",
+      "support": {
+        "chrome": "55",
+        "chrome_android": "55",
+        "edge": "15",
+        "firefox": "52",
+        "firefox_android": "52",
+        "safari": "10.1",
+        "safari_ios": "10.3"
+      }
+    }
+  },
+  "async-clipboard": {
+    "caniuse": "async-clipboard",
+    "compat_features": [
+      "api.Clipboard",
+      "api.Clipboard.read",
+      "api.Clipboard.readText",
+      "api.Clipboard.write",
+      "api.Clipboard.writeText",
+      "api.ClipboardEvent",
+      "api.ClipboardEvent.ClipboardEvent",
+      "api.ClipboardEvent.clipboardData",
+      "api.ClipboardItem",
+      "api.ClipboardItem.ClipboardItem",
+      "api.ClipboardItem.getType",
+      "api.ClipboardItem.presentationStyle",
+      "api.ClipboardItem.types",
+      "api.Navigator.clipboard",
+      "api.Permissions.permission_clipboard-read"
+    ],
+    "spec": "https://w3c.github.io/clipboard-apis/#async-clipboard-api",
+    "status": {
+      "baseline": false,
+      "support": {}
+    }
+  },
+  "avif": {
+    "caniuse": "avif",
+    "spec": "https://aomediacodec.github.io/av1-avif/",
+    "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/3798"
   },
   "background-fetch": {
     "compat_features": [
@@ -68,7 +111,15 @@
       "api.ServiceWorkerGlobalScope.backgroundfetchsuccess_event",
       "api.ServiceWorkerRegistration.backgroundFetch"
     ],
-    "spec": "https://wicg.github.io/background-fetch/"
+    "spec": "https://wicg.github.io/background-fetch/",
+    "status": {
+      "baseline": false,
+      "support": {
+        "chrome": "74",
+        "chrome_android": "74",
+        "edge": "79"
+      }
+    }
   },
   "bigint": {
     "caniuse": "bigint",
@@ -81,7 +132,20 @@
       "javascript.builtins.BigInt.toString",
       "javascript.builtins.BigInt.valueOf"
     ],
-    "spec": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint-objects"
+    "spec": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint-objects",
+    "status": {
+      "baseline": "high",
+      "baseline_low_date": "2020-09-16",
+      "support": {
+        "chrome": "67",
+        "chrome_android": "67",
+        "edge": "79",
+        "firefox": "68",
+        "firefox_android": "68",
+        "safari": "14",
+        "safari_ios": "14"
+      }
+    }
   },
   "border-image": {
     "caniuse": "border-image",
@@ -100,20 +164,45 @@
     ],
     "spec": "https://drafts.csswg.org/css-backgrounds-3/#border-images",
     "status": {
-      "is_baseline": true,
-      "since": "2017-03-09",
+      "baseline": "high",
+      "baseline_low_date": "2017-02-01",
       "support": {
         "chrome": "56",
+        "chrome_android": "56",
         "edge": "12",
         "firefox": "50",
-        "safari": "9.1"
+        "firefox_android": "50",
+        "safari": "9.1",
+        "safari_ios": "9.3"
       }
     },
     "usage_stats": "https://chromestatus.com/metrics/css/timeline/popularity/43"
   },
   "broadcast-channel": {
     "caniuse": "broadcastchannel",
+    "compat_features": [
+      "api.BroadcastChannel",
+      "api.BroadcastChannel.BroadcastChannel",
+      "api.BroadcastChannel.close",
+      "api.BroadcastChannel.message_event",
+      "api.BroadcastChannel.messageerror_event",
+      "api.BroadcastChannel.name",
+      "api.BroadcastChannel.postMessage"
+    ],
     "spec": "https://html.spec.whatwg.org/multipage/web-messaging.html#broadcasting-to-other-browsing-contexts",
+    "status": {
+      "baseline": "low",
+      "baseline_low_date": "2022-03-15",
+      "support": {
+        "chrome": "60",
+        "chrome_android": "60",
+        "edge": "79",
+        "firefox": "57",
+        "firefox_android": "57",
+        "safari": "15.4",
+        "safari_ios": "15.4"
+      }
+    },
     "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/1447"
   },
   "canvas-context-lost": {
@@ -127,9 +216,10 @@
     ],
     "spec": "https://html.spec.whatwg.org/multipage/webappapis.html#context-lost-steps",
     "status": {
-      "is_baseline": false,
+      "baseline": false,
       "support": {
         "chrome": "99",
+        "chrome_android": "99",
         "edge": "99"
       }
     },
@@ -148,13 +238,16 @@
     ],
     "spec": "https://drafts.csswg.org/css-cascade-5/#layering",
     "status": {
-      "is_baseline": true,
-      "since": "2022-09-19",
+      "baseline": "low",
+      "baseline_low_date": "2022-03-15",
       "support": {
         "chrome": "99",
+        "chrome_android": "99",
         "edge": "99",
         "firefox": "97",
-        "safari": "15.4"
+        "firefox_android": "97",
+        "safari": "15.4",
+        "safari_ios": "15.4"
       }
     },
     "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/4007"
@@ -168,7 +261,101 @@
       "javascript.classes.static",
       "javascript.statements.class"
     ],
-    "spec": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions"
+    "spec": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions",
+    "status": {
+      "baseline": "high",
+      "baseline_low_date": "2017-03-27",
+      "support": {
+        "chrome": "42",
+        "chrome_android": "42",
+        "edge": "13",
+        "firefox": "45",
+        "firefox_android": "45",
+        "safari": "10.1",
+        "safari_ios": "10.3"
+      }
+    }
+  },
+  "constraint-validation": {
+    "caniuse": "constraint-validation",
+    "compat_features": [
+      "api.ElementInternals.checkValidity",
+      "api.ElementInternals.reportValidity",
+      "api.ElementInternals.setValidity",
+      "api.ElementInternals.validationMessage",
+      "api.ElementInternals.validity",
+      "api.ElementInternals.willValidate",
+      "api.HTMLButtonElement.checkValidity",
+      "api.HTMLButtonElement.reportValidity",
+      "api.HTMLButtonElement.setCustomValidity",
+      "api.HTMLButtonElement.validationMessage",
+      "api.HTMLButtonElement.validity",
+      "api.HTMLButtonElement.willValidate",
+      "api.HTMLFieldSetElement.checkValidity",
+      "api.HTMLFieldSetElement.reportValidity",
+      "api.HTMLFieldSetElement.setCustomValidity",
+      "api.HTMLFieldSetElement.validationMessage",
+      "api.HTMLFieldSetElement.validity",
+      "api.HTMLFieldSetElement.willValidate",
+      "api.HTMLFormElement.checkValidity",
+      "api.HTMLFormElement.reportValidity",
+      "api.HTMLInputElement.checkValidity",
+      "api.HTMLInputElement.reportValidity",
+      "api.HTMLInputElement.setCustomValidity",
+      "api.HTMLInputElement.validationMessage",
+      "api.HTMLInputElement.validity",
+      "api.HTMLInputElement.willValidate",
+      "api.HTMLObjectElement.checkValidity",
+      "api.HTMLObjectElement.reportValidity",
+      "api.HTMLObjectElement.setCustomValidity",
+      "api.HTMLObjectElement.validationMessage",
+      "api.HTMLObjectElement.validity",
+      "api.HTMLObjectElement.willValidate",
+      "api.HTMLOutputElement.checkValidity",
+      "api.HTMLOutputElement.reportValidity",
+      "api.HTMLOutputElement.setCustomValidity",
+      "api.HTMLOutputElement.validationMessage",
+      "api.HTMLOutputElement.validity",
+      "api.HTMLOutputElement.willValidate",
+      "api.HTMLSelectElement.checkValidity",
+      "api.HTMLSelectElement.reportValidity",
+      "api.HTMLSelectElement.setCustomValidity",
+      "api.HTMLSelectElement.validationMessage",
+      "api.HTMLSelectElement.validity",
+      "api.HTMLSelectElement.willValidate",
+      "api.HTMLTextAreaElement.checkValidity",
+      "api.HTMLTextAreaElement.reportValidity",
+      "api.HTMLTextAreaElement.setCustomValidity",
+      "api.HTMLTextAreaElement.validationMessage",
+      "api.HTMLTextAreaElement.validity",
+      "api.HTMLTextAreaElement.willValidate",
+      "api.ValidityState",
+      "api.ValidityState.badInput",
+      "api.ValidityState.customError",
+      "api.ValidityState.patternMismatch",
+      "api.ValidityState.rangeOverflow",
+      "api.ValidityState.rangeUnderflow",
+      "api.ValidityState.stepMismatch",
+      "api.ValidityState.tooLong",
+      "api.ValidityState.tooShort",
+      "api.ValidityState.typeMismatch",
+      "api.ValidityState.valid",
+      "api.ValidityState.valueMissing"
+    ],
+    "spec": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api",
+    "status": {
+      "baseline": "low",
+      "baseline_low_date": "2023-03-27",
+      "support": {
+        "chrome": "77",
+        "chrome_android": "77",
+        "edge": "79",
+        "firefox": "98",
+        "firefox_android": "98",
+        "safari": "16.4",
+        "safari_ios": "16.4"
+      }
+    }
   },
   "container-queries": {
     "caniuse": "css-container-queries",
@@ -182,11 +369,38 @@
       "css.properties.container-type"
     ],
     "spec": "https://drafts.csswg.org/css-contain-3/#container-queries",
+    "status": {
+      "baseline": "low",
+      "baseline_low_date": "2023-02-14",
+      "support": {
+        "chrome": "105",
+        "chrome_android": "105",
+        "edge": "105",
+        "firefox": "110",
+        "firefox_android": "110",
+        "safari": "16",
+        "safari_ios": "16"
+      }
+    },
     "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/4165"
   },
   "content-visibility": {
     "caniuse": "css-content-visibility",
-    "spec": "https://drafts.csswg.org/css-contain-2/#content-visibility"
+    "compat_features": [
+      "api.ContentVisibilityAutoStateChangeEvent",
+      "api.ContentVisibilityAutoStateChangeEvent.ContentVisibilityAutoStateChangeEvent",
+      "api.ContentVisibilityAutoStateChangeEvent.skipped",
+      "css.properties.content-visibility"
+    ],
+    "spec": "https://drafts.csswg.org/css-contain-2/#content-visibility",
+    "status": {
+      "baseline": false,
+      "support": {
+        "chrome": "108",
+        "chrome_android": "108",
+        "edge": "108"
+      }
+    }
   },
   "custom-elements": {
     "caniuse": "custom-elementsv1",
@@ -200,17 +414,66 @@
       "css.selectors.host-context",
       "css.selectors.part"
     ],
-    "spec": "https://html.spec.whatwg.org/multipage/custom-elements.html"
+    "spec": "https://html.spec.whatwg.org/multipage/custom-elements.html",
+    "status": {
+      "baseline": false,
+      "support": {
+        "chrome": "73",
+        "chrome_android": "73",
+        "edge": "79"
+      }
+    }
   },
   "custom-properties": {
     "caniuse": "css-variables",
-    "spec": "https://drafts.csswg.org/css-variables-1/"
+    "compat_features": [
+      "css.properties.custom-property",
+      "css.properties.custom-property.var"
+    ],
+    "spec": "https://drafts.csswg.org/css-variables-1/",
+    "status": {
+      "baseline": "high",
+      "baseline_low_date": "2017-04-05",
+      "support": {
+        "chrome": "49",
+        "chrome_android": "49",
+        "edge": "15",
+        "firefox": "31",
+        "firefox_android": "31",
+        "safari": "9.1",
+        "safari_ios": "9.3"
+      }
+    }
+  },
+  "default": {
+    "caniuse": "css-default-pseudo",
+    "compat_features": [
+      "css.selectors.default"
+    ],
+    "spec": "https://drafts.csswg.org/selectors-4/#the-default-pseudo"
   },
   "dialog": {
     "caniuse": "dialog",
+    "compat_features": [
+      "api.HTMLDialogElement",
+      "api.HTMLDialogElement.cancel_event",
+      "api.HTMLDialogElement.close",
+      "api.HTMLDialogElement.close_event",
+      "api.HTMLDialogElement.open",
+      "api.HTMLDialogElement.returnValue",
+      "api.HTMLDialogElement.show",
+      "api.HTMLDialogElement.showModal",
+      "css.selectors.backdrop.dialog",
+      "html.elements.dialog",
+      "html.elements.dialog.open"
+    ],
     "spec": "https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element",
     "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/481"
   },
+  "document-picture-in-picture": {
+    "spec": "https://wicg.github.io/document-picture-in-picture/",
+    "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/4397"
+  },
   "fetch-priority": {
     "compat_features": [
       "api.fetch.init_priority_parameter",
@@ -266,6 +529,28 @@
     },
     "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/1692"
   },
+  "focus-visible": {
+    "caniuse": "css-focus-visible",
+    "compat_features": [
+      "css.selectors.focus-visible"
+    ],
+    "spec": "https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo",
+    "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/2388"
+  },
+  "font-variant-alternates": {
+    "caniuse": "font-variant-alternates",
+    "compat_features": [
+      "css.properties.font-variant-alternates",
+      "css.properties.font-variant-alternates.annotation",
+      "css.properties.font-variant-alternates.character_variant",
+      "css.properties.font-variant-alternates.ornaments",
+      "css.properties.font-variant-alternates.styleset",
+      "css.properties.font-variant-alternates.stylistic",
+      "css.properties.font-variant-alternates.swash"
+    ],
+    "spec": "https://drafts.csswg.org/css-fonts-4/#font-variant-alternates-prop",
+    "usage_stats": "https://chromestatus.com/metrics/css/timeline/popularity/738"
+  },
   "fonts": {
     "caniuse": "fontface",
     "compat_features": [
@@ -279,6 +564,25 @@
   },
   "fullscreen": {
     "caniuse": "fullscreen",
+    "compat_features": [
+      "api.Document.exitFullscreen",
+      "api.Document.exitFullscreen.returns_promise",
+      "api.Document.fullscreen",
+      "api.Document.fullscreenchange_event",
+      "api.Document.fullscreenElement",
+      "api.Document.fullscreenEnabled",
+      "api.Document.fullscreenerror_event",
+      "api.Element.fullscreenchange_event",
+      "api.Element.fullscreenerror_event",
+      "api.Element.requestFullscreen",
+      "api.Element.requestFullscreen.returns_promise",
+      "api.HTMLIFrameElement.allowFullscreen",
+      "api.ShadowRoot.fullscreenElement",
+      "css.selectors.backdrop.fullscreen",
+      "css.selectors.fullscreen",
+      "css.selectors.fullscreen.all_elements",
+      "html.elements.iframe.allowfullscreen"
+    ],
     "spec": "https://fullscreen.spec.whatwg.org/"
   },
   "grid": {
@@ -335,20 +639,48 @@
         "firefox": "76",
         "safari": "12.1"
       }
-    }
+    },
+    "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/1693"
   },
   "grid-animation": {
     "compat_features": [
       "css.properties.grid-template-columns.animation",
       "css.properties.grid-template-rows.animation"
     ],
-    "spec": "https://drafts.csswg.org/css-grid-2/#track-sizing"
+    "spec": "https://drafts.csswg.org/css-grid-2/#track-sizing",
+    "status": {
+      "baseline": "low",
+      "baseline_low_date": "2022-10-27",
+      "support": {
+        "chrome": "107",
+        "chrome_android": "107",
+        "edge": "107",
+        "firefox": "66",
+        "firefox_android": "66",
+        "safari": "16",
+        "safari_ios": "16"
+      }
+    }
   },
   "has": {
     "caniuse": "css-has",
-    "spec": "https://drafts.csswg.org/selectors-4/#relational"
+    "compat_features": [
+      "css.selectors.has"
+    ],
+    "spec": "https://drafts.csswg.org/selectors-4/#relational",
+    "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/4743"
   },
   "idle-detection": {
+    "compat_features": [
+      "api.IdleDetector",
+      "api.IdleDetector.IdleDetector",
+      "api.IdleDetector.change_event",
+      "api.IdleDetector.requestPermission_static",
+      "api.IdleDetector.screenState",
+      "api.IdleDetector.start",
+      "api.IdleDetector.userState",
+      "http.headers.Permissions-Policy.idle-detection"
+    ],
     "spec": "https://wicg.github.io/idle-detection/",
     "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/2834"
   },
@@ -358,13 +690,52 @@
   },
   "import-maps": {
     "caniuse": "import-maps",
+    "compat_features": [
+      "html.elements.script.type.importmap"
+    ],
     "spec": "https://html.spec.whatwg.org/multipage/webappapis.html#import-maps"
   },
-  "leading-trim": {
-    "spec": "https://drafts.csswg.org/css-inline-3/#leading-trim"
+  "indeterminate": {
+    "caniuse": "css-indeterminate-pseudo",
+    "compat_features": [
+      "css.selectors.indeterminate",
+      "css.selectors.indeterminate.checkbox",
+      "css.selectors.indeterminate.progress",
+      "css.selectors.indeterminate.radio"
+    ],
+    "spec": [
+      "https://drafts.csswg.org/selectors-4/#indeterminate",
+      "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-indeterminate"
+    ]
+  },
+  "input-event": {
+    "caniuse": "input-event",
+    "compat_features": [
+      "api.HTMLElement.input_event",
+      "api.InputEvent",
+      "api.InputEvent.InputEvent",
+      "api.InputEvent.data",
+      "api.InputEvent.dataTransfer",
+      "api.InputEvent.getTargetRanges",
+      "api.InputEvent.inputType",
+      "api.InputEvent.isComposing"
+    ],
+    "spec": "https://w3c.github.io/uievents/#event-type-input"
+  },
+  "is": {
+    "caniuse": "css-matches-pseudo",
+    "compat_features": [
+      "css.selectors.is",
+      "css.selectors.is.forgiving_selector_list"
+    ],
+    "spec": "https://drafts.csswg.org/selectors-4/#matches",
+    "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/2322"
   },
   "line-clamp": {
     "caniuse": "css-line-clamp",
+    "compat_features": [
+      "css.properties.-webkit-line-clamp"
+    ],
     "spec": "https://drafts.csswg.org/css-overflow-3/#line-clamp"
   },
   "masonry": {
@@ -377,11 +748,25 @@
     ],
     "spec": "https://drafts.csswg.org/css-grid-3/"
   },
+  "media-capture": {
+    "caniuse": "html-media-capture",
+    "compat_features": [
+      "api.HTMLInputElement.capture",
+      "html.elements.input.capture"
+    ],
+    "spec": "https://w3c.github.io/html-media-capture/"
+  },
   "navigation": {
-    "spec": "https://wicg.github.io/navigation-api/"
+    "spec": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api"
   },
   "nesting": {
     "caniuse": "css-nesting",
+    "compat_features": [
+      "css.selectors.nesting",
+      "api.CSSStyleRule.cssRules",
+      "api.CSSStyleRule.deleteRule",
+      "api.CSSStyleRule.insertRule"
+    ],
     "spec": "https://drafts.csswg.org/css-nesting-1/"
   },
   "offscreen-canvas": {
@@ -459,10 +844,77 @@
     "spec": "https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-interface",
     "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/1624"
   },
+  "overflow-shorthand": {
+    "caniuse": "css-overflow",
+    "compat_features": [
+      "css.properties.overflow-x",
+      "css.properties.overflow-x.clip",
+      "css.properties.overflow-y",
+      "css.properties.overflow-y.clip",
+      "css.properties.overflow",
+      "css.properties.overflow.clip",
+      "css.properties.overflow.multiple_keywords",
+      "css.types.overflow",
+      "css.types.overflow.clip"
+    ],
+    "spec": "https://drafts.csswg.org/css-overflow-3/#propdef-overflow"
+  },
+  "picture-in-picture": {
+    "caniuse": "picture-in-picture",
+    "spec": "https://w3c.github.io/picture-in-picture/",
+    "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/2444"
+  },
   "popover": {
+    "compat_features": [
+      "api.HTMLButtonElement.popoverTargetAction",
+      "api.HTMLButtonElement.popoverTargetElement",
+      "api.HTMLElement.beforetoggle_event",
+      "api.HTMLElement.hidePopover",
+      "api.HTMLElement.popover",
+      "api.HTMLElement.showPopover",
+      "api.HTMLElement.toggle_event",
+      "api.HTMLElement.togglePopover",
+      "api.HTMLInputElement.popoverTargetAction",
+      "api.HTMLInputElement.popoverTargetElement",
+      "api.ToggleEvent",
+      "api.ToggleEvent.ToggleEvent",
+      "api.ToggleEvent.newstate",
+      "api.ToggleEvent.oldstate",
+      "css.selectors.backdrop.popover",
+      "css.selectors.popover-open",
+      "html.global_attributes.popover",
+      "html.global_attributes.popovertarget",
+      "html.global_attributes.popovertargetaction"
+    ],
     "spec": "https://html.spec.whatwg.org/multipage/popover.html",
     "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/4191"
   },
+  "read-write-pseudo-classes": {
+    "caniuse": "css-read-only-write",
+    "compat_features": [
+      "css.selectors.read-only",
+      "css.selectors.read-write"
+    ],
+    "spec": [
+      "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-read-only",
+      "https://drafts.csswg.org/selectors-4/#rw-pseudos"
+    ]
+  },
+  "registered-custom-properties": {
+    "compat_features": [
+      "api.CSS.registerProperty_static",
+      "api.CSSPropertyRule",
+      "api.CSSPropertyRule.inherits",
+      "api.CSSPropertyRule.initialValue",
+      "api.CSSPropertyRule.name",
+      "api.CSSPropertyRule.syntax",
+      "css.at-rules.property",
+      "css.at-rules.property.inherits",
+      "css.at-rules.property.initial-value",
+      "css.at-rules.property.syntax"
+    ],
+    "spec": "https://drafts.css-houdini.org/css-properties-values-api-1/"
+  },
   "sanitizer": {
     "spec": "https://wicg.github.io/sanitizer-api/"
   },
@@ -485,6 +937,26 @@
   "scope": {
     "spec": "https://drafts.csswg.org/css-cascade-6/#scope-atrule"
   },
+  "scrollintoview": {
+    "caniuse": "scrollintoview",
+    "compat_features": [
+      "api.Element.scrollIntoView",
+      "api.Element.scrollIntoView.options_parameter"
+    ],
+    "spec": "https://drafts.csswg.org/cssom-view-1/#dom-element-scrollintoview"
+  },
+  "set-methods": {
+    "compat_features": [
+      "javascript.builtins.Set.difference",
+      "javascript.builtins.Set.intersection",
+      "javascript.builtins.Set.isDisjointFrom",
+      "javascript.builtins.Set.isSubsetOf",
+      "javascript.builtins.Set.isSupersetOf",
+      "javascript.builtins.Set.symmetricDifference",
+      "javascript.builtins.Set.union"
+    ],
+    "spec": "https://tc39.es/proposal-set-methods/"
+  },
   "shadow-dom": {
     "caniuse": "shadowdomv1",
     "compat_features": [
@@ -505,8 +977,28 @@
   },
   "sticky-positioning": {
     "caniuse": "css-sticky",
+    "compat_features": [
+      "css.properties.position.position_sticky_table_elements",
+      "css.properties.position.sticky"
+    ],
     "spec": "https://drafts.csswg.org/css-position-3/#stickypos-insets"
   },
+  "structured-clone": {
+    "compat_features": [
+      "api.structuredClone",
+      "api.structuredClone.worker_support"
+    ],
+    "spec": "https://html.spec.whatwg.org/multipage/structured-data.html#structured-cloning",
+    "status": {
+      "is_baseline": true,
+      "support": {
+        "chrome": "98",
+        "edge": "98",
+        "firefox": "94",
+        "safari": "15.4"
+      }
+    }
+  },
   "subgrid": {
     "caniuse": "css-subgrid",
     "compat_features": [
@@ -515,42 +1007,508 @@
     ],
     "spec": "https://drafts.csswg.org/css-grid-2/#subgrids",
     "status": {
-      "is_baseline": false,
+      "baseline": "low",
+      "baseline_low_date": "2023-09-15",
       "support": {
+        "chrome": "117",
+        "chrome_android": "117",
+        "edge": "117",
         "firefox": "71",
-        "safari": "16"
+        "firefox_android": "71",
+        "safari": "16",
+        "safari_ios": "16"
       }
-    }
+    },
+    "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/4680"
+  },
+  "svg2-script-html-equivalance": {
+    "compat_features": [
+      "api.SVGScriptElement.async",
+      "api.SVGScriptElement.defer",
+      "svg.elements.script.async",
+      "svg.elements.script.defer",
+      "svg.elements.script.type.module"
+    ],
+    "spec": "https://svgwg.org/svg2-draft/interact.html#ScriptElement"
+  },
+  "tabindex": {
+    "caniuse": "tabindex-attr",
+    "compat_features": [
+      "api.HTMLElement.tabIndex",
+      "html.global_attributes.tabindex"
+    ],
+    "spec": "https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex"
   },
   "temporal": {
     "caniuse": "temporal",
     "spec": "https://tc39.es/proposal-temporal/"
   },
+  "text-box-trim": {
+    "alias": "leading-trim",
+    "spec": "https://drafts.csswg.org/css-inline-3/#leading-trim"
+  },
+  "text-indent": {
+    "caniuse": "css-text-indent",
+    "compat_features": [
+      "css.properties.text-indent"
+    ],
+    "spec": "https://drafts.csswg.org/css-text-3/#text-indent-property",
+    "usage_stats": "https://chromestatus.com/metrics/css/timeline/popularity/130"
+  },
+  "view-transitions": {
+    "caniuse": "view-transitions",
+    "compat_features": [
+      "api.Document.startViewTransition",
+      "api.ViewTransition",
+      "api.ViewTransition.finished",
+      "api.ViewTransition.ready",
+      "api.ViewTransition.skipTransition",
+      "api.ViewTransition.updateCallbackDone",
+      "css.properties.view-transition-name",
+      "css.selectors.view-transition-group",
+      "css.selectors.view-transition-image-pair",
+      "css.selectors.view-transition-new",
+      "css.selectors.view-transition-old",
+      "css.selectors.view-transition"
+    ],
+    "spec": "https://drafts.csswg.org/css-view-transitions-1/",
+    "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/4383"
+  },
+  "viewport-relative-unit-variants": {
+    "caniuse": "viewport-unit-variants",
+    "compat_features": [
+      "css.types.length.vb",
+      "css.types.length.vi",
+      "css.types.length.viewport_percentage_units_dynamic",
+      "css.types.length.viewport_percentage_units_large",
+      "css.types.length.viewport_percentage_units_small"
+    ],
+    "spec": [
+      "https://drafts.csswg.org/css-values-4/#viewport-variants",
+      "https://drafts.csswg.org/css-values-4/#viewport-relative-lengths"
+    ],
+    "status": {
+      "baseline": "low",
+      "baseline_low_date": "2022-12-06",
+      "support": {
+        "chrome": "108",
+        "chrome_android": "108",
+        "edge": "108",
+        "firefox": "101",
+        "firefox_android": "101",
+        "safari": "15.4",
+        "safari_ios": "15.4"
+      }
+    }
+  },
+  "viewport-relative-units": {
+    "caniuse": "viewport-units",
+    "compat_features": [
+      "css.types.length.vh",
+      "css.types.length.vmax",
+      "css.types.length.vmin",
+      "css.types.length.vw"
+    ],
+    "spec": "https://drafts.csswg.org/css-values-4/#viewport-relative-lengths",
+    "status": {
+      "baseline": "high",
+      "baseline_low_date": "2017-10-17",
+      "support": {
+        "chrome": "26",
+        "chrome_android": "26",
+        "edge": "16",
+        "firefox": "19",
+        "firefox_android": "19",
+        "safari": "7",
+        "safari_ios": "7"
+      }
+    }
+  },
+  "web-animations": {
+    "caniuse": "web-animation",
+    "compat_features": [
+      "api.Animation",
+      "api.Animation.Animation",
+      "api.Animation.cancel_event",
+      "api.Animation.cancel",
+      "api.Animation.commitStyles",
+      "api.Animation.currentTime",
+      "api.Animation.effect",
+      "api.Animation.finish",
+      "api.Animation.finished",
+      "api.Animation.finish_event",
+      "api.Animation.id",
+      "api.Animation.pause",
+      "api.Animation.pending",
+      "api.Animation.persist",
+      "api.Animation.play",
+      "api.Animation.playbackRate",
+      "api.Animation.playState",
+      "api.Animation.ready",
+      "api.Animation.remove_event",
+      "api.Animation.replaceState",
+      "api.Animation.reverse",
+      "api.Animation.startTime",
+      "api.Animation.timeline",
+      "api.Animation.updatePlaybackRate",
+      "api.AnimationTimeline",
+      "api.AnimationTimeline.currentTime",
+      "api.AnimationEffect",
+      "api.AnimationEffect.getComputedTiming",
+      "api.AnimationEffect.getTiming",
+      "api.AnimationEffect.updateTiming",
+      "api.AnimationPlaybackEvent",
+      "api.AnimationPlaybackEvent.AnimationPlaybackEvent",
+      "api.AnimationPlaybackEvent.currentTime",
+      "api.AnimationPlaybackEvent.timelineTime",
+      "api.KeyframeEffect",
+      "api.KeyframeEffect.KeyframeEffect",
+      "api.KeyframeEffect.composite",
+      "api.KeyframeEffect.getKeyframes",
+      "api.KeyframeEffect.iterationComposite",
+      "api.KeyframeEffect.pseudoElement",
+      "api.KeyframeEffect.setKeyframes",
+      "api.KeyframeEffect.target",
+      "api.DocumentTimeline",
+      "api.DocumentTimeline.DocumentTimeline",
+      "api.Document.getAnimations",
+      "api.Document.timeline",
+      "api.Element.animate"
+    ],
+    "spec": "https://drafts.csswg.org/web-animations-1/"
+  },
   "webcodecs": {
     "caniuse": "webcodecs",
+    "compat_features": [
+      "api.AudioData",
+      "api.AudioData.allocationSize",
+      "api.AudioData.AudioData",
+      "api.AudioData.clone",
+      "api.AudioData.close",
+      "api.AudioData.copyTo",
+      "api.AudioData.duration",
+      "api.AudioData.format",
+      "api.AudioData.numberOfChannels",
+      "api.AudioData.numberOfFrames",
+      "api.AudioData.sampleRate",
+      "api.AudioData.timestamp",
+      "api.AudioDecoder",
+      "api.AudioDecoder.AudioDecoder",
+      "api.AudioDecoder.close",
+      "api.AudioDecoder.configure",
+      "api.AudioDecoder.decode",
+      "api.AudioDecoder.decodeQueueSize",
+      "api.AudioDecoder.dequeue_event",
+      "api.AudioDecoder.flush",
+      "api.AudioDecoder.isConfigSupported_static",
+      "api.AudioDecoder.reset",
+      "api.AudioDecoder.state",
+      "api.AudioEncoder",
+      "api.AudioEncoder.AudioEncoder",
+      "api.AudioEncoder.close",
+      "api.AudioEncoder.configure",
+      "api.AudioEncoder.dequeue_event",
+      "api.AudioEncoder.encode",
+      "api.AudioEncoder.encodeQueueSize",
+      "api.AudioEncoder.flush",
+      "api.AudioEncoder.isConfigSupported_static",
+      "api.AudioEncoder.reset",
+      "api.AudioEncoder.state",
+      "api.EncodedAudioChunk",
+      "api.EncodedAudioChunk.byteLength",
+      "api.EncodedAudioChunk.copyTo",
+      "api.EncodedAudioChunk.duration",
+      "api.EncodedAudioChunk.EncodedAudioChunk",
+      "api.EncodedAudioChunk.timestamp",
+      "api.EncodedAudioChunk.type",
+      "api.EncodedVideoChunk",
+      "api.EncodedVideoChunk.byteLength",
+      "api.EncodedVideoChunk.copyTo",
+      "api.EncodedVideoChunk.duration",
+      "api.EncodedVideoChunk.EncodedVideoChunk",
+      "api.EncodedVideoChunk.timestamp",
+      "api.EncodedVideoChunk.type",
+      "api.ImageDecoder",
+      "api.ImageDecoder.close",
+      "api.ImageDecoder.complete",
+      "api.ImageDecoder.completed",
+      "api.ImageDecoder.decode",
+      "api.ImageDecoder.ImageDecoder",
+      "api.ImageDecoder.isTypeSupported_static",
+      "api.ImageDecoder.reset",
+      "api.ImageDecoder.tracks",
+      "api.ImageDecoder.type",
+      "api.ImageTrack",
+      "api.ImageTrack.animated",
+      "api.ImageTrack.frameCount",
+      "api.ImageTrack.repetitionCount",
+      "api.ImageTrack.selected",
+      "api.ImageTrackList",
+      "api.ImageTrackList.length",
+      "api.ImageTrackList.ready",
+      "api.ImageTrackList.selectedIndex",
+      "api.ImageTrackList.selectedTrack",
+      "api.VideoColorSpace",
+      "api.VideoColorSpace.fullRange",
+      "api.VideoColorSpace.matrix",
+      "api.VideoColorSpace.primaries",
+      "api.VideoColorSpace.toJSON",
+      "api.VideoColorSpace.transfer",
+      "api.VideoColorSpace.VideoColorSpace",
+      "api.VideoDecoder",
+      "api.VideoDecoder.close",
+      "api.VideoDecoder.configure",
+      "api.VideoDecoder.decode",
+      "api.VideoDecoder.decodeQueueSize",
+      "api.VideoDecoder.dequeue_event",
+      "api.VideoDecoder.flush",
+      "api.VideoDecoder.isConfigSupported_static",
+      "api.VideoDecoder.reset",
+      "api.VideoDecoder.state",
+      "api.VideoDecoder.VideoDecoder",
+      "api.VideoEncoder",
+      "api.VideoEncoder.close",
+      "api.VideoEncoder.configure",
+      "api.VideoEncoder.dequeue_event",
+      "api.VideoEncoder.encode",
+      "api.VideoEncoder.encodeQueueSize",
+      "api.VideoEncoder.flush",
+      "api.VideoEncoder.isConfigSupported_static",
+      "api.VideoEncoder.reset",
+      "api.VideoEncoder.state",
+      "api.VideoEncoder.VideoEncoder",
+      "api.VideoFrame",
+      "api.VideoFrame.allocationSize",
+      "api.VideoFrame.clone",
+      "api.VideoFrame.close",
+      "api.VideoFrame.codedHeight",
+      "api.VideoFrame.codedRect",
+      "api.VideoFrame.codedWidth",
+      "api.VideoFrame.colorSpace",
+      "api.VideoFrame.copyTo",
+      "api.VideoFrame.displayHeight",
+      "api.VideoFrame.displayWidth",
+      "api.VideoFrame.duration",
+      "api.VideoFrame.format",
+      "api.VideoFrame.timestamp",
+      "api.VideoFrame.VideoFrame",
+      "api.VideoFrame.visibleRect"
+    ],
     "spec": "https://w3c.github.io/webcodecs/",
     "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/3464"
   },
   "webdriver-bidi": {
     "spec": "https://w3c.github.io/webdriver-bidi/"
   },
+  "webhid": {
+    "caniuse": "webhid",
+    "compat_features": [
+      "api.HID",
+      "api.HID.connect_event",
+      "api.HID.disconnect_event",
+      "api.HID.getDevices",
+      "api.HID.requestDevice",
+      "api.HIDConnectionEvent",
+      "api.HIDConnectionEvent.HIDConnectionEvent",
+      "api.HIDConnectionEvent.device",
+      "api.HIDDevice",
+      "api.HIDDevice.close",
+      "api.HIDDevice.collections",
+      "api.HIDDevice.inputreport_event",
+      "api.HIDDevice.open",
+      "api.HIDDevice.opened",
+      "api.HIDDevice.productId",
+      "api.HIDDevice.productName",
+      "api.HIDDevice.receiveFeatureReport",
+      "api.HIDDevice.sendFeatureReport",
+      "api.HIDDevice.sendReport",
+      "api.HIDDevice.vendorId",
+      "api.HIDInputReportEvent",
+      "api.HIDInputReportEvent.data",
+      "api.HIDInputReportEvent.device",
+      "api.HIDInputReportEvent.reportId",
+      "api.Navigator.hid",
+      "http.headers.Permissions-Policy.hid"
+    ],
+    "spec": "https://wicg.github.io/webhid/",
+    "status": {
+      "baseline": false,
+      "support": {
+        "chrome": "89",
+        "edge": "89"
+      }
+    },
+    "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/2865"
+  },
+  "webp": {
+    "caniuse": "webp",
+    "spec": "https://www.ietf.org/archive/id/draft-zern-webp-13.html",
+    "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/3797"
+  },
   "webtransport": {
     "caniuse": "webtransport",
+    "compat_features": [
+      "api.WebTransport",
+      "api.WebTransport.WebTransport",
+      "api.WebTransport.WebTransport.options_allowPooling_parameter",
+      "api.WebTransport.WebTransport.options_requireUnreliable_parameter",
+      "api.WebTransport.WebTransport.options_serverCertificateHashes_parameter",
+      "api.WebTransport.close",
+      "api.WebTransport.closed",
+      "api.WebTransport.createBidirectionalStream",
+      "api.WebTransport.createUnidirectionalStream",
+      "api.WebTransport.datagrams",
+      "api.WebTransport.getStats",
+      "api.WebTransport.incomingBidirectionalStreams",
+      "api.WebTransport.incomingUnidirectionalStreams",
+      "api.WebTransport.ready",
+      "api.WebTransport.reliability",
+      "api.WebTransportBidirectionalStream",
+      "api.WebTransportBidirectionalStream.readable",
+      "api.WebTransportBidirectionalStream.writable",
+      "api.WebTransportDatagramDuplexStream",
+      "api.WebTransportDatagramDuplexStream.incomingHighWaterMark",
+      "api.WebTransportDatagramDuplexStream.incomingMaxAge",
+      "api.WebTransportDatagramDuplexStream.maxDatagramSize",
+      "api.WebTransportDatagramDuplexStream.outgoingHighWaterMark",
+      "api.WebTransportDatagramDuplexStream.outgoingMaxAge",
+      "api.WebTransportDatagramDuplexStream.readable",
+      "api.WebTransportDatagramDuplexStream.writable",
+      "api.WebTransportError",
+      "api.WebTransportError.WebTransportError",
+      "api.WebTransportError.source",
+      "api.WebTransportError.streamErrorCode"
+    ],
     "spec": "https://w3c.github.io/webtransport/",
     "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/3472"
   },
   "webusb": {
     "caniuse": "webusb",
+    "compat_features": [
+      "api.Navigator.usb",
+      "api.USB",
+      "api.USB.connect_event",
+      "api.USB.disconnect_event",
+      "api.USB.getDevices",
+      "api.USB.requestDevice",
+      "api.USBAlternateInterface",
+      "api.USBAlternateInterface.alternateSetting",
+      "api.USBAlternateInterface.endpoints",
+      "api.USBAlternateInterface.interfaceClass",
+      "api.USBAlternateInterface.interfaceName",
+      "api.USBAlternateInterface.interfaceProtocol",
+      "api.USBAlternateInterface.interfaceSubclass",
+      "api.USBAlternateInterface.USBAlternateInterface",
+      "api.USBConfiguration",
+      "api.USBConfiguration.configurationName",
+      "api.USBConfiguration.configurationValue",
+      "api.USBConfiguration.interfaces",
+      "api.USBConfiguration.USBConfiguration",
+      "api.USBConnectionEvent",
+      "api.USBConnectionEvent.device",
+      "api.USBConnectionEvent.USBConnectionEvent",
+      "api.USBDevice",
+      "api.USBDevice.claimInterface",
+      "api.USBDevice.clearHalt",
+      "api.USBDevice.close",
+      "api.USBDevice.configuration",
+      "api.USBDevice.configurations",
+      "api.USBDevice.controlTransferIn",
+      "api.USBDevice.controlTransferOut",
+      "api.USBDevice.deviceClass",
+      "api.USBDevice.deviceProtocol",
+      "api.USBDevice.deviceSubclass",
+      "api.USBDevice.deviceVersionMajor",
+      "api.USBDevice.deviceVersionMinor",
+      "api.USBDevice.deviceVersionSubminor",
+      "api.USBDevice.forget",
+      "api.USBDevice.isochronousTransferIn",
+      "api.USBDevice.isochronousTransferOut",
+      "api.USBDevice.manufacturerName",
+      "api.USBDevice.open",
+      "api.USBDevice.opened",
+      "api.USBDevice.productId",
+      "api.USBDevice.productName",
+      "api.USBDevice.releaseInterface",
+      "api.USBDevice.reset",
+      "api.USBDevice.selectAlternateInterface",
+      "api.USBDevice.selectConfiguration",
+      "api.USBDevice.serialNumber",
+      "api.USBDevice.transferIn",
+      "api.USBDevice.transferOut",
+      "api.USBDevice.usbVersionMajor",
+      "api.USBDevice.usbVersionMinor",
+      "api.USBDevice.usbVersionSubminor",
+      "api.USBDevice.vendorId",
+      "api.USBEndpoint",
+      "api.USBEndpoint.direction",
+      "api.USBEndpoint.endpointNumber",
+      "api.USBEndpoint.packetSize",
+      "api.USBEndpoint.type",
+      "api.USBEndpoint.USBEndpoint",
+      "api.USBInterface",
+      "api.USBInterface.alternate",
+      "api.USBInterface.alternates",
+      "api.USBInterface.claimed",
+      "api.USBInterface.interfaceNumber",
+      "api.USBInterface.USBInterface",
+      "api.USBInTransferResult",
+      "api.USBInTransferResult.data",
+      "api.USBInTransferResult.status",
+      "api.USBInTransferResult.USBInTransferResult",
+      "api.USBIsochronousInTransferPacket",
+      "api.USBIsochronousInTransferPacket.data",
+      "api.USBIsochronousInTransferPacket.status",
+      "api.USBIsochronousInTransferPacket.USBIsochronousInTransferPacket",
+      "api.USBIsochronousInTransferResult",
+      "api.USBIsochronousInTransferResult.data",
+      "api.USBIsochronousInTransferResult.packets",
+      "api.USBIsochronousInTransferResult.USBIsochronousInTransferResult",
+      "api.USBIsochronousOutTransferPacket",
+      "api.USBIsochronousOutTransferPacket.bytesWritten",
+      "api.USBIsochronousOutTransferPacket.status",
+      "api.USBIsochronousOutTransferPacket.USBIsochronousOutTransferPacket",
+      "api.USBIsochronousOutTransferResult",
+      "api.USBIsochronousOutTransferResult.packets",
+      "api.USBIsochronousOutTransferResult.USBIsochronousOutTransferResult",
+      "api.USBOutTransferResult",
+      "api.USBOutTransferResult.bytesWritten",
+      "api.USBOutTransferResult.status",
+      "api.USBOutTransferResult.USBOutTransferResult",
+      "api.WorkerNavigator.usb",
+      "http.headers.Feature-Policy.usb",
+      "http.headers.Permissions-Policy.usb"
+    ],
     "spec": "https://wicg.github.io/webusb/",
     "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/1519"
   },
   "webvtt": {
     "caniuse": "webvtt",
+    "compat_features": [
+      "api.VTTCue",
+      "api.VTTCue.VTTCue",
+      "api.VTTCue.align",
+      "api.VTTCue.getCueAsHTML",
+      "api.VTTCue.line",
+      "api.VTTCue.position",
+      "api.VTTCue.size",
+      "api.VTTCue.snapToLines",
+      "api.VTTCue.text",
+      "api.VTTCue.vertical"
+    ],
     "spec": "https://w3c.github.io/webvtt/",
     "usage_stats": [
       "https://chromestatus.com/metrics/feature/timeline/popularity/409",
       "https://chromestatus.com/metrics/feature/timeline/popularity/410",
       "https://chromestatus.com/metrics/feature/timeline/popularity/2891"
     ]
+  },
+  "where": {
+    "compat_features": [
+      "css.selectors.where",
+      "css.selectors.where.forgiving_selector_list"
+    ],
+    "spec": "https://drafts.csswg.org/selectors-4/#zero-matches",
+    "usage_stats": "https://chromestatus.com/metrics/feature/timeline/popularity/2431"
   }
 }

```