### PR TITLE
`structured-clone`: set Baseline status (and correct feature list)

### DIFF
--- a/feature-group-definitions/structured-clone.yml
+++ b/feature-group-definitions/structured-clone.yml
@@ -1,11 +1,14 @@
 spec: https://html.spec.whatwg.org/multipage/structured-data.html#structured-cloning
 status:
-  is_baseline: true
+  baseline: low
+  baseline_low_date: 2022-03-15
   support:
     chrome: "98"
+    chrome_android: "98"
     edge: "98"
     firefox: "94"
+    firefox_android: "94"
     safari: "15.4"
+    safari_ios: "15.4"
 compat_features:
   - api.structuredClone
-  - api.structuredClone.worker_support


### PR DESCRIPTION
| Key                  | Baseline | Since      | Versions                                                                                                                    |
| :------------------- | :------: | :--------- | --------------------------------------------------------------------------------------------------------------------------- |
| **structured-clone** |    🔵    | 2022-03-15 | Chrome 98<br>Chrome Android 98<br>Edge 98<br>Firefox 94<br>Firefox for Android 94<br>Safari 15.4 🔑💎<br>Safari on iOS 15.4 |
| api.structuredClone  |    🔵    | 2022-03-15 | Chrome 98<br>Chrome Android 98<br>Edge 98<br>Firefox 94<br>Firefox for Android 94<br>Safari 15.4 🔑💎<br>Safari on iOS 15.4 |