### PR TITLE
`webusb`: revise feature list and set Baseline status

### DIFF
--- a/feature-group-definitions/webusb.yml
+++ b/feature-group-definitions/webusb.yml
@@ -93,5 +93,4 @@ compat_features:
   - api.USBOutTransferResult.status
   - api.USBOutTransferResult.USBOutTransferResult
   - api.WorkerNavigator.usb
-  - http.headers.Feature-Policy.usb
   - http.headers.Permissions-Policy.usb

--- a/feature-group-definitions/webusb.yml
+++ b/feature-group-definitions/webusb.yml
@@ -1,6 +1,12 @@
 spec: https://wicg.github.io/webusb/
 caniuse: webusb
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1519
+status:
+  baseline: false
+  support:
+    chrome: "101"
+    chrome_android: "101"
+    edge: "101"
 compat_features:
   - api.Navigator.usb
   - api.USB


### PR DESCRIPTION
I removed a non-existent feature here.

| Key                                                                                                                                                                                                       |    Baseline    | Low since date | Versions                                                                                                          |
| :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :------------- | ----------------------------------------------------------------------------------------------------------------- |
| **webusb**                                                                                                                                                                                                | ❌ Not Baseline |                | Chrome 101<br>Chrome Android 101<br>Edge 101<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.Navigator.usb`](https://developer.mozilla.org/docs/Web/API/Navigator/usb#browser_compatibility)                                                                                                     | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USB`](https://developer.mozilla.org/docs/Web/API/USB#browser_compatibility)                                                                                                                         | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USB.connect_event`](https://developer.mozilla.org/docs/Web/API/USB/connect_event#browser_compatibility)                                                                                             | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USB.disconnect_event`](https://developer.mozilla.org/docs/Web/API/USB/disconnect_event#browser_compatibility)                                                                                       | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USB.getDevices`](https://developer.mozilla.org/docs/Web/API/USB/getDevices#browser_compatibility)                                                                                                   | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USB.requestDevice`](https://developer.mozilla.org/docs/Web/API/USB/requestDevice#browser_compatibility)                                                                                             | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBAlternateInterface`](https://developer.mozilla.org/docs/Web/API/USBAlternateInterface#browser_compatibility)                                                                                     | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBAlternateInterface.alternateSetting`](https://developer.mozilla.org/docs/Web/API/USBAlternateInterface/alternateSetting#browser_compatibility)                                                   | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBAlternateInterface.endpoints`](https://developer.mozilla.org/docs/Web/API/USBAlternateInterface/endpoints#browser_compatibility)                                                                 | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBAlternateInterface.interfaceClass`](https://developer.mozilla.org/docs/Web/API/USBAlternateInterface/interfaceClass#browser_compatibility)                                                       | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBAlternateInterface.interfaceName`](https://developer.mozilla.org/docs/Web/API/USBAlternateInterface/interfaceName#browser_compatibility)                                                         | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBAlternateInterface.interfaceProtocol`](https://developer.mozilla.org/docs/Web/API/USBAlternateInterface/interfaceProtocol#browser_compatibility)                                                 | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBAlternateInterface.interfaceSubclass`](https://developer.mozilla.org/docs/Web/API/USBAlternateInterface/interfaceSubclass#browser_compatibility)                                                 | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBAlternateInterface.USBAlternateInterface`](https://developer.mozilla.org/docs/Web/API/USBAlternateInterface/USBAlternateInterface#browser_compatibility)                                         | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBConfiguration`](https://developer.mozilla.org/docs/Web/API/USBConfiguration#browser_compatibility)                                                                                               | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBConfiguration.configurationName`](https://developer.mozilla.org/docs/Web/API/USBConfiguration/configurationName#browser_compatibility)                                                           | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBConfiguration.configurationValue`](https://developer.mozilla.org/docs/Web/API/USBConfiguration/configurationValue#browser_compatibility)                                                         | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBConfiguration.interfaces`](https://developer.mozilla.org/docs/Web/API/USBConfiguration/interfaces#browser_compatibility)                                                                         | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBConfiguration.USBConfiguration`](https://developer.mozilla.org/docs/Web/API/USBConfiguration/USBConfiguration#browser_compatibility)                                                             | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBConnectionEvent`](https://developer.mozilla.org/docs/Web/API/USBConnectionEvent#browser_compatibility)                                                                                           | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBConnectionEvent.device`](https://developer.mozilla.org/docs/Web/API/USBConnectionEvent/device#browser_compatibility)                                                                             | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBConnectionEvent.USBConnectionEvent`](https://developer.mozilla.org/docs/Web/API/USBConnectionEvent/USBConnectionEvent#browser_compatibility)                                                     | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice`](https://developer.mozilla.org/docs/Web/API/USBDevice#browser_compatibility)                                                                                                             | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.claimInterface`](https://developer.mozilla.org/docs/Web/API/USBDevice/claimInterface#browser_compatibility)                                                                               | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.clearHalt`](https://developer.mozilla.org/docs/Web/API/USBDevice/clearHalt#browser_compatibility)                                                                                         | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.close`](https://developer.mozilla.org/docs/Web/API/USBDevice/close#browser_compatibility)                                                                                                 | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.configuration`](https://developer.mozilla.org/docs/Web/API/USBDevice/configuration#browser_compatibility)                                                                                 | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.configurations`](https://developer.mozilla.org/docs/Web/API/USBDevice/configurations#browser_compatibility)                                                                               | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.controlTransferIn`](https://developer.mozilla.org/docs/Web/API/USBDevice/controlTransferIn#browser_compatibility)                                                                         | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.controlTransferOut`](https://developer.mozilla.org/docs/Web/API/USBDevice/controlTransferOut#browser_compatibility)                                                                       | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.deviceClass`](https://developer.mozilla.org/docs/Web/API/USBDevice/deviceClass#browser_compatibility)                                                                                     | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.deviceProtocol`](https://developer.mozilla.org/docs/Web/API/USBDevice/deviceProtocol#browser_compatibility)                                                                               | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.deviceSubclass`](https://developer.mozilla.org/docs/Web/API/USBDevice/deviceSubclass#browser_compatibility)                                                                               | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.deviceVersionMajor`](https://developer.mozilla.org/docs/Web/API/USBDevice/deviceVersionMajor#browser_compatibility)                                                                       | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.deviceVersionMinor`](https://developer.mozilla.org/docs/Web/API/USBDevice/deviceVersionMinor#browser_compatibility)                                                                       | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.deviceVersionSubminor`](https://developer.mozilla.org/docs/Web/API/USBDevice/deviceVersionSubminor#browser_compatibility)                                                                 | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.forget`](https://developer.mozilla.org/docs/Web/API/USBDevice/forget#browser_compatibility)                                                                                               | ❌ Not Baseline |                | Chrome 101<br>Chrome Android 101<br>Edge 101<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.USBDevice.isochronousTransferIn`](https://developer.mozilla.org/docs/Web/API/USBDevice/isochronousTransferIn#browser_compatibility)                                                                 | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.isochronousTransferOut`](https://developer.mozilla.org/docs/Web/API/USBDevice/isochronousTransferOut#browser_compatibility)                                                               | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.manufacturerName`](https://developer.mozilla.org/docs/Web/API/USBDevice/manufacturerName#browser_compatibility)                                                                           | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.open`](https://developer.mozilla.org/docs/Web/API/USBDevice/open#browser_compatibility)                                                                                                   | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.opened`](https://developer.mozilla.org/docs/Web/API/USBDevice/opened#browser_compatibility)                                                                                               | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.productId`](https://developer.mozilla.org/docs/Web/API/USBDevice/productId#browser_compatibility)                                                                                         | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.productName`](https://developer.mozilla.org/docs/Web/API/USBDevice/productName#browser_compatibility)                                                                                     | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.releaseInterface`](https://developer.mozilla.org/docs/Web/API/USBDevice/releaseInterface#browser_compatibility)                                                                           | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.reset`](https://developer.mozilla.org/docs/Web/API/USBDevice/reset#browser_compatibility)                                                                                                 | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.selectAlternateInterface`](https://developer.mozilla.org/docs/Web/API/USBDevice/selectAlternateInterface#browser_compatibility)                                                           | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.selectConfiguration`](https://developer.mozilla.org/docs/Web/API/USBDevice/selectConfiguration#browser_compatibility)                                                                     | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.serialNumber`](https://developer.mozilla.org/docs/Web/API/USBDevice/serialNumber#browser_compatibility)                                                                                   | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.transferIn`](https://developer.mozilla.org/docs/Web/API/USBDevice/transferIn#browser_compatibility)                                                                                       | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.transferOut`](https://developer.mozilla.org/docs/Web/API/USBDevice/transferOut#browser_compatibility)                                                                                     | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.usbVersionMajor`](https://developer.mozilla.org/docs/Web/API/USBDevice/usbVersionMajor#browser_compatibility)                                                                             | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.usbVersionMinor`](https://developer.mozilla.org/docs/Web/API/USBDevice/usbVersionMinor#browser_compatibility)                                                                             | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.usbVersionSubminor`](https://developer.mozilla.org/docs/Web/API/USBDevice/usbVersionSubminor#browser_compatibility)                                                                       | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBDevice.vendorId`](https://developer.mozilla.org/docs/Web/API/USBDevice/vendorId#browser_compatibility)                                                                                           | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBEndpoint`](https://developer.mozilla.org/docs/Web/API/USBEndpoint#browser_compatibility)                                                                                                         | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBEndpoint.direction`](https://developer.mozilla.org/docs/Web/API/USBEndpoint/direction#browser_compatibility)                                                                                     | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBEndpoint.endpointNumber`](https://developer.mozilla.org/docs/Web/API/USBEndpoint/endpointNumber#browser_compatibility)                                                                           | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBEndpoint.packetSize`](https://developer.mozilla.org/docs/Web/API/USBEndpoint/packetSize#browser_compatibility)                                                                                   | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBEndpoint.type`](https://developer.mozilla.org/docs/Web/API/USBEndpoint/type#browser_compatibility)                                                                                               | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBEndpoint.USBEndpoint`](https://developer.mozilla.org/docs/Web/API/USBEndpoint/USBEndpoint#browser_compatibility)                                                                                 | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBInterface`](https://developer.mozilla.org/docs/Web/API/USBInterface#browser_compatibility)                                                                                                       | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBInterface.alternate`](https://developer.mozilla.org/docs/Web/API/USBInterface/alternate#browser_compatibility)                                                                                   | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBInterface.alternates`](https://developer.mozilla.org/docs/Web/API/USBInterface/alternates#browser_compatibility)                                                                                 | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBInterface.claimed`](https://developer.mozilla.org/docs/Web/API/USBInterface/claimed#browser_compatibility)                                                                                       | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBInterface.interfaceNumber`](https://developer.mozilla.org/docs/Web/API/USBInterface/interfaceNumber#browser_compatibility)                                                                       | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBInterface.USBInterface`](https://developer.mozilla.org/docs/Web/API/USBInterface/USBInterface#browser_compatibility)                                                                             | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBInTransferResult`](https://developer.mozilla.org/docs/Web/API/USBInTransferResult#browser_compatibility)                                                                                         | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBInTransferResult.data`](https://developer.mozilla.org/docs/Web/API/USBInTransferResult/data#browser_compatibility)                                                                               | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBInTransferResult.status`](https://developer.mozilla.org/docs/Web/API/USBInTransferResult/status#browser_compatibility)                                                                           | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBInTransferResult.USBInTransferResult`](https://developer.mozilla.org/docs/Web/API/USBInTransferResult/USBInTransferResult#browser_compatibility)                                                 | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBIsochronousInTransferPacket`](https://developer.mozilla.org/docs/Web/API/USBIsochronousInTransferPacket#browser_compatibility)                                                                   | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBIsochronousInTransferPacket.data`](https://developer.mozilla.org/docs/Web/API/USBIsochronousInTransferPacket/data#browser_compatibility)                                                         | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBIsochronousInTransferPacket.status`](https://developer.mozilla.org/docs/Web/API/USBIsochronousInTransferPacket/status#browser_compatibility)                                                     | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBIsochronousInTransferPacket.USBIsochronousInTransferPacket`](https://developer.mozilla.org/docs/Web/API/USBIsochronousInTransferPacket/USBIsochronousInTransferPacket#browser_compatibility)     | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBIsochronousInTransferResult`](https://developer.mozilla.org/docs/Web/API/USBIsochronousInTransferResult#browser_compatibility)                                                                   | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBIsochronousInTransferResult.data`](https://developer.mozilla.org/docs/Web/API/USBIsochronousInTransferResult/data#browser_compatibility)                                                         | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBIsochronousInTransferResult.packets`](https://developer.mozilla.org/docs/Web/API/USBIsochronousInTransferResult/packets#browser_compatibility)                                                   | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBIsochronousInTransferResult.USBIsochronousInTransferResult`](https://developer.mozilla.org/docs/Web/API/USBIsochronousInTransferResult/USBIsochronousInTransferResult#browser_compatibility)     | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBIsochronousOutTransferPacket`](https://developer.mozilla.org/docs/Web/API/USBIsochronousOutTransferPacket#browser_compatibility)                                                                 | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBIsochronousOutTransferPacket.bytesWritten`](https://developer.mozilla.org/docs/Web/API/USBIsochronousOutTransferPacket/bytesWritten#browser_compatibility)                                       | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBIsochronousOutTransferPacket.status`](https://developer.mozilla.org/docs/Web/API/USBIsochronousOutTransferPacket/status#browser_compatibility)                                                   | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBIsochronousOutTransferPacket.USBIsochronousOutTransferPacket`](https://developer.mozilla.org/docs/Web/API/USBIsochronousOutTransferPacket/USBIsochronousOutTransferPacket#browser_compatibility) | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBIsochronousOutTransferResult`](https://developer.mozilla.org/docs/Web/API/USBIsochronousOutTransferResult#browser_compatibility)                                                                 | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBIsochronousOutTransferResult.packets`](https://developer.mozilla.org/docs/Web/API/USBIsochronousOutTransferResult/packets#browser_compatibility)                                                 | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBIsochronousOutTransferResult.USBIsochronousOutTransferResult`](https://developer.mozilla.org/docs/Web/API/USBIsochronousOutTransferResult/USBIsochronousOutTransferResult#browser_compatibility) | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBOutTransferResult`](https://developer.mozilla.org/docs/Web/API/USBOutTransferResult#browser_compatibility)                                                                                       | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBOutTransferResult.bytesWritten`](https://developer.mozilla.org/docs/Web/API/USBOutTransferResult/bytesWritten#browser_compatibility)                                                             | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBOutTransferResult.status`](https://developer.mozilla.org/docs/Web/API/USBOutTransferResult/status#browser_compatibility)                                                                         | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.USBOutTransferResult.USBOutTransferResult`](https://developer.mozilla.org/docs/Web/API/USBOutTransferResult/USBOutTransferResult#browser_compatibility)                                             | ❌ Not Baseline |                | Chrome 61<br>Chrome Android 61<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`api.WorkerNavigator.usb`](https://developer.mozilla.org/docs/Web/API/WorkerNavigator/usb#browser_compatibility)                                                                                         | ❌ Not Baseline |                | Chrome 70<br>Chrome Android 70<br>Edge 79<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |
| [`http.headers.Permissions-Policy.usb`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/usb#browser_compatibility)                                                                 | ❌ Not Baseline |                | Chrome 88<br>Chrome Android 88<br>Edge 88<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌    |



