### PR TITLE
Features starting with S: set Baseline statuses

### DIFF
--- a/feature-group-definitions/scrollintoview.yml
+++ b/feature-group-definitions/scrollintoview.yml
@@ -1,5 +1,16 @@
 spec: https://drafts.csswg.org/cssom-view-1/#dom-element-scrollintoview
 caniuse: scrollintoview
+status:
+  baseline: high
+  baseline_low_date: 2020-09-16
+  support:
+    chrome: "61"
+    chrome_android: "61"
+    edge: "79"
+    firefox: "36"
+    firefox_android: "36"
+    safari: "14"
+    safari_ios: "14"
 compat_features:
   - api.Element.scrollIntoView
   - api.Element.scrollIntoView.options_parameter

--- a/feature-group-definitions/set-methods.yml
+++ b/feature-group-definitions/set-methods.yml
@@ -1,4 +1,9 @@
 spec: https://tc39.es/proposal-set-methods/
+status:
+  baseline: false
+  support:
+    safari: "17"
+    safari_ios: "17"
 compat_features:
   - javascript.builtins.Set.difference
   - javascript.builtins.Set.intersection

--- a/feature-group-definitions/shadow-dom.yml
+++ b/feature-group-definitions/shadow-dom.yml
@@ -1,5 +1,16 @@
 spec: https://dom.spec.whatwg.org/#shadow-trees
 caniuse: shadowdomv1
+status:
+  baseline: high
+  baseline_low_date: 2020-01-15
+  support:
+    chrome: "54"
+    chrome_android: "54"
+    edge: "79"
+    firefox: "63"
+    firefox_android: "63"
+    safari: "10.1"
+    safari_ios: "10.3"
 compat_features:
   - api.Element.attachShadow
   - api.Element.shadowRoot

--- a/feature-group-definitions/sticky-positioning.yml
+++ b/feature-group-definitions/sticky-positioning.yml
@@ -1,5 +1,16 @@
 spec: https://drafts.csswg.org/css-position-3/#stickypos-insets
 caniuse: css-sticky
+status:
+  baseline: high
+  baseline_low_date: 2019-09-19
+  support:
+    chrome: "56"
+    chrome_android: "56"
+    edge: "16"
+    firefox: "59"
+    firefox_android: "59"
+    safari: "13"
+    safari_ios: "13"
 compat_features:
   - css.properties.position.position_sticky_table_elements
   - css.properties.position.sticky


### PR DESCRIPTION
## scrollintoview

| Key                                                                                                                     | Baseline | Low since date | Versions                                                                                                                |
| :---------------------------------------------------------------------------------------------------------------------- | :------: | :------------- | ----------------------------------------------------------------------------------------------------------------------- |
| **scrollintoview**                                                                                                      |  ✅ High  | 2020-09-16     | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox 36<br>Firefox for Android 36<br>Safari 14 🔑💎<br>Safari on iOS 14 |
| [`api.Element.scrollIntoView`](https://developer.mozilla.org/docs/Web/API/Element/scrollIntoView#browser_compatibility) |  ✅ High  | 2020-01-15     | Chrome 1<br>Chrome Android 18<br>Edge 79 🔑💎<br>Firefox 1<br>Firefox for Android 4<br>Safari 3<br>Safari on iOS 1      |
| `api.Element.scrollIntoView.options_parameter`                                                                          |  ✅ High  | 2020-09-16     | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox 36<br>Firefox for Android 36<br>Safari 14 🔑💎<br>Safari on iOS 14 |

🔑💎 marks a release that contributes to the Baseline low date.<br>

## set-methods

| Key                                                                                                                                                                       |    Baseline    | Low since date | Versions                                                                                                      |
| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------: | :------------- | ------------------------------------------------------------------------------------------------------------- |
| **set-methods**                                                                                                                                                           | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge ❌<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17 |
| [`javascript.builtins.Set.difference`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/difference#browser_compatibility)                   | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge ❌<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17 |
| [`javascript.builtins.Set.intersection`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/intersection#browser_compatibility)               | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge ❌<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17 |
| [`javascript.builtins.Set.isDisjointFrom`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/isDisjointFrom#browser_compatibility)           | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge ❌<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17 |
| [`javascript.builtins.Set.isSubsetOf`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/isSubsetOf#browser_compatibility)                   | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge ❌<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17 |
| [`javascript.builtins.Set.isSupersetOf`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/isSupersetOf#browser_compatibility)               | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge ❌<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17 |
| [`javascript.builtins.Set.symmetricDifference`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/symmetricDifference#browser_compatibility) | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge ❌<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17 |
| [`javascript.builtins.Set.union`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/union#browser_compatibility)                             | ❌ Not Baseline |                | Chrome ❌<br>Chrome Android ❌<br>Edge ❌<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17 |



## shadow-dom

| Key                                                                                                                                         | Baseline | Low since date | Versions                                                                                                                    |
| :------------------------------------------------------------------------------------------------------------------------------------------ | :------: | :------------- | --------------------------------------------------------------------------------------------------------------------------- |
| **shadow-dom**                                                                                                                              |  ✅ High  | 2020-01-15     | Chrome 54<br>Chrome Android 54<br>Edge 79 🔑💎<br>Firefox 63<br>Firefox for Android 63<br>Safari 10.1<br>Safari on iOS 10.3 |
| [`api.Element.attachShadow`](https://developer.mozilla.org/docs/Web/API/Element/attachShadow#browser_compatibility)                         |  ✅ High  | 2020-01-15     | Chrome 53<br>Chrome Android 53<br>Edge 79 🔑💎<br>Firefox 63<br>Firefox for Android 63<br>Safari 10<br>Safari on iOS 10     |
| [`api.Element.shadowRoot`](https://developer.mozilla.org/docs/Web/API/Element/shadowRoot#browser_compatibility)                             |  ✅ High  | 2020-01-15     | Chrome 35<br>Chrome Android 35<br>Edge 79 🔑💎<br>Firefox 63<br>Firefox for Android 63<br>Safari 10<br>Safari on iOS 10     |
| [`api.Event.composed`](https://developer.mozilla.org/docs/Web/API/Event/composed#browser_compatibility)                                     |  ✅ High  | 2020-01-15     | Chrome 53<br>Chrome Android 53<br>Edge 79 🔑💎<br>Firefox 52<br>Firefox for Android 52<br>Safari 10<br>Safari on iOS 10     |
| [`api.Event.composedPath`](https://developer.mozilla.org/docs/Web/API/Event/composedPath#browser_compatibility)                             |  ✅ High  | 2020-01-15     | Chrome 53<br>Chrome Android 53<br>Edge 79 🔑💎<br>Firefox 59<br>Firefox for Android 59<br>Safari 10<br>Safari on iOS 10     |
| [`api.HTMLSlotElement`](https://developer.mozilla.org/docs/Web/API/HTMLSlotElement#browser_compatibility)                                   |  ✅ High  | 2020-01-15     | Chrome 53<br>Chrome Android 53<br>Edge 79 🔑💎<br>Firefox 63<br>Firefox for Android 63<br>Safari 10<br>Safari on iOS 10     |
| [`api.HTMLSlotElement.slotchange_event`](https://developer.mozilla.org/docs/Web/API/HTMLSlotElement/slotchange_event#browser_compatibility) |  ✅ High  | 2020-01-15     | Chrome 53<br>Chrome Android 53<br>Edge 79 🔑💎<br>Firefox 63<br>Firefox for Android 63<br>Safari 10.1<br>Safari on iOS 10.3 |
| [`api.Node.getRootNode`](https://developer.mozilla.org/docs/Web/API/Node/getRootNode#browser_compatibility)                                 |  ✅ High  | 2020-01-15     | Chrome 54<br>Chrome Android 54<br>Edge 79 🔑💎<br>Firefox 53<br>Firefox for Android 53<br>Safari 10.1<br>Safari on iOS 10.3 |
| [`api.Node.isConnected`](https://developer.mozilla.org/docs/Web/API/Node/isConnected#browser_compatibility)                                 |  ✅ High  | 2020-01-15     | Chrome 51<br>Chrome Android 51<br>Edge 79 🔑💎<br>Firefox 49<br>Firefox for Android 49<br>Safari 10<br>Safari on iOS 10     |
| [`api.ShadowRoot`](https://developer.mozilla.org/docs/Web/API/ShadowRoot#browser_compatibility)                                             |  ✅ High  | 2020-01-15     | Chrome 53<br>Chrome Android 53<br>Edge 79 🔑💎<br>Firefox 63<br>Firefox for Android 63<br>Safari 10<br>Safari on iOS 10     |
| [`api.ShadowRoot.host`](https://developer.mozilla.org/docs/Web/API/ShadowRoot/host#browser_compatibility)                                   |  ✅ High  | 2020-01-15     | Chrome 53<br>Chrome Android 53<br>Edge 79 🔑💎<br>Firefox 63<br>Firefox for Android 63<br>Safari 10<br>Safari on iOS 10     |
| [`api.ShadowRoot.mode`](https://developer.mozilla.org/docs/Web/API/ShadowRoot/mode#browser_compatibility)                                   |  ✅ High  | 2020-01-15     | Chrome 53<br>Chrome Android 53<br>Edge 79 🔑💎<br>Firefox 63<br>Firefox for Android 63<br>Safari 10.1<br>Safari on iOS 10.3 |
| [`html.elements.slot`](https://developer.mozilla.org/docs/Web/HTML/Element/slot#browser_compatibility)                                      |  ✅ High  | 2020-01-15     | Chrome 53<br>Chrome Android 53<br>Edge 79 🔑💎<br>Firefox 63<br>Firefox for Android 63<br>Safari 10<br>Safari on iOS 10     |

🔑💎 marks a release that contributes to the Baseline low date.<br>

## sticky-positioning

| Key                                                      | Baseline | Low since date | Versions                                                                                                                |
| :------------------------------------------------------- | :------: | :------------- | ----------------------------------------------------------------------------------------------------------------------- |
| **sticky-positioning**                                   |  ✅ High  | 2019-09-19     | Chrome 56<br>Chrome Android 56<br>Edge 16<br>Firefox 59<br>Firefox for Android 59<br>Safari 13 🔑💎<br>Safari on iOS 13 |
| `css.properties.position.position_sticky_table_elements` |  ✅ High  | 2018-03-13     | Chrome 56<br>Chrome Android 56<br>Edge 16<br>Firefox 59 🔑💎<br>Firefox for Android 59<br>Safari 8<br>Safari on iOS 8   |
| `css.properties.position.sticky`                         |  ✅ High  | 2019-09-19     | Chrome 56<br>Chrome Android 56<br>Edge 16<br>Firefox 32<br>Firefox for Android 32<br>Safari 13 🔑💎<br>Safari on iOS 13 |

🔑💎 marks a release that contributes to the Baseline low date.<br>

