### PR TITLE
`web-animations`: revise feature list and set Baseline status

### DIFF
--- a/feature-group-definitions/web-animations.yml
+++ b/feature-group-definitions/web-animations.yml
@@ -1,5 +1,16 @@
 spec: https://drafts.csswg.org/web-animations-1/
 caniuse: web-animation
+status:
+  baseline: low
+  baseline_low_date: 2022-09-12
+  support:
+    chrome: "84"
+    chrome_android: "84"
+    edge: "84"
+    firefox: "80"
+    firefox_android: "80"
+    safari: "16"
+    safari_ios: "16"
 compat_features:
   # Animation interface.
   - api.Animation


### PR DESCRIPTION
This has exactly one "low" subfeature: [api.KeyframeEffect.composite](https://developer.mozilla.org/docs/Web/API/KeyframeEffect/composite#browser_compatibility). I don't know how critical it is the overall feature.

| Key                                                                                                                                                                   | Baseline | Low since date | Versions                                                                                                                    |
| :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------: | :------------- | --------------------------------------------------------------------------------------------------------------------------- |
| **web-animations**                                                                                                                                                    |  🆕 Low  | 2022-09-12     | Chrome 84<br>Chrome Android 84<br>Edge 84<br>Firefox 80<br>Firefox for Android 80<br>Safari 16 🔑💎<br>Safari on iOS 16     |
| [`api.Animation`](https://developer.mozilla.org/docs/Web/API/Animation#browser_compatibility)                                                                         |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 48<br>Firefox for Android 48<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.Animation.Animation`](https://developer.mozilla.org/docs/Web/API/Animation/Animation#browser_compatibility)                                                     |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 48<br>Firefox for Android 48<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.Animation.cancel_event`](https://developer.mozilla.org/docs/Web/API/Animation/cancel_event#browser_compatibility)                                               |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 48<br>Firefox for Android 48<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.Animation.cancel`](https://developer.mozilla.org/docs/Web/API/Animation/cancel#browser_compatibility)                                                           |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 48<br>Firefox for Android 48<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.Animation.commitStyles`](https://developer.mozilla.org/docs/Web/API/Animation/commitStyles#browser_compatibility)                                               |  ✅ High  | 2020-07-28     | Chrome 84<br>Chrome Android 84<br>Edge 84<br>Firefox 75<br>Firefox for Android 79 🔑💎<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.Animation.currentTime`](https://developer.mozilla.org/docs/Web/API/Animation/currentTime#browser_compatibility)                                                 |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 48<br>Firefox for Android 48<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.Animation.effect`](https://developer.mozilla.org/docs/Web/API/Animation/effect#browser_compatibility)                                                           |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.Animation.finish`](https://developer.mozilla.org/docs/Web/API/Animation/finish#browser_compatibility)                                                           |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 48<br>Firefox for Android 48<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.Animation.finished`](https://developer.mozilla.org/docs/Web/API/Animation/finished#browser_compatibility)                                                       |  ✅ High  | 2020-07-27     | Chrome 84 🔑💎<br>Chrome Android 84<br>Edge 84<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.Animation.finish_event`](https://developer.mozilla.org/docs/Web/API/Animation/finish_event#browser_compatibility)                                               |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 48<br>Firefox for Android 48<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.Animation.id`](https://developer.mozilla.org/docs/Web/API/Animation/id#browser_compatibility)                                                                   |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 48<br>Firefox for Android 48<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.Animation.pause`](https://developer.mozilla.org/docs/Web/API/Animation/pause#browser_compatibility)                                                             |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 48<br>Firefox for Android 48<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.Animation.pending`](https://developer.mozilla.org/docs/Web/API/Animation/pending#browser_compatibility)                                                         |  ✅ High  | 2020-03-24     | Chrome 76<br>Chrome Android 76<br>Edge 79<br>Firefox 59<br>Firefox for Android 59<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.Animation.persist`](https://developer.mozilla.org/docs/Web/API/Animation/persist#browser_compatibility)                                                         |  ✅ High  | 2020-07-28     | Chrome 84<br>Chrome Android 84<br>Edge 84<br>Firefox 75<br>Firefox for Android 79 🔑💎<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.Animation.play`](https://developer.mozilla.org/docs/Web/API/Animation/play#browser_compatibility)                                                               |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 48<br>Firefox for Android 48<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.Animation.playbackRate`](https://developer.mozilla.org/docs/Web/API/Animation/playbackRate#browser_compatibility)                                               |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 48<br>Firefox for Android 48<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.Animation.playState`](https://developer.mozilla.org/docs/Web/API/Animation/playState#browser_compatibility)                                                     |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 48<br>Firefox for Android 48<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.Animation.ready`](https://developer.mozilla.org/docs/Web/API/Animation/ready#browser_compatibility)                                                             |  ✅ High  | 2020-07-27     | Chrome 84 🔑💎<br>Chrome Android 84<br>Edge 84<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.Animation.remove_event`](https://developer.mozilla.org/docs/Web/API/Animation/remove_event#browser_compatibility)                                               |  ✅ High  | 2020-07-28     | Chrome 84<br>Chrome Android 84<br>Edge 84<br>Firefox 75<br>Firefox for Android 79 🔑💎<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.Animation.replaceState`](https://developer.mozilla.org/docs/Web/API/Animation/replaceState#browser_compatibility)                                               |  ✅ High  | 2020-07-28     | Chrome 84<br>Chrome Android 84<br>Edge 84<br>Firefox 75<br>Firefox for Android 79 🔑💎<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.Animation.reverse`](https://developer.mozilla.org/docs/Web/API/Animation/reverse#browser_compatibility)                                                         |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 48<br>Firefox for Android 48<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.Animation.startTime`](https://developer.mozilla.org/docs/Web/API/Animation/startTime#browser_compatibility)                                                     |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 48<br>Firefox for Android 48<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.Animation.timeline`](https://developer.mozilla.org/docs/Web/API/Animation/timeline#browser_compatibility)                                                       |  ✅ High  | 2020-07-28     | Chrome 84<br>Chrome Android 84<br>Edge 84<br>Firefox 75<br>Firefox for Android 79 🔑💎<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.Animation.updatePlaybackRate`](https://developer.mozilla.org/docs/Web/API/Animation/updatePlaybackRate#browser_compatibility)                                   |  ✅ High  | 2020-03-24     | Chrome 76<br>Chrome Android 76<br>Edge 79<br>Firefox 60<br>Firefox for Android 60<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.AnimationTimeline`](https://developer.mozilla.org/docs/Web/API/AnimationTimeline#browser_compatibility)                                                         |  ✅ High  | 2020-07-28     | Chrome 84<br>Chrome Android 84<br>Edge 84<br>Firefox 75<br>Firefox for Android 79 🔑💎<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.AnimationTimeline.currentTime`](https://developer.mozilla.org/docs/Web/API/AnimationTimeline/currentTime#browser_compatibility)                                 |  ✅ High  | 2020-07-28     | Chrome 84<br>Chrome Android 84<br>Edge 84<br>Firefox 75<br>Firefox for Android 79 🔑💎<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.AnimationEffect`](https://developer.mozilla.org/docs/Web/API/AnimationEffect#browser_compatibility)                                                             |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.AnimationEffect.getComputedTiming`](https://developer.mozilla.org/docs/Web/API/AnimationEffect/getComputedTiming#browser_compatibility)                         |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.AnimationEffect.getTiming`](https://developer.mozilla.org/docs/Web/API/AnimationEffect/getTiming#browser_compatibility)                                         |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.AnimationEffect.updateTiming`](https://developer.mozilla.org/docs/Web/API/AnimationEffect/updateTiming#browser_compatibility)                                   |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.AnimationPlaybackEvent`](https://developer.mozilla.org/docs/Web/API/AnimationPlaybackEvent#browser_compatibility)                                               |  ✅ High  | 2020-07-27     | Chrome 84 🔑💎<br>Chrome Android 84<br>Edge 84<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.AnimationPlaybackEvent.AnimationPlaybackEvent`](https://developer.mozilla.org/docs/Web/API/AnimationPlaybackEvent/AnimationPlaybackEvent#browser_compatibility) |  ✅ High  | 2020-07-27     | Chrome 84 🔑💎<br>Chrome Android 84<br>Edge 84<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.AnimationPlaybackEvent.currentTime`](https://developer.mozilla.org/docs/Web/API/AnimationPlaybackEvent/currentTime#browser_compatibility)                       |  ✅ High  | 2020-07-27     | Chrome 84 🔑💎<br>Chrome Android 84<br>Edge 84<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.AnimationPlaybackEvent.timelineTime`](https://developer.mozilla.org/docs/Web/API/AnimationPlaybackEvent/timelineTime#browser_compatibility)                     |  ✅ High  | 2020-07-27     | Chrome 84 🔑💎<br>Chrome Android 84<br>Edge 84<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.KeyframeEffect`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect#browser_compatibility)                                                               |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.KeyframeEffect.KeyframeEffect`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect/KeyframeEffect#browser_compatibility)                                 |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.KeyframeEffect.composite`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect/composite#browser_compatibility)                                           |  🆕 Low  | 2022-09-12     | Chrome 84<br>Chrome Android 84<br>Edge 84<br>Firefox 80<br>Firefox for Android 80<br>Safari 16 🔑💎<br>Safari on iOS 16     |
| [`api.KeyframeEffect.getKeyframes`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect/getKeyframes#browser_compatibility)                                     |  ✅ High  | 2020-07-27     | Chrome 84 🔑💎<br>Chrome Android 84<br>Edge 84<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.KeyframeEffect.pseudoElement`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect/pseudoElement#browser_compatibility)                                   |  ✅ High  | 2020-09-16     | Chrome 84<br>Chrome Android 84<br>Edge 84<br>Firefox 75<br>Firefox for Android 79<br>Safari 14 🔑💎<br>Safari on iOS 14     |
| [`api.KeyframeEffect.setKeyframes`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect/setKeyframes#browser_compatibility)                                     |  ✅ High  | 2020-07-27     | Chrome 84 🔑💎<br>Chrome Android 84<br>Edge 84<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.KeyframeEffect.target`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect/target#browser_compatibility)                                                 |  ✅ High  | 2020-03-24     | Chrome 75<br>Chrome Android 75<br>Edge 79<br>Firefox 63<br>Firefox for Android 63<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |
| [`api.DocumentTimeline`](https://developer.mozilla.org/docs/Web/API/DocumentTimeline#browser_compatibility)                                                           |  ✅ High  | 2020-07-28     | Chrome 84<br>Chrome Android 84<br>Edge 84<br>Firefox 75<br>Firefox for Android 79 🔑💎<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.DocumentTimeline.DocumentTimeline`](https://developer.mozilla.org/docs/Web/API/DocumentTimeline/DocumentTimeline#browser_compatibility)                         |  ✅ High  | 2020-07-28     | Chrome 84<br>Chrome Android 84<br>Edge 84<br>Firefox 75<br>Firefox for Android 79 🔑💎<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.Document.getAnimations`](https://developer.mozilla.org/docs/Web/API/Document/getAnimations#browser_compatibility)                                               |  ✅ High  | 2020-09-16     | Chrome 84<br>Chrome Android 84<br>Edge 84<br>Firefox 75<br>Firefox for Android 79<br>Safari 14 🔑💎<br>Safari on iOS 14     |
| [`api.Document.timeline`](https://developer.mozilla.org/docs/Web/API/Document/timeline#browser_compatibility)                                                         |  ✅ High  | 2020-07-28     | Chrome 84<br>Chrome Android 84<br>Edge 84<br>Firefox 75<br>Firefox for Android 79 🔑💎<br>Safari 13.1<br>Safari on iOS 13.4 |
| [`api.Element.animate`](https://developer.mozilla.org/docs/Web/API/Element/animate#browser_compatibility)                                                             |  ✅ High  | 2020-03-24     | Chrome 36<br>Chrome Android 36<br>Edge 79<br>Firefox 48<br>Firefox for Android 48<br>Safari 13.1 🔑💎<br>Safari on iOS 13.4 |

🔑💎 marks a release that contributes to the Baseline low date.<br>

