### PR TITLE
`masonry`: set Baseline status (and correct feature list)

### DIFF
--- a/feature-group-definitions/masonry.yml
+++ b/feature-group-definitions/masonry.yml
@@ -1,7 +1,10 @@
 spec: https://drafts.csswg.org/css-grid-3/
+status:
+  baseline: false
+  support: {}
 compat_features:
   - css.properties.align-tracks
-  - css.properties.grid-column-rows.masonry
+  - css.properties.grid-template-columns.masonry
   - css.properties.grid-template-rows.masonry
   - css.properties.justify-tracks
   - css.properties.masonry-auto-flow


### PR DESCRIPTION
| Key                                                                                                                                            |    Baseline    | Low since date | Versions                                                                                                             |
| :--------------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :------------- | -------------------------------------------------------------------------------------------------------------------- |
| **masonry**                                                                                                                                    | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge ❌<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`css.properties.align-tracks`](https://developer.mozilla.org/docs/Web/CSS/align-tracks#browser_compatibility)                                 | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge ❌<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| `css.properties.grid-template-columns.masonry`                                                                                                 | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge ❌<br>Firefox ❌<br>Firefox for Android ❌<br>Safari preview 🚧<br>Safari on iOS ❌ |
| [`css.properties.grid-template-rows.masonry`](https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout/Masonry_Layout#browser_compatibility) | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge ❌<br>Firefox ❌<br>Firefox for Android ❌<br>Safari preview 🚧<br>Safari on iOS ❌ |
| [`css.properties.justify-tracks`](https://developer.mozilla.org/docs/Web/CSS/justify-tracks#browser_compatibility)                             | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge ❌<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`css.properties.masonry-auto-flow`](https://developer.mozilla.org/docs/Web/CSS/masonry-auto-flow#browser_compatibility)                       | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge ❌<br>Firefox ❌<br>Firefox for Android ❌<br>Safari preview 🚧<br>Safari on iOS ❌ |

🚧 marks a prerelease (nominally unsupported).<br>

