### PR TITLE
`input-event`: set Baseline status

### DIFF
--- a/feature-group-definitions/input-event.yml
+++ b/feature-group-definitions/input-event.yml
@@ -1,5 +1,13 @@
 spec: https://w3c.github.io/uievents/#event-type-input
 caniuse: input-event
+status:
+  baseline: false
+  support:
+    chrome: "60"
+    chrome_android: "60"
+    edge: "79"
+    firefox: "87"
+    firefox_android: "87"
 compat_features:
   - api.HTMLElement.input_event
   - api.InputEvent

--- a/feature-group-definitions/input-event.yml
+++ b/feature-group-definitions/input-event.yml
@@ -1,13 +1,16 @@
 spec: https://w3c.github.io/uievents/#event-type-input
 caniuse: input-event
 status:
-  baseline: false
+  baseline: low
+  baseline_low_date: 2023-03-27
   support:
     chrome: "60"
     chrome_android: "60"
     edge: "79"
     firefox: "87"
     firefox_android: "87"
+    safari: "16.4"
+    safari_ios: "16.4"
 compat_features:
   - api.HTMLElement.input_event
   - api.InputEvent


### PR DESCRIPTION
I'm somewhat skeptical of this one. Safari has two issues:

- `InputEvent()` is listed as partial, due to missing some options on the constructor. I wonder if anyone's checked on this recently.
- `isComposing` was added later. This looks right.

Without the former, this is a newly available feature; without the latter, it's widely supported.

## input-event

| Key                                                                                                                             |    Baseline    | Low since date | Versions                                                                                                                    |
| :------------------------------------------------------------------------------------------------------------------------------ | :------------: | :------------- | --------------------------------------------------------------------------------------------------------------------------- |
| **input-event**                                                                                                                 | ❌ Not Baseline |                | Chrome 60<br>Chrome Android 60<br>Edge 79<br>Firefox 87<br>Firefox for Android 87<br>Safari ❌<br>Safari on iOS ❌            |
| [`api.HTMLElement.input_event`](https://developer.mozilla.org/docs/Web/API/HTMLElement/input_event#browser_compatibility)       |     ✅ High     | 2020-01-15     | Chrome 1<br>Chrome Android 18<br>Edge 79 🔑💎<br>Firefox 6<br>Firefox for Android 6<br>Safari 3.1<br>Safari on iOS 2        |
| [`api.InputEvent`](https://developer.mozilla.org/docs/Web/API/InputEvent#browser_compatibility)                                 |     ✅ High     | 2020-01-15     | Chrome 60<br>Chrome Android 60<br>Edge 79 🔑💎<br>Firefox 31<br>Firefox for Android 31<br>Safari 10.1<br>Safari on iOS 10.3 |
| [`api.InputEvent.InputEvent`](https://developer.mozilla.org/docs/Web/API/InputEvent/InputEvent#browser_compatibility)           | ❌ Not Baseline |                | Chrome 60<br>Chrome Android 60<br>Edge 79<br>Firefox 31<br>Firefox for Android 31<br>Safari ❌<br>Safari on iOS ❌            |
| [`api.InputEvent.data`](https://developer.mozilla.org/docs/Web/API/InputEvent/data#browser_compatibility)                       |     ✅ High     | 2020-01-15     | Chrome 60<br>Chrome Android 60<br>Edge 79 🔑💎<br>Firefox 67<br>Firefox for Android 67<br>Safari 10.1<br>Safari on iOS 10.3 |
| [`api.InputEvent.dataTransfer`](https://developer.mozilla.org/docs/Web/API/InputEvent/dataTransfer#browser_compatibility)       |     ✅ High     | 2020-01-15     | Chrome 60<br>Chrome Android 60<br>Edge 79 🔑💎<br>Firefox 67<br>Firefox for Android 67<br>Safari 10.1<br>Safari on iOS 10.3 |
| [`api.InputEvent.getTargetRanges`](https://developer.mozilla.org/docs/Web/API/InputEvent/getTargetRanges#browser_compatibility) |     ✅ High     | 2021-03-23     | Chrome 60<br>Chrome Android 60<br>Edge 79<br>Firefox 87 🔑💎<br>Firefox for Android 87<br>Safari 10.1<br>Safari on iOS 10.3 |
| [`api.InputEvent.inputType`](https://developer.mozilla.org/docs/Web/API/InputEvent/inputType#browser_compatibility)             |     ✅ High     | 2020-01-15     | Chrome 60<br>Chrome Android 60<br>Edge 79 🔑💎<br>Firefox 66<br>Firefox for Android 66<br>Safari 10.1<br>Safari on iOS 10.3 |
| [`api.InputEvent.isComposing`](https://developer.mozilla.org/docs/Web/API/InputEvent/isComposing#browser_compatibility)         |     🆕 Low     | 2023-03-27     | Chrome 60<br>Chrome Android 60<br>Edge 79<br>Firefox 31<br>Firefox for Android 31<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |

<small>🔑💎 indicates a release that determines the Baseline low date.</small>