### PR TITLE
`webtransport`: revise feature list and set Baseline status

### DIFF
--- a/feature-group-definitions/webtransport.yml
+++ b/feature-group-definitions/webtransport.yml
@@ -1,6 +1,9 @@
 spec: https://w3c.github.io/webtransport/
 caniuse: webtransport
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3472
+status:
+  baseline: false
+  support: {}
 compat_features:
   - api.WebTransport
   - api.WebTransport.WebTransport

--- a/feature-group-definitions/webtransport.yml
+++ b/feature-group-definitions/webtransport.yml
@@ -4,19 +4,14 @@ usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3472
 compat_features:
   - api.WebTransport
   - api.WebTransport.WebTransport
-  - api.WebTransport.WebTransport.options_allowPooling_parameter
-  - api.WebTransport.WebTransport.options_requireUnreliable_parameter
-  - api.WebTransport.WebTransport.options_serverCertificateHashes_parameter
   - api.WebTransport.close
   - api.WebTransport.closed
   - api.WebTransport.createBidirectionalStream
   - api.WebTransport.createUnidirectionalStream
   - api.WebTransport.datagrams
-  - api.WebTransport.getStats
   - api.WebTransport.incomingBidirectionalStreams
   - api.WebTransport.incomingUnidirectionalStreams
   - api.WebTransport.ready
-  - api.WebTransport.reliability
   - api.WebTransportBidirectionalStream
   - api.WebTransportBidirectionalStream.readable
   - api.WebTransportBidirectionalStream.writable


### PR DESCRIPTION
There are several experimental features in the feature list. It doesn't impact the overall story (Safari doesn't implement), but I thought I'd tidy up while I was here.

| Key                                                                                                                                                                                     |    Baseline    | Low since date | Versions                                                                                                           |
| :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :------------- | ------------------------------------------------------------------------------------------------------------------ |
| **webtransport**                                                                                                                                                                        | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌     |
| [`api.WebTransport`](https://developer.mozilla.org/docs/Web/API/WebTransport#browser_compatibility)                                                                                     | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransport.WebTransport`](https://developer.mozilla.org/docs/Web/API/WebTransport/WebTransport#browser_compatibility)                                                           | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransport.close`](https://developer.mozilla.org/docs/Web/API/WebTransport/close#browser_compatibility)                                                                         | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransport.closed`](https://developer.mozilla.org/docs/Web/API/WebTransport/closed#browser_compatibility)                                                                       | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransport.createBidirectionalStream`](https://developer.mozilla.org/docs/Web/API/WebTransport/createBidirectionalStream#browser_compatibility)                                 | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransport.createUnidirectionalStream`](https://developer.mozilla.org/docs/Web/API/WebTransport/createUnidirectionalStream#browser_compatibility)                               | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌     |
| [`api.WebTransport.datagrams`](https://developer.mozilla.org/docs/Web/API/WebTransport/datagrams#browser_compatibility)                                                                 | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransport.incomingBidirectionalStreams`](https://developer.mozilla.org/docs/Web/API/WebTransport/incomingBidirectionalStreams#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransport.incomingUnidirectionalStreams`](https://developer.mozilla.org/docs/Web/API/WebTransport/incomingUnidirectionalStreams#browser_compatibility)                         | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransport.ready`](https://developer.mozilla.org/docs/Web/API/WebTransport/ready#browser_compatibility)                                                                         | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransportBidirectionalStream`](https://developer.mozilla.org/docs/Web/API/WebTransportBidirectionalStream#browser_compatibility)                                               | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransportBidirectionalStream.readable`](https://developer.mozilla.org/docs/Web/API/WebTransportBidirectionalStream/readable#browser_compatibility)                             | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransportBidirectionalStream.writable`](https://developer.mozilla.org/docs/Web/API/WebTransportBidirectionalStream/writable#browser_compatibility)                             | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransportDatagramDuplexStream`](https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream#browser_compatibility)                                             | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransportDatagramDuplexStream.incomingHighWaterMark`](https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream/incomingHighWaterMark#browser_compatibility) | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransportDatagramDuplexStream.incomingMaxAge`](https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream/incomingMaxAge#browser_compatibility)               | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransportDatagramDuplexStream.maxDatagramSize`](https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream/maxDatagramSize#browser_compatibility)             | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransportDatagramDuplexStream.outgoingHighWaterMark`](https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream/outgoingHighWaterMark#browser_compatibility) | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransportDatagramDuplexStream.outgoingMaxAge`](https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream/outgoingMaxAge#browser_compatibility)               | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransportDatagramDuplexStream.readable`](https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream/readable#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransportDatagramDuplexStream.writable`](https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream/writable#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransportError`](https://developer.mozilla.org/docs/Web/API/WebTransportError#browser_compatibility)                                                                           | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransportError.WebTransportError`](https://developer.mozilla.org/docs/Web/API/WebTransportError/WebTransportError#browser_compatibility)                                       | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransportError.source`](https://developer.mozilla.org/docs/Web/API/WebTransportError/source#browser_compatibility)                                                             | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.WebTransportError.streamErrorCode`](https://developer.mozilla.org/docs/Web/API/WebTransportError/streamErrorCode#browser_compatibility)                                           | ❌ Not Baseline |                | Chrome 97<br>Chrome Android 97<br>Edge 97<br>Firefox 114<br>Firefox for Android 114<br>Safari ❌<br>Safari on iOS ❌ |



