### PR TITLE
`has`, `i*` (excluding `input-event`): set Baseline statuses

### DIFF
--- a/feature-group-definitions/has.yml
+++ b/feature-group-definitions/has.yml
@@ -1,5 +1,13 @@
 spec: https://drafts.csswg.org/selectors-4/#relational
 caniuse: css-has
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4743
+status:
+  baseline: false
+  support:
+    chrome: "105"
+    chrome_android: "105"
+    edge: "105"
+    safari: "15.4"
+    safari_ios: "15.4"
 compat_features:
   - css.selectors.has

--- a/feature-group-definitions/idle-detection.yml
+++ b/feature-group-definitions/idle-detection.yml
@@ -1,5 +1,11 @@
 spec: https://wicg.github.io/idle-detection/
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2834
+status:
+  baseline: false
+  support:
+    chrome: "94"
+    chrome_android: "94"
+    edge: "94"
 compat_features:
   - api.IdleDetector
   - api.IdleDetector.IdleDetector

--- a/feature-group-definitions/import-maps.yml
+++ b/feature-group-definitions/import-maps.yml
@@ -1,4 +1,15 @@
 spec: https://html.spec.whatwg.org/multipage/webappapis.html#import-maps
 caniuse: import-maps
+status:
+  baseline: low
+  baseline_low_date: 2023-03-27
+  support:
+    chrome: "89"
+    chrome_android: "89"
+    edge: "89"
+    firefox: "108"
+    firefox_android: "108"
+    safari: "16.4"
+    safari_ios: "16.4"
 compat_features:
   - html.elements.script.type.importmap

--- a/feature-group-definitions/indeterminate.yml
+++ b/feature-group-definitions/indeterminate.yml
@@ -2,6 +2,17 @@ spec:
   - https://drafts.csswg.org/selectors-4/#indeterminate
   - https://html.spec.whatwg.org/multipage/semantics-other.html#selector-indeterminate
 caniuse: css-indeterminate-pseudo
+status:
+  baseline: high
+  baseline_low_date: 2020-01-15
+  support:
+    chrome: "39"
+    chrome_android: "39"
+    edge: "79"
+    firefox: "51"
+    firefox_android: "51"
+    safari: "10"
+    safari_ios: "10"
 compat_features:
   - css.selectors.indeterminate
   - css.selectors.indeterminate.checkbox

--- a/feature-group-definitions/is.yml
+++ b/feature-group-definitions/is.yml
@@ -1,6 +1,17 @@
 spec: https://drafts.csswg.org/selectors-4/#matches
 caniuse: css-matches-pseudo
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2322
+status:
+  baseline: high
+  baseline_low_date: 2021-01-21
+  support:
+    chrome: "88"
+    chrome_android: "88"
+    edge: "88"
+    firefox: "82"
+    firefox_android: "82"
+    safari: "14"
+    safari_ios: "14"
 compat_features:
   - css.selectors.is
   - css.selectors.is.forgiving_selector_list


### PR DESCRIPTION
## has

| Key                                                                                          |    Baseline    | Low since date | Versions                                                                                                                          |
| :------------------------------------------------------------------------------------------- | :------------: | :------------- | --------------------------------------------------------------------------------------------------------------------------------- |
| **has**                                                                                      | ❌ Not Baseline |                | Chrome 105<br>Chrome Android 105<br>Edge 105<br>Firefox 121 🚧<br>Firefox for Android 121 🚧<br>Safari 15.4<br>Safari on iOS 15.4 |
| [`css.selectors.has`](https://developer.mozilla.org/docs/Web/CSS/:has#browser_compatibility) | ❌ Not Baseline |                | Chrome 105<br>Chrome Android 105<br>Edge 105<br>Firefox 121 🚧<br>Firefox for Android 121 🚧<br>Safari 15.4<br>Safari on iOS 15.4 |

🚧 marks a prerelease (nominally unsupported).<br>

## idle-detection

| Key                                                                                                                                                             |    Baseline    | Low since date | Versions                                                                                                       |
| :-------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :------------- | -------------------------------------------------------------------------------------------------------------- |
| **idle-detection**                                                                                                                                              | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.IdleDetector`](https://developer.mozilla.org/docs/Web/API/IdleDetector#browser_compatibility)                                                             | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.IdleDetector.IdleDetector`](https://developer.mozilla.org/docs/Web/API/IdleDetector/IdleDetector#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.IdleDetector.change_event`](https://developer.mozilla.org/docs/Web/API/IdleDetector/change_event#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.IdleDetector.requestPermission_static`](https://developer.mozilla.org/docs/Web/API/IdleDetector/requestPermission_static#browser_compatibility)           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.IdleDetector.screenState`](https://developer.mozilla.org/docs/Web/API/IdleDetector/screenState#browser_compatibility)                                     | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.IdleDetector.start`](https://developer.mozilla.org/docs/Web/API/IdleDetector/start#browser_compatibility)                                                 | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.IdleDetector.userState`](https://developer.mozilla.org/docs/Web/API/IdleDetector/userState#browser_compatibility)                                         | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`http.headers.Permissions-Policy.idle-detection`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/idle-detection#browser_compatibility) | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |



## import-maps

| Key                                   | Baseline | Low since date | Versions                                                                                                                      |
| :------------------------------------ | :------: | :------------- | ----------------------------------------------------------------------------------------------------------------------------- |
| **import-maps**                       |  🆕 Low  | 2023-03-27     | Chrome 89<br>Chrome Android 89<br>Edge 89<br>Firefox 108<br>Firefox for Android 108<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `html.elements.script.type.importmap` |  🆕 Low  | 2023-03-27     | Chrome 89<br>Chrome Android 89<br>Edge 89<br>Firefox 108<br>Firefox for Android 108<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |

🔑💎 marks a release that contributes to the Baseline low date.<br>

## indeterminate

| Key                                                                                                              | Baseline | Low since date | Versions                                                                                                                |
| :--------------------------------------------------------------------------------------------------------------- | :------: | :------------- | ----------------------------------------------------------------------------------------------------------------------- |
| **indeterminate**                                                                                                |  ✅ High  | 2020-01-15     | Chrome 39<br>Chrome Android 39<br>Edge 79 🔑💎<br>Firefox 51<br>Firefox for Android 51<br>Safari 10<br>Safari on iOS 10 |
| [`css.selectors.indeterminate`](https://developer.mozilla.org/docs/Web/CSS/:indeterminate#browser_compatibility) |  ✅ High  | 2015-07-28     | Chrome 1<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 2<br>Firefox for Android 4<br>Safari 3<br>Safari on iOS 1      |
| `css.selectors.indeterminate.checkbox`                                                                           |  ✅ High  | 2015-07-28     | Chrome 1<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 3.6<br>Firefox for Android 4<br>Safari 3<br>Safari on iOS 1    |
| `css.selectors.indeterminate.progress`                                                                           |  ✅ High  | 2015-07-28     | Chrome 6<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 6<br>Firefox for Android 6<br>Safari 5.1<br>Safari on iOS 5    |
| `css.selectors.indeterminate.radio`                                                                              |  ✅ High  | 2020-01-15     | Chrome 39<br>Chrome Android 39<br>Edge 79 🔑💎<br>Firefox 51<br>Firefox for Android 51<br>Safari 10<br>Safari on iOS 10 |

🔑💎 marks a release that contributes to the Baseline low date.<br>

## is

| Key                                                                                                                                           | Baseline | Low since date | Versions                                                                                                                |
| :-------------------------------------------------------------------------------------------------------------------------------------------- | :------: | :------------- | ----------------------------------------------------------------------------------------------------------------------- |
| **is**                                                                                                                                        |  ✅ High  | 2021-01-21     | Chrome 88<br>Chrome Android 88<br>Edge 88 🔑💎<br>Firefox 82<br>Firefox for Android 82<br>Safari 14<br>Safari on iOS 14 |
| [`css.selectors.is`](https://developer.mozilla.org/docs/Web/CSS/:is#browser_compatibility)                                                    |  ✅ High  | 2021-01-21     | Chrome 88<br>Chrome Android 88<br>Edge 88 🔑💎<br>Firefox 78<br>Firefox for Android 79<br>Safari 14<br>Safari on iOS 14 |
| [`css.selectors.is.forgiving_selector_list`](https://developer.mozilla.org/docs/Web/CSS/:is#Forgiving_Selector_Parsing#browser_compatibility) |  ✅ High  | 2021-01-21     | Chrome 88<br>Chrome Android 88<br>Edge 88 🔑💎<br>Firefox 82<br>Firefox for Android 82<br>Safari 14<br>Safari on iOS 14 |

🔑💎 marks a release that contributes to the Baseline low date.<br>

