### PR TITLE
`scheduler`: set Baseline status (and correct feature list)

### DIFF
--- a/feature-group-definitions/scheduler.yml
+++ b/feature-group-definitions/scheduler.yml
@@ -1,4 +1,10 @@
 spec: https://wicg.github.io/scheduling-apis/
+status:
+  baseline: false
+  support:
+    chrome: "94"
+    chrome_android: "94"
+    edge: "94"
 compat_features:
   - api.Scheduler
   - api.Scheduler.postTask
@@ -10,4 +16,4 @@ compat_features:
   - api.TaskPriorityChangeEvent.TaskPriorityChangeEvent
   - api.TaskSignal
   - api.TaskSignal.priority
-  - api.window.scheduler
+  - api.scheduler


### PR DESCRIPTION
| Key                                                                                                                                                                       |    Baseline    | Low since date | Versions                                                                                                       |
| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------: | :------------- | -------------------------------------------------------------------------------------------------------------- |
| **scheduler**                                                                                                                                                             | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.Scheduler`](https://developer.mozilla.org/docs/Web/API/Scheduler#browser_compatibility)                                                                             | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.Scheduler.postTask`](https://developer.mozilla.org/docs/Web/API/Scheduler/postTask#browser_compatibility)                                                           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.TaskController`](https://developer.mozilla.org/docs/Web/API/TaskController#browser_compatibility)                                                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.TaskController.setPriority`](https://developer.mozilla.org/docs/Web/API/TaskController/setPriority#browser_compatibility)                                           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.TaskController.TaskController`](https://developer.mozilla.org/docs/Web/API/TaskController/TaskController#browser_compatibility)                                     | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.TaskPriorityChangeEvent`](https://developer.mozilla.org/docs/Web/API/TaskPriorityChangeEvent#browser_compatibility)                                                 | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.TaskPriorityChangeEvent.previousPriority`](https://developer.mozilla.org/docs/Web/API/TaskPriorityChangeEvent/previousPriority#browser_compatibility)               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.TaskPriorityChangeEvent.TaskPriorityChangeEvent`](https://developer.mozilla.org/docs/Web/API/TaskPriorityChangeEvent/TaskPriorityChangeEvent#browser_compatibility) | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.TaskSignal`](https://developer.mozilla.org/docs/Web/API/TaskSignal#browser_compatibility)                                                                           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.TaskSignal.priority`](https://developer.mozilla.org/docs/Web/API/TaskSignal/priority#browser_compatibility)                                                         | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.scheduler`](https://developer.mozilla.org/docs/Web/API/Window/scheduler#browser_compatibility)                                                                      | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |



