### PR TITLE
Features O-R: set Baseline status

### DIFF
--- a/feature-group-definitions/offscreen-canvas.yml
+++ b/feature-group-definitions/offscreen-canvas.yml
@@ -2,8 +2,12 @@ spec: https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-int
 caniuse: offscreencanvas
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1624
 status:
-  baseline: false
+  baseline: low
+  baseline_low_date: 2023-03-27
   support:
+    chrome: "80"
+    chrome_android: "80"
+    edge: "80"
     firefox: "105"
     firefox_android: "105"
     safari: "16.4"

--- a/feature-group-definitions/offscreen-canvas.yml
+++ b/feature-group-definitions/offscreen-canvas.yml
@@ -1,14 +1,13 @@
 spec: https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-interface
 caniuse: offscreencanvas
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1624
-# status:
-#   is_baseline: false
-#   # since: future
-#   support:
-#     chrome: "80"
-#     edge: "80"
-#     firefox: "105"
-#     safari: "16.4"
+status:
+  baseline: false
+  support:
+    firefox: "105"
+    firefox_android: "105"
+    safari: "16.4"
+    safari_ios: "16.4"
 compat_features:
   - api.HTMLCanvasElement.transferControlToOffscreen
   - api.OffscreenCanvas

--- a/feature-group-definitions/offscreen-canvas.yml
+++ b/feature-group-definitions/offscreen-canvas.yml
@@ -26,7 +26,10 @@ compat_features:
   - api.OffscreenCanvasRenderingContext2D.clearRect
   - api.OffscreenCanvasRenderingContext2D.clip
   - api.OffscreenCanvasRenderingContext2D.closePath
-  - api.OffscreenCanvasRenderingContext2D.commit
+  # `commit`'s relevance and future are uncertain, see both:
+  #   https://github.com/whatwg/html/pull/9979
+  #   https://bugs.chromium.org/p/chromium/issues/detail?id=1507769
+  # - api.OffscreenCanvasRenderingContext2D.commit
   - api.OffscreenCanvasRenderingContext2D.createImageData
   - api.OffscreenCanvasRenderingContext2D.createLinearGradient
   - api.OffscreenCanvasRenderingContext2D.createPattern

--- a/feature-group-definitions/overflow-shorthand.yml
+++ b/feature-group-definitions/overflow-shorthand.yml
@@ -1,5 +1,16 @@
 spec: https://drafts.csswg.org/css-overflow-3/#propdef-overflow
 caniuse: css-overflow
+status:
+  baseline: low
+  baseline_low_date: 2022-09-12
+  support:
+    chrome: "90"
+    chrome_android: "90"
+    edge: "90"
+    firefox: "81"
+    firefox_android: "81"
+    safari: "16"
+    safari_ios: "16"
 compat_features:
   - css.properties.overflow-x
   - css.properties.overflow-x.clip

--- a/feature-group-definitions/popover.yml
+++ b/feature-group-definitions/popover.yml
@@ -1,5 +1,13 @@
 spec: https://html.spec.whatwg.org/multipage/popover.html
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4191
+status:
+  baseline: false
+  support:
+    chrome: "114"
+    chrome_android: "114"
+    edge: "114"
+    safari: "17"
+    safari_ios: "17"
 compat_features:
   - api.HTMLButtonElement.popoverTargetAction
   - api.HTMLButtonElement.popoverTargetElement
@@ -13,8 +21,8 @@ compat_features:
   - api.HTMLInputElement.popoverTargetElement
   - api.ToggleEvent
   - api.ToggleEvent.ToggleEvent
-  - api.ToggleEvent.newstate
-  - api.ToggleEvent.oldstate
+  - api.ToggleEvent.newState
+  - api.ToggleEvent.oldState
   - css.selectors.backdrop.popover
   - css.selectors.popover-open
   - html.global_attributes.popover

--- a/feature-group-definitions/read-write-pseudo-classes.yml
+++ b/feature-group-definitions/read-write-pseudo-classes.yml
@@ -2,6 +2,15 @@ spec:
   - https://html.spec.whatwg.org/multipage/semantics-other.html#selector-read-only
   - https://drafts.csswg.org/selectors-4/#rw-pseudos
 caniuse: css-read-only-write
+status:
+  baseline: false
+  support:
+    chrome: "1"
+    chrome_android: "18"
+    edge: "13"
+    firefox: "78"
+    safari: "4"
+    safari_ios: "3.2"
 compat_features:
   - css.selectors.read-only
   - css.selectors.read-write

--- a/feature-group-definitions/read-write-pseudo-classes.yml
+++ b/feature-group-definitions/read-write-pseudo-classes.yml
@@ -3,12 +3,14 @@ spec:
   - https://drafts.csswg.org/selectors-4/#rw-pseudos
 caniuse: css-read-only-write
 status:
-  baseline: false
+  baseline: high
+  baseline_low_date: 2020-07-28
   support:
     chrome: "1"
     chrome_android: "18"
     edge: "13"
     firefox: "78"
+    firefox_android: "79"
     safari: "4"
     safari_ios: "3.2"
 compat_features:

--- a/feature-group-definitions/registered-custom-properties.yml
+++ b/feature-group-definitions/registered-custom-properties.yml
@@ -1,4 +1,12 @@
 spec: https://drafts.css-houdini.org/css-properties-values-api-1/
+status:
+  baseline: false
+  support:
+    chrome: "85"
+    chrome_android: "85"
+    edge: "85"
+    safari: "16.4"
+    safari_ios: "16.4"
 compat_features:
   - api.CSS.registerProperty_static
   - api.CSSPropertyRule


### PR DESCRIPTION
## offscreen-canvas

| Key                                                                                                                                                                 | Baseline | Low since date | Versions                                                                                                                      |
| :------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------: | :------------- | ----------------------------------------------------------------------------------------------------------------------------- |
| **offscreen-canvas**                                                                                                                                                |  🆕 Low  | 2023-03-27     | Chrome 80<br>Chrome Android 80<br>Edge 80<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| [`api.HTMLCanvasElement.transferControlToOffscreen`](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/transferControlToOffscreen#browser_compatibility) |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| [`api.OffscreenCanvas`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas#browser_compatibility)                                                           |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| [`api.OffscreenCanvas.convertToBlob`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/convertToBlob#browser_compatibility)                               |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| [`api.OffscreenCanvas.getContext`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/getContext#browser_compatibility)                                     |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| [`api.OffscreenCanvas.height`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/height#browser_compatibility)                                             |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| [`api.OffscreenCanvas.OffscreenCanvas`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/OffscreenCanvas#browser_compatibility)                           |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| [`api.OffscreenCanvas.transferToImageBitmap`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/transferToImageBitmap#browser_compatibility)               |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| [`api.OffscreenCanvas.width`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/width#browser_compatibility)                                               |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| [`api.OffscreenCanvasRenderingContext2D`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvasRenderingContext2D#browser_compatibility)                       |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.arc`                                                                                                                         |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.arcTo`                                                                                                                       |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.beginPath`                                                                                                                   |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.bezierCurveTo`                                                                                                               |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.canvas`                                                                                                                      |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.clearRect`                                                                                                                   |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.clip`                                                                                                                        |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.closePath`                                                                                                                   |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.createImageData`                                                                                                             |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.createLinearGradient`                                                                                                        |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.createPattern`                                                                                                               |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.createRadialGradient`                                                                                                        |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.direction`                                                                                                                   |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.drawImage`                                                                                                                   |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.ellipse`                                                                                                                     |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.fill`                                                                                                                        |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.fillRect`                                                                                                                    |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.fillStyle`                                                                                                                   |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.fillText`                                                                                                                    |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.font`                                                                                                                        |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.getImageData`                                                                                                                |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.getLineDash`                                                                                                                 |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.getTransform`                                                                                                                |  🆕 Low  | 2023-03-27     | Chrome 80<br>Chrome Android 80<br>Edge 80<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.globalAlpha`                                                                                                                 |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.globalCompositeOperation`                                                                                                    |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.imageSmoothingEnabled`                                                                                                       |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.isPointInPath`                                                                                                               |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.isPointInStroke`                                                                                                             |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.lineCap`                                                                                                                     |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.lineDashOffset`                                                                                                              |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.lineJoin`                                                                                                                    |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.lineTo`                                                                                                                      |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.lineWidth`                                                                                                                   |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.measureText`                                                                                                                 |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.miterLimit`                                                                                                                  |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.moveTo`                                                                                                                      |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.putImageData`                                                                                                                |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.quadraticCurveTo`                                                                                                            |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.rect`                                                                                                                        |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.resetTransform`                                                                                                              |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.restore`                                                                                                                     |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.rotate`                                                                                                                      |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.save`                                                                                                                        |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.scale`                                                                                                                       |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.setLineDash`                                                                                                                 |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.setTransform`                                                                                                                |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.shadowBlur`                                                                                                                  |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.shadowColor`                                                                                                                 |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.shadowOffsetX`                                                                                                               |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.shadowOffsetY`                                                                                                               |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.stroke`                                                                                                                      |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.strokeRect`                                                                                                                  |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.strokeStyle`                                                                                                                 |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.strokeText`                                                                                                                  |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.textAlign`                                                                                                                   |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.textBaseline`                                                                                                                |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.transform`                                                                                                                   |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |
| `api.OffscreenCanvasRenderingContext2D.translate`                                                                                                                   |  🆕 Low  | 2023-03-27     | Chrome 69<br>Chrome Android 69<br>Edge 79<br>Firefox 105<br>Firefox for Android 105<br>Safari 16.4 🔑💎<br>Safari on iOS 16.4 |

🔑💎 marks a release that contributes to the Baseline low date.<br>

## overflow-shorthand

| Key                                                                                                        | Baseline | Low since date | Versions                                                                                                                    |
| :--------------------------------------------------------------------------------------------------------- | :------: | :------------- | --------------------------------------------------------------------------------------------------------------------------- |
| **overflow-shorthand**                                                                                     |  🆕 Low  | 2022-09-12     | Chrome 90<br>Chrome Android 90<br>Edge 90<br>Firefox 81<br>Firefox for Android 81<br>Safari 16 🔑💎<br>Safari on iOS 16     |
| [`css.properties.overflow-x`](https://developer.mozilla.org/docs/Web/CSS/overflow-x#browser_compatibility) |  ✅ High  | 2015-07-28     | Chrome 1<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 3.5<br>Firefox for Android 4<br>Safari 3<br>Safari on iOS 1        |
| `css.properties.overflow-x.clip`                                                                           |  🆕 Low  | 2022-09-12     | Chrome 90<br>Chrome Android 90<br>Edge 90<br>Firefox 81<br>Firefox for Android 81<br>Safari 16 🔑💎<br>Safari on iOS 16     |
| [`css.properties.overflow-y`](https://developer.mozilla.org/docs/Web/CSS/overflow-y#browser_compatibility) |  ✅ High  | 2015-07-28     | Chrome 1<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 3.5<br>Firefox for Android 4<br>Safari 3<br>Safari on iOS 1        |
| `css.properties.overflow-y.clip`                                                                           |  🆕 Low  | 2022-09-12     | Chrome 90<br>Chrome Android 90<br>Edge 90<br>Firefox 81<br>Firefox for Android 81<br>Safari 16 🔑💎<br>Safari on iOS 16     |
| [`css.properties.overflow`](https://developer.mozilla.org/docs/Web/CSS/overflow#browser_compatibility)     |  ✅ High  | 2015-07-28     | Chrome 1<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 1<br>Firefox for Android 4<br>Safari 1<br>Safari on iOS 1          |
| `css.properties.overflow.clip`                                                                             |  🆕 Low  | 2022-09-12     | Chrome 90<br>Chrome Android 90<br>Edge 90<br>Firefox 81<br>Firefox for Android 81<br>Safari 16 🔑💎<br>Safari on iOS 16     |
| `css.properties.overflow.multiple_keywords`                                                                |  ✅ High  | 2020-03-24     | Chrome 68<br>Chrome Android 68<br>Edge 79<br>Firefox 61<br>Firefox for Android 61<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`css.types.overflow`](https://developer.mozilla.org/docs/Web/CSS/overflow_value#browser_compatibility)    |  ✅ High  | 2015-07-28     | Chrome 1<br>Chrome Android 18<br>Edge 12 🔑💎<br>Firefox 1<br>Firefox for Android 4<br>Safari 1<br>Safari on iOS 1          |
| `css.types.overflow.clip`                                                                                  |  🆕 Low  | 2022-09-12     | Chrome 90<br>Chrome Android 90<br>Edge 90<br>Firefox 81<br>Firefox for Android 81<br>Safari 16 🔑💎<br>Safari on iOS 16     |

🔑💎 marks a release that contributes to the Baseline low date.<br>

## popover

| Key                                                                                                                                                     |    Baseline    | Low since date | Versions                                                                                                                     |
| :------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------: | :------------- | ---------------------------------------------------------------------------------------------------------------------------- |
| **popover**                                                                                                                                             | ❌ Not Baseline |                | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17          |
| [`api.HTMLButtonElement.popoverTargetAction`](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/popoverTargetAction#browser_compatibility)   | ❌ Not Baseline |                | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17          |
| [`api.HTMLButtonElement.popoverTargetElement`](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/popoverTargetElement#browser_compatibility) | ❌ Not Baseline |                | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17          |
| [`api.HTMLElement.beforetoggle_event`](https://developer.mozilla.org/docs/Web/API/HTMLElement/beforetoggle_event#browser_compatibility)                 | ❌ Not Baseline |                | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17          |
| [`api.HTMLElement.hidePopover`](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidePopover#browser_compatibility)                               | ❌ Not Baseline |                | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17          |
| [`api.HTMLElement.popover`](https://developer.mozilla.org/docs/Web/API/HTMLElement/popover#browser_compatibility)                                       | ❌ Not Baseline |                | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17          |
| [`api.HTMLElement.showPopover`](https://developer.mozilla.org/docs/Web/API/HTMLElement/showPopover#browser_compatibility)                               | ❌ Not Baseline |                | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17          |
| [`api.HTMLElement.toggle_event`](https://developer.mozilla.org/docs/Web/API/HTMLElement/toggle_event#browser_compatibility)                             | ❌ Not Baseline |                | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17          |
| [`api.HTMLElement.togglePopover`](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17          |
| [`api.HTMLInputElement.popoverTargetAction`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/popoverTargetAction#browser_compatibility)     | ❌ Not Baseline |                | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17          |
| [`api.HTMLInputElement.popoverTargetElement`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/popoverTargetElement#browser_compatibility)   | ❌ Not Baseline |                | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17          |
| [`api.ToggleEvent`](https://developer.mozilla.org/docs/Web/API/ToggleEvent#browser_compatibility)                                                       |     🆕 Low     | 2023-11-21     | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox 120 🔑💎<br>Firefox for Android 120<br>Safari 17<br>Safari on iOS 17 |
| [`api.ToggleEvent.ToggleEvent`](https://developer.mozilla.org/docs/Web/API/ToggleEvent/ToggleEvent#browser_compatibility)                               |     🆕 Low     | 2023-11-21     | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox 120 🔑💎<br>Firefox for Android 120<br>Safari 17<br>Safari on iOS 17 |
| [`api.ToggleEvent.newState`](https://developer.mozilla.org/docs/Web/API/ToggleEvent/newState#browser_compatibility)                                     |     🆕 Low     | 2023-11-21     | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox 120 🔑💎<br>Firefox for Android 120<br>Safari 17<br>Safari on iOS 17 |
| [`api.ToggleEvent.oldState`](https://developer.mozilla.org/docs/Web/API/ToggleEvent/oldState#browser_compatibility)                                     |     🆕 Low     | 2023-11-21     | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox 120 🔑💎<br>Firefox for Android 120<br>Safari 17<br>Safari on iOS 17 |
| `css.selectors.backdrop.popover`                                                                                                                        | ❌ Not Baseline |                | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17          |
| [`css.selectors.popover-open`](https://developer.mozilla.org/docs/Web/CSS/:popover-open#browser_compatibility)                                          | ❌ Not Baseline |                | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17          |
| [`html.global_attributes.popover`](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/popover#browser_compatibility)                         | ❌ Not Baseline |                | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17          |
| [`html.global_attributes.popovertarget`](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/popovertarget#browser_compatibility)             | ❌ Not Baseline |                | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17          |
| [`html.global_attributes.popovertargetaction`](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/popovertargetaction#browser_compatibility) | ❌ Not Baseline |                | Chrome 114<br>Chrome Android 114<br>Edge 114<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17          |

🔑💎 marks a release that contributes to the Baseline low date.<br>

## read-write-pseudo-classes

| Key                                                                                                        |    Baseline    | Low since date | Versions                                                                                                         |
| :--------------------------------------------------------------------------------------------------------- | :------------: | :------------- | ---------------------------------------------------------------------------------------------------------------- |
| **read-write-pseudo-classes**                                                                              | ❌ Not Baseline |                | Chrome 1<br>Chrome Android 18<br>Edge 13<br>Firefox 78<br>Firefox for Android ❌<br>Safari 4<br>Safari on iOS 3.2 |
| [`css.selectors.read-only`](https://developer.mozilla.org/docs/Web/CSS/:read-only#browser_compatibility)   | ❌ Not Baseline |                | Chrome 1<br>Chrome Android 18<br>Edge 13<br>Firefox 78<br>Firefox for Android ❌<br>Safari 4<br>Safari on iOS 3.2 |
| [`css.selectors.read-write`](https://developer.mozilla.org/docs/Web/CSS/:read-write#browser_compatibility) | ❌ Not Baseline |                | Chrome 1<br>Chrome Android 18<br>Edge 13<br>Firefox 78<br>Firefox for Android ❌<br>Safari 4<br>Safari on iOS 3.2 |



## registered-custom-properties

| Key                                                                                                                                 |    Baseline    | Low since date | Versions                                                                                                                      |
| :---------------------------------------------------------------------------------------------------------------------------------- | :------------: | :------------- | ----------------------------------------------------------------------------------------------------------------------------- |
| **registered-custom-properties**                                                                                                    | ❌ Not Baseline |                | Chrome 85<br>Chrome Android 85<br>Edge 85<br>Firefox preview 🚧<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4 |
| [`api.CSS.registerProperty_static`](https://developer.mozilla.org/docs/Web/API/CSS/registerProperty_static#browser_compatibility)   | ❌ Not Baseline |                | Chrome 78<br>Chrome Android 78<br>Edge 79<br>Firefox preview 🚧<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4 |
| [`api.CSSPropertyRule`](https://developer.mozilla.org/docs/Web/API/CSSPropertyRule#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 85<br>Chrome Android 85<br>Edge 85<br>Firefox preview 🚧<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4 |
| [`api.CSSPropertyRule.inherits`](https://developer.mozilla.org/docs/Web/API/CSSPropertyRule/inherits#browser_compatibility)         | ❌ Not Baseline |                | Chrome 85<br>Chrome Android 85<br>Edge 85<br>Firefox preview 🚧<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4 |
| [`api.CSSPropertyRule.initialValue`](https://developer.mozilla.org/docs/Web/API/CSSPropertyRule/initialValue#browser_compatibility) | ❌ Not Baseline |                | Chrome 85<br>Chrome Android 85<br>Edge 85<br>Firefox preview 🚧<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4 |
| [`api.CSSPropertyRule.name`](https://developer.mozilla.org/docs/Web/API/CSSPropertyRule/name#browser_compatibility)                 | ❌ Not Baseline |                | Chrome 85<br>Chrome Android 85<br>Edge 85<br>Firefox preview 🚧<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4 |
| [`api.CSSPropertyRule.syntax`](https://developer.mozilla.org/docs/Web/API/CSSPropertyRule/syntax#browser_compatibility)             | ❌ Not Baseline |                | Chrome 85<br>Chrome Android 85<br>Edge 85<br>Firefox preview 🚧<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4 |
| [`css.at-rules.property`](https://developer.mozilla.org/docs/Web/CSS/@property#browser_compatibility)                               | ❌ Not Baseline |                | Chrome 85<br>Chrome Android 85<br>Edge 85<br>Firefox preview 🚧<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4 |
| [`css.at-rules.property.inherits`](https://developer.mozilla.org/docs/Web/CSS/@property/inherits#browser_compatibility)             | ❌ Not Baseline |                | Chrome 85<br>Chrome Android 85<br>Edge 85<br>Firefox preview 🚧<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4 |
| [`css.at-rules.property.initial-value`](https://developer.mozilla.org/docs/Web/CSS/@property/initial-value#browser_compatibility)   | ❌ Not Baseline |                | Chrome 85<br>Chrome Android 85<br>Edge 85<br>Firefox preview 🚧<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4 |
| [`css.at-rules.property.syntax`](https://developer.mozilla.org/docs/Web/CSS/@property/syntax#browser_compatibility)                 | ❌ Not Baseline |                | Chrome 85<br>Chrome Android 85<br>Edge 85<br>Firefox preview 🚧<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4 |

🚧 marks a prerelease (nominally unsupported).<br>

