### PR TITLE
Remove old Baseline definition schema fields

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -27,10 +27,6 @@ type BaselineHighLow = "high" | "low";
 interface SupportStatus {
     /** Whether the feature is Baseline (low substatus), Baseline (high substatus), or not (false) */
     baseline?: BaselineHighLow | false;
-    /** Whether the feature is Baseline (legacy) */
-    is_baseline?: true | false;
-    /** Date the feature achieved Baseline status (legacy) */
-    since?: string;
     /** Date the feature achieved Baseline low status */
     baseline_low_date?: string;
     /** Browser versions that most-recently introduced the feature */

--- a/schemas/defs.schema.json
+++ b/schemas/defs.schema.json
@@ -76,18 +76,6 @@
               "description": "Date the feature achieved Baseline low status",
               "type": "string"
             },
-            "is_baseline": {
-              "description": "Whether the feature is Baseline (legacy)",
-              "enum": [
-                true,
-                false
-              ],
-              "type": "boolean"
-            },
-            "since": {
-              "description": "Date the feature achieved Baseline status (legacy)",
-              "type": "string"
-            },
             "support": {
               "additionalProperties": false,
               "description": "Browser versions that most-recently introduced the feature",


### PR DESCRIPTION
This disposes of the old `is_baseline` and `since` fields, striking them from the schema.

Blocked on:

- #450 
- #451 
- #452