### PR TITLE
`f*`: set Baseline statuses (excluding `fullscreen`)

### DIFF
--- a/feature-group-definitions/fetch-priority.yml
+++ b/feature-group-definitions/fetch-priority.yml
@@ -1,6 +1,12 @@
 spec:
   - https://fetch.spec.whatwg.org/#request-priority
   - https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attributes
+status:
+  baseline: false
+  support:
+    chrome: "102"
+    chrome_android: "102"
+    edge: "102"
 compat_features:
   - api.fetch.init_priority_parameter
   - api.HTMLImageElement.fetchPriority

--- a/feature-group-definitions/focus-visible.yml
+++ b/feature-group-definitions/focus-visible.yml
@@ -1,5 +1,16 @@
 spec: https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo
 caniuse: css-focus-visible
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2388
+status:
+  baseline: low
+  baseline_low_date: 2022-03-15
+  support:
+    chrome: "86"
+    chrome_android: "86"
+    edge: "86"
+    firefox: "85"
+    firefox_android: "85"
+    safari: "15.4"
+    safari_ios: "15.4"
 compat_features:
   - css.selectors.focus-visible

--- a/feature-group-definitions/font-variant-alternates.yml
+++ b/feature-group-definitions/font-variant-alternates.yml
@@ -1,6 +1,17 @@
 spec: https://drafts.csswg.org/css-fonts-4/#font-variant-alternates-prop
 caniuse: font-variant-alternates
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/738
+status:
+  baseline: low
+  baseline_low_date: 2023-03-13
+  support:
+    chrome: "111"
+    chrome_android: "111"
+    edge: "111"
+    firefox: "34"
+    firefox_android: "34"
+    safari: "16.2"
+    safari_ios: "16.2"
 compat_features:
   - css.properties.font-variant-alternates
   - css.properties.font-variant-alternates.annotation

--- a/feature-group-definitions/fonts.yml
+++ b/feature-group-definitions/fonts.yml
@@ -1,8 +1,19 @@
 spec: https://drafts.csswg.org/css-fonts-5/
 caniuse: fontface
+status:
+  baseline: high
+  baseline_low_date: 2016-09-20
+  support:
+    chrome: "36"
+    chrome_android: "36"
+    edge: "14"
+    firefox: "39"
+    firefox_android: "39"
+    safari: "10"
+    safari_ios: "10"
 compat_features:
   - css.at-rules.font-face
   - css.at-rules.font-face.font-family
   - css.at-rules.font-face.src
   - css.at-rules.font-face.WOFF
-  - css.at-rules.font-face.WOFF2
+  - css.at-rules.font-face.WOFF_2


### PR DESCRIPTION
Fullscreen is weird. I'll create a separate PR for that one.

## fetch-priority

| Key                                                                                                                                     |    Baseline    | Low since date | Versions                                                                                                          |
| :-------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :------------- | ----------------------------------------------------------------------------------------------------------------- |
| **fetch-priority**                                                                                                                      | ❌ Not Baseline |                | Chrome 102<br>Chrome Android 102<br>Edge 102<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| `api.fetch.init_priority_parameter`                                                                                                     | ❌ Not Baseline |                | Chrome 101<br>Chrome Android 101<br>Edge 101<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.HTMLImageElement.fetchPriority`](https://developer.mozilla.org/docs/Web/API/HTMLImageElement/fetchPriority#browser_compatibility) | ❌ Not Baseline |                | Chrome 102<br>Chrome Android 102<br>Edge 102<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.HTMLLinkElement.fetchPriority`](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/fetchPriority#browser_compatibility)   | ❌ Not Baseline |                | Chrome 102<br>Chrome Android 102<br>Edge 102<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| `api.HTMLScriptElement.fetchPriority`                                                                                                   | ❌ Not Baseline |                | Chrome 102<br>Chrome Android 102<br>Edge 102<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| `api.Request.Request.init_priority_parameter`                                                                                           | ❌ Not Baseline |                | Chrome 101<br>Chrome Android 101<br>Edge 101<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| `html.elements.img.fetchpriority`                                                                                                       | ❌ Not Baseline |                | Chrome 101<br>Chrome Android 101<br>Edge 101<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| `html.elements.link.fetchpriority`                                                                                                      | ❌ Not Baseline |                | Chrome 101<br>Chrome Android 101<br>Edge 101<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| `html.elements.script.fetchpriority`                                                                                                    | ❌ Not Baseline |                | Chrome 101<br>Chrome Android 101<br>Edge 101<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |

<small>🔑💎 indicates a release that determines the Baseline low date.</small>

## focus-visible

| Key                                                                                                              | Baseline | Low since date | Versions                                                                                                                    |
| :--------------------------------------------------------------------------------------------------------------- | :------: | :------------- | --------------------------------------------------------------------------------------------------------------------------- |
| **focus-visible**                                                                                                |  🆕 Low  | 2022-03-15     | Chrome 86<br>Chrome Android 86<br>Edge 86<br>Firefox 85<br>Firefox for Android 85<br>Safari 15.4 🔑💎<br>Safari on iOS 15.4 |
| [`css.selectors.focus-visible`](https://developer.mozilla.org/docs/Web/CSS/:focus-visible#browser_compatibility) |  🆕 Low  | 2022-03-15     | Chrome 86<br>Chrome Android 86<br>Edge 86<br>Firefox 85<br>Firefox for Android 85<br>Safari 15.4 🔑💎<br>Safari on iOS 15.4 |

<small>🔑💎 indicates a release that determines the Baseline low date.</small>

## font-variant-alternates

| Key                                                                                                                                                                        | Baseline | Low since date | Versions                                                                                                                       |
| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------: | :------------- | ------------------------------------------------------------------------------------------------------------------------------ |
| **font-variant-alternates**                                                                                                                                                |  🆕 Low  | 2023-03-13     | Chrome 111<br>Chrome Android 111<br>Edge 111 🔑💎<br>Firefox 34<br>Firefox for Android 34<br>Safari 16.2<br>Safari on iOS 16.2 |
| [`css.properties.font-variant-alternates`](https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#browser_compatibility)                                       |  🆕 Low  | 2023-03-13     | Chrome 111<br>Chrome Android 111<br>Edge 111 🔑💎<br>Firefox 34<br>Firefox for Android 34<br>Safari 9.1<br>Safari on iOS 9.3   |
| [`css.properties.font-variant-alternates.annotation`](https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#annotation()#browser_compatibility)               |  🆕 Low  | 2023-03-13     | Chrome 111<br>Chrome Android 111<br>Edge 111 🔑💎<br>Firefox 34<br>Firefox for Android 34<br>Safari 16.2<br>Safari on iOS 16.2 |
| [`css.properties.font-variant-alternates.character_variant`](https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#character-variant()#browser_compatibility) |  🆕 Low  | 2023-03-13     | Chrome 111<br>Chrome Android 111<br>Edge 111 🔑💎<br>Firefox 34<br>Firefox for Android 34<br>Safari 16.2<br>Safari on iOS 16.2 |
| [`css.properties.font-variant-alternates.ornaments`](https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#ornaments()#browser_compatibility)                 |  🆕 Low  | 2023-03-13     | Chrome 111<br>Chrome Android 111<br>Edge 111 🔑💎<br>Firefox 34<br>Firefox for Android 34<br>Safari 16.2<br>Safari on iOS 16.2 |
| [`css.properties.font-variant-alternates.styleset`](https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#styleset()#browser_compatibility)                   |  🆕 Low  | 2023-03-13     | Chrome 111<br>Chrome Android 111<br>Edge 111 🔑💎<br>Firefox 34<br>Firefox for Android 34<br>Safari 16.2<br>Safari on iOS 16.2 |
| [`css.properties.font-variant-alternates.stylistic`](https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#stylistic()#browser_compatibility)                 |  🆕 Low  | 2023-03-13     | Chrome 111<br>Chrome Android 111<br>Edge 111 🔑💎<br>Firefox 34<br>Firefox for Android 34<br>Safari 16.2<br>Safari on iOS 16.2 |
| [`css.properties.font-variant-alternates.swash`](https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#swash()#browser_compatibility)                         |  🆕 Low  | 2023-03-13     | Chrome 111<br>Chrome Android 111<br>Edge 111 🔑💎<br>Firefox 34<br>Firefox for Android 34<br>Safari 16.2<br>Safari on iOS 16.2 |

<small>🔑💎 indicates a release that determines the Baseline low date.</small>

## fonts

| Key                                                                                                                             | Baseline | Low since date | Versions                                                                                                                |
| :------------------------------------------------------------------------------------------------------------------------------ | :------: | :------------- | ----------------------------------------------------------------------------------------------------------------------- |
| **fonts**                                                                                                                       |  ✅ High  | 2016-09-20     | Chrome 36<br>Chrome Android 36<br>Edge 14<br>Firefox 39<br>Firefox for Android 39<br>Safari 10 🔑💎<br>Safari on iOS 10 |
| [`css.at-rules.font-face`](https://developer.mozilla.org/docs/Web/CSS/@font-face#browser_compatibility)                         |  ✅ High  | 2015-07-28     | Chrome 1<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 3.5<br>Firefox for Android 4<br>Safari 3.1<br>Safari on iOS 2  |
| [`css.at-rules.font-face.font-family`](https://developer.mozilla.org/docs/Web/CSS/@font-face/font-family#browser_compatibility) |  ✅ High  | 2015-07-28     | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 3.5<br>Firefox for Android 4<br>Safari 3.1<br>Safari on iOS 2  |
| [`css.at-rules.font-face.src`](https://developer.mozilla.org/docs/Web/CSS/@font-face/src#browser_compatibility)                 |  ✅ High  | 2015-07-28     | Chrome 4<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 3.5<br>Firefox for Android 4<br>Safari 3.1<br>Safari on iOS 2  |
| [`css.at-rules.font-face.WOFF`](https://developer.mozilla.org/docs/Web/Guide/WOFF#browser_compatibility)                        |  ✅ High  | 2015-07-28     | Chrome 6<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 3.5<br>Firefox for Android 4<br>Safari 5.1<br>Safari on iOS 5  |
| [`css.at-rules.font-face.WOFF_2`](https://developer.mozilla.org/docs/Web/Guide/WOFF#browser_compatibility)                      |  ✅ High  | 2016-09-20     | Chrome 36<br>Chrome Android 36<br>Edge 14<br>Firefox 39<br>Firefox for Android 39<br>Safari 10 🔑💎<br>Safari on iOS 10 |

<small>🔑💎 indicates a release that determines the Baseline low date.</small>

