### PR TITLE
`fullscreen`: set Baseline status

### DIFF
--- a/feature-group-definitions/fullscreen.yml
+++ b/feature-group-definitions/fullscreen.yml
@@ -1,5 +1,11 @@
 spec: https://fullscreen.spec.whatwg.org/
 caniuse: fullscreen
+status:
+  baseline: false
+  support:
+    edge: "79"
+    firefox: "64"
+    firefox_android: "64"
 compat_features:
   - api.Document.exitFullscreen
   - api.Document.exitFullscreen.returns_promise


### PR DESCRIPTION
This one's messy. There are lots of prefixes on Safari on iOS _only_, which makes me think think the underlying data is potentially wrong.

## fullscreen

(overall, then oldest last)

| Key                                                                                                                                       |    Baseline    | Low since date | Versions                                                                                                                    |
| :---------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :------------- | --------------------------------------------------------------------------------------------------------------------------- |
| **fullscreen**                                                                                                                            | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge 79<br>Firefox 64<br>Firefox for Android 64<br>Safari ❌<br>Safari on iOS ❌              |
| [`api.Document.exitFullscreen`](https://developer.mozilla.org/docs/Web/API/Document/exitFullscreen#browser_compatibility)                 | ❌ Not Baseline |                | Chrome 71<br>Chrome Android 71<br>Edge 12<br>Firefox 64<br>Firefox for Android 64<br>Safari 16.4<br>Safari on iOS ❌         |
| [`api.Document.fullscreen`](https://developer.mozilla.org/docs/Web/API/Document/fullscreen#browser_compatibility)                         | ❌ Not Baseline |                | Chrome 71<br>Chrome Android 71<br>Edge 79<br>Firefox 64<br>Firefox for Android 64<br>Safari 16.4<br>Safari on iOS ❌         |
| [`api.Document.fullscreenchange_event`](https://developer.mozilla.org/docs/Web/API/Document/fullscreenchange_event#browser_compatibility) | ❌ Not Baseline |                | Chrome 71<br>Chrome Android 71<br>Edge 12<br>Firefox 64<br>Firefox for Android 64<br>Safari 16.4<br>Safari on iOS ❌         |
| [`api.Document.fullscreenElement`](https://developer.mozilla.org/docs/Web/API/Document/fullscreenElement#browser_compatibility)           | ❌ Not Baseline |                | Chrome 71<br>Chrome Android 71<br>Edge 12<br>Firefox 64<br>Firefox for Android 64<br>Safari 16.4<br>Safari on iOS ❌         |
| [`api.Document.fullscreenEnabled`](https://developer.mozilla.org/docs/Web/API/Document/fullscreenEnabled#browser_compatibility)           | ❌ Not Baseline |                | Chrome 71<br>Chrome Android 71<br>Edge 12<br>Firefox 64<br>Firefox for Android 64<br>Safari 16.4<br>Safari on iOS ❌         |
| [`api.Document.fullscreenerror_event`](https://developer.mozilla.org/docs/Web/API/Document/fullscreenerror_event#browser_compatibility)   | ❌ Not Baseline |                | Chrome 71<br>Chrome Android 71<br>Edge 12<br>Firefox 64<br>Firefox for Android 64<br>Safari 16.4<br>Safari on iOS ❌         |
| [`api.Element.fullscreenchange_event`](https://developer.mozilla.org/docs/Web/API/Element/fullscreenchange_event#browser_compatibility)   | ❌ Not Baseline |                | Chrome 71<br>Chrome Android 71<br>Edge 12<br>Firefox 64<br>Firefox for Android 64<br>Safari 16.4<br>Safari on iOS ❌         |
| [`api.Element.fullscreenerror_event`](https://developer.mozilla.org/docs/Web/API/Element/fullscreenerror_event#browser_compatibility)     | ❌ Not Baseline |                | Chrome 71<br>Chrome Android 71<br>Edge 12<br>Firefox 64<br>Firefox for Android 64<br>Safari 16.4<br>Safari on iOS ❌         |
| [`api.Element.requestFullscreen`](https://developer.mozilla.org/docs/Web/API/Element/requestFullscreen#browser_compatibility)             | ❌ Not Baseline |                | Chrome 71<br>Chrome Android 71<br>Edge 12<br>Firefox 64<br>Firefox for Android 64<br>Safari 16.4<br>Safari on iOS ❌         |
| `api.HTMLIFrameElement.allowFullscreen`                                                                                                   | ❌ Not Baseline |                | Chrome 38<br>Chrome Android 38<br>Edge 12<br>Firefox 22<br>Firefox for Android 22<br>Safari 10.1<br>Safari on iOS ❌         |
| `css.selectors.backdrop.fullscreen`                                                                                                       | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge 12<br>Firefox 47<br>Firefox for Android 47<br>Safari ❌<br>Safari on iOS ❌              |
| [`css.selectors.fullscreen`](https://developer.mozilla.org/docs/Web/CSS/:fullscreen#browser_compatibility)                                | ❌ Not Baseline |                | Chrome 71<br>Chrome Android 71<br>Edge 12<br>Firefox 64<br>Firefox for Android 64<br>Safari 16.4<br>Safari on iOS ❌         |
| `css.selectors.fullscreen.all_elements`                                                                                                   | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge 12<br>Firefox 43<br>Firefox for Android 43<br>Safari ❌<br>Safari on iOS ❌              |
| `html.elements.iframe.allowfullscreen`                                                                                                    | ❌ Not Baseline |                | Chrome 38<br>Chrome Android 38<br>Edge 12<br>Firefox 18<br>Firefox for Android 18<br>Safari 10.1<br>Safari on iOS ❌         |
| `api.Document.exitFullscreen.returns_promise`                                                                                             |     🆕 Low     | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 64<br>Firefox for Android 64<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.Element.requestFullscreen.returns_promise`                                                                                           |     🆕 Low     | 2023-03-27     | Chrome 71<br>Chrome Android 71<br>Edge 79<br>Firefox 64<br>Firefox for Android 64<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| [`api.ShadowRoot.fullscreenElement`](https://developer.mozilla.org/docs/Web/API/ShadowRoot/fullscreenElement#browser_compatibility)       |     🆕 Low     | 2023-03-27     | Chrome 71<br>Chrome Android 71<br>Edge 79<br>Firefox 64<br>Firefox for Android 64<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |

🔑💎 marks a release that contributes to the Baseline low date.<br>

