### PR TITLE
Features V-W: set Baseline status

### DIFF
--- a/feature-group-definitions/view-transitions.yml
+++ b/feature-group-definitions/view-transitions.yml
@@ -1,6 +1,12 @@
 spec: https://drafts.csswg.org/css-view-transitions-1/
 caniuse: view-transitions
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4383
+status:
+  baseline: false
+  support:
+    chrome: "111"
+    chrome_android: "111"
+    edge: "111"
 compat_features:
   - api.Document.startViewTransition
   - api.ViewTransition

--- a/feature-group-definitions/webcodecs.yml
+++ b/feature-group-definitions/webcodecs.yml
@@ -1,6 +1,12 @@
 spec: https://w3c.github.io/webcodecs/
 caniuse: webcodecs
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3464
+status:
+  baseline: false
+  support:
+    chrome: "106"
+    chrome_android: "106"
+    edge: "106"
 compat_features:
   - api.AudioData
   - api.AudioData.allocationSize

--- a/feature-group-definitions/webvtt.yml
+++ b/feature-group-definitions/webvtt.yml
@@ -1,6 +1,17 @@
 spec: https://w3c.github.io/webvtt/
 caniuse: webvtt
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/409
+status:
+  baseline: high
+  baseline_low_date: 2020-01-15
+  support:
+    chrome: "33"
+    chrome_android: "33"
+    edge: "79"
+    firefox: "31"
+    firefox_android: "31"
+    safari: "8"
+    safari_ios: "8"
 compat_features:
   - api.VTTCue
   - api.VTTCue.VTTCue

--- a/feature-group-definitions/where.yml
+++ b/feature-group-definitions/where.yml
@@ -1,5 +1,16 @@
 spec: https://drafts.csswg.org/selectors-4/#zero-matches
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2431
+status:
+  baseline: high
+  baseline_low_date: 2021-01-21
+  support:
+    chrome: "88"
+    chrome_android: "88"
+    edge: "88"
+    firefox: "82"
+    firefox_android: "82"
+    safari: "14"
+    safari_ios: "14"
 compat_features:
   - css.selectors.where
   - css.selectors.where.forgiving_selector_list


### PR DESCRIPTION
## view-transitions

| Key                                                                                                                                           |    Baseline    | Low since date | Versions                                                                                                          |
| :-------------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :------------- | ----------------------------------------------------------------------------------------------------------------- |
| **view-transitions**                                                                                                                          | ❌ Not Baseline |                | Chrome 111<br>Chrome Android 111<br>Edge 111<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.Document.startViewTransition`](https://developer.mozilla.org/docs/Web/API/Document/startViewTransition#browser_compatibility)           | ❌ Not Baseline |                | Chrome 111<br>Chrome Android 111<br>Edge 111<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.ViewTransition`](https://developer.mozilla.org/docs/Web/API/ViewTransition#browser_compatibility)                                       | ❌ Not Baseline |                | Chrome 111<br>Chrome Android 111<br>Edge 111<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.ViewTransition.finished`](https://developer.mozilla.org/docs/Web/API/ViewTransition/finished#browser_compatibility)                     | ❌ Not Baseline |                | Chrome 111<br>Chrome Android 111<br>Edge 111<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.ViewTransition.ready`](https://developer.mozilla.org/docs/Web/API/ViewTransition/ready#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 111<br>Chrome Android 111<br>Edge 111<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.ViewTransition.skipTransition`](https://developer.mozilla.org/docs/Web/API/ViewTransition/skipTransition#browser_compatibility)         | ❌ Not Baseline |                | Chrome 111<br>Chrome Android 111<br>Edge 111<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`api.ViewTransition.updateCallbackDone`](https://developer.mozilla.org/docs/Web/API/ViewTransition/updateCallbackDone#browser_compatibility) | ❌ Not Baseline |                | Chrome 111<br>Chrome Android 111<br>Edge 111<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`css.properties.view-transition-name`](https://developer.mozilla.org/docs/Web/CSS/view-transition-name#browser_compatibility)                | ❌ Not Baseline |                | Chrome 111<br>Chrome Android 111<br>Edge 111<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`css.selectors.view-transition-group`](https://developer.mozilla.org/docs/Web/CSS/::view-transition-group#browser_compatibility)             | ❌ Not Baseline |                | Chrome 111<br>Chrome Android 111<br>Edge 111<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`css.selectors.view-transition-image-pair`](https://developer.mozilla.org/docs/Web/CSS/::view-transition-image-pair#browser_compatibility)   | ❌ Not Baseline |                | Chrome 111<br>Chrome Android 111<br>Edge 111<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`css.selectors.view-transition-new`](https://developer.mozilla.org/docs/Web/CSS/::view-transition-new#browser_compatibility)                 | ❌ Not Baseline |                | Chrome 111<br>Chrome Android 111<br>Edge 111<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`css.selectors.view-transition-old`](https://developer.mozilla.org/docs/Web/CSS/::view-transition-old#browser_compatibility)                 | ❌ Not Baseline |                | Chrome 111<br>Chrome Android 111<br>Edge 111<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |
| [`css.selectors.view-transition`](https://developer.mozilla.org/docs/Web/CSS/::view-transition#browser_compatibility)                         | ❌ Not Baseline |                | Chrome 111<br>Chrome Android 111<br>Edge 111<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌ |



## webcodecs

| Key                                                                                                                                               |    Baseline    | Low since date | Versions                                                                                                                |
| :------------------------------------------------------------------------------------------------------------------------------------------------ | :------------: | :------------- | ----------------------------------------------------------------------------------------------------------------------- |
| **webcodecs**                                                                                                                                     | ❌ Not Baseline |                | Chrome 106<br>Chrome Android 106<br>Edge 106<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌       |
| [`api.AudioData`](https://developer.mozilla.org/docs/Web/API/AudioData#browser_compatibility)                                                     | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioData.allocationSize`](https://developer.mozilla.org/docs/Web/API/AudioData/allocationSize#browser_compatibility)                       | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioData.AudioData`](https://developer.mozilla.org/docs/Web/API/AudioData/AudioData#browser_compatibility)                                 | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioData.clone`](https://developer.mozilla.org/docs/Web/API/AudioData/clone#browser_compatibility)                                         | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioData.close`](https://developer.mozilla.org/docs/Web/API/AudioData/close#browser_compatibility)                                         | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioData.copyTo`](https://developer.mozilla.org/docs/Web/API/AudioData/copyTo#browser_compatibility)                                       | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioData.duration`](https://developer.mozilla.org/docs/Web/API/AudioData/duration#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioData.format`](https://developer.mozilla.org/docs/Web/API/AudioData/format#browser_compatibility)                                       | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioData.numberOfChannels`](https://developer.mozilla.org/docs/Web/API/AudioData/numberOfChannels#browser_compatibility)                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioData.numberOfFrames`](https://developer.mozilla.org/docs/Web/API/AudioData/numberOfFrames#browser_compatibility)                       | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioData.sampleRate`](https://developer.mozilla.org/docs/Web/API/AudioData/sampleRate#browser_compatibility)                               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioData.timestamp`](https://developer.mozilla.org/docs/Web/API/AudioData/timestamp#browser_compatibility)                                 | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioDecoder`](https://developer.mozilla.org/docs/Web/API/AudioDecoder#browser_compatibility)                                               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioDecoder.AudioDecoder`](https://developer.mozilla.org/docs/Web/API/AudioDecoder/AudioDecoder#browser_compatibility)                     | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioDecoder.close`](https://developer.mozilla.org/docs/Web/API/AudioDecoder/close#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioDecoder.configure`](https://developer.mozilla.org/docs/Web/API/AudioDecoder/configure#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioDecoder.decode`](https://developer.mozilla.org/docs/Web/API/AudioDecoder/decode#browser_compatibility)                                 | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioDecoder.decodeQueueSize`](https://developer.mozilla.org/docs/Web/API/AudioDecoder/decodeQueueSize#browser_compatibility)               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| `api.AudioDecoder.dequeue_event`                                                                                                                  | ❌ Not Baseline |                | Chrome 106<br>Chrome Android 106<br>Edge 106<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌       |
| [`api.AudioDecoder.flush`](https://developer.mozilla.org/docs/Web/API/AudioDecoder/flush#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| `api.AudioDecoder.isConfigSupported_static`                                                                                                       | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioDecoder.reset`](https://developer.mozilla.org/docs/Web/API/AudioDecoder/reset#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioDecoder.state`](https://developer.mozilla.org/docs/Web/API/AudioDecoder/state#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioEncoder`](https://developer.mozilla.org/docs/Web/API/AudioEncoder#browser_compatibility)                                               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioEncoder.AudioEncoder`](https://developer.mozilla.org/docs/Web/API/AudioEncoder/AudioEncoder#browser_compatibility)                     | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioEncoder.close`](https://developer.mozilla.org/docs/Web/API/AudioEncoder/close#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioEncoder.configure`](https://developer.mozilla.org/docs/Web/API/AudioEncoder/configure#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| `api.AudioEncoder.dequeue_event`                                                                                                                  | ❌ Not Baseline |                | Chrome 106<br>Chrome Android 106<br>Edge 106<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌       |
| [`api.AudioEncoder.encode`](https://developer.mozilla.org/docs/Web/API/AudioEncoder/encode#browser_compatibility)                                 | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioEncoder.encodeQueueSize`](https://developer.mozilla.org/docs/Web/API/AudioEncoder/encodeQueueSize#browser_compatibility)               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioEncoder.flush`](https://developer.mozilla.org/docs/Web/API/AudioEncoder/flush#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| `api.AudioEncoder.isConfigSupported_static`                                                                                                       | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioEncoder.reset`](https://developer.mozilla.org/docs/Web/API/AudioEncoder/reset#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.AudioEncoder.state`](https://developer.mozilla.org/docs/Web/API/AudioEncoder/state#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.EncodedAudioChunk`](https://developer.mozilla.org/docs/Web/API/EncodedAudioChunk#browser_compatibility)                                     | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.EncodedAudioChunk.byteLength`](https://developer.mozilla.org/docs/Web/API/EncodedAudioChunk/byteLength#browser_compatibility)               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.EncodedAudioChunk.copyTo`](https://developer.mozilla.org/docs/Web/API/EncodedAudioChunk/copyTo#browser_compatibility)                       | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.EncodedAudioChunk.duration`](https://developer.mozilla.org/docs/Web/API/EncodedAudioChunk/duration#browser_compatibility)                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.EncodedAudioChunk.EncodedAudioChunk`](https://developer.mozilla.org/docs/Web/API/EncodedAudioChunk/EncodedAudioChunk#browser_compatibility) | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.EncodedAudioChunk.timestamp`](https://developer.mozilla.org/docs/Web/API/EncodedAudioChunk/timestamp#browser_compatibility)                 | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.EncodedAudioChunk.type`](https://developer.mozilla.org/docs/Web/API/EncodedAudioChunk/type#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.EncodedVideoChunk`](https://developer.mozilla.org/docs/Web/API/EncodedVideoChunk#browser_compatibility)                                     | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.EncodedVideoChunk.byteLength`](https://developer.mozilla.org/docs/Web/API/EncodedVideoChunk/byteLength#browser_compatibility)               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.EncodedVideoChunk.copyTo`](https://developer.mozilla.org/docs/Web/API/EncodedVideoChunk/copyTo#browser_compatibility)                       | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.EncodedVideoChunk.duration`](https://developer.mozilla.org/docs/Web/API/EncodedVideoChunk/duration#browser_compatibility)                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.EncodedVideoChunk.EncodedVideoChunk`](https://developer.mozilla.org/docs/Web/API/EncodedVideoChunk/EncodedVideoChunk#browser_compatibility) | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.EncodedVideoChunk.timestamp`](https://developer.mozilla.org/docs/Web/API/EncodedVideoChunk/timestamp#browser_compatibility)                 | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.EncodedVideoChunk.type`](https://developer.mozilla.org/docs/Web/API/EncodedVideoChunk/type#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.ImageDecoder`](https://developer.mozilla.org/docs/Web/API/ImageDecoder#browser_compatibility)                                               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageDecoder.close`](https://developer.mozilla.org/docs/Web/API/ImageDecoder/close#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageDecoder.complete`](https://developer.mozilla.org/docs/Web/API/ImageDecoder/complete#browser_compatibility)                             | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageDecoder.completed`](https://developer.mozilla.org/docs/Web/API/ImageDecoder/completed#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageDecoder.decode`](https://developer.mozilla.org/docs/Web/API/ImageDecoder/decode#browser_compatibility)                                 | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageDecoder.ImageDecoder`](https://developer.mozilla.org/docs/Web/API/ImageDecoder/ImageDecoder#browser_compatibility)                     | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageDecoder.isTypeSupported_static`](https://developer.mozilla.org/docs/Web/API/ImageDecoder/isTypeSupported_static#browser_compatibility) | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageDecoder.reset`](https://developer.mozilla.org/docs/Web/API/ImageDecoder/reset#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageDecoder.tracks`](https://developer.mozilla.org/docs/Web/API/ImageDecoder/tracks#browser_compatibility)                                 | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageDecoder.type`](https://developer.mozilla.org/docs/Web/API/ImageDecoder/type#browser_compatibility)                                     | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageTrack`](https://developer.mozilla.org/docs/Web/API/ImageTrack#browser_compatibility)                                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageTrack.animated`](https://developer.mozilla.org/docs/Web/API/ImageTrack/animated#browser_compatibility)                                 | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageTrack.frameCount`](https://developer.mozilla.org/docs/Web/API/ImageTrack/frameCount#browser_compatibility)                             | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageTrack.repetitionCount`](https://developer.mozilla.org/docs/Web/API/ImageTrack/repetitionCount#browser_compatibility)                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageTrack.selected`](https://developer.mozilla.org/docs/Web/API/ImageTrack/selected#browser_compatibility)                                 | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageTrackList`](https://developer.mozilla.org/docs/Web/API/ImageTrackList#browser_compatibility)                                           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageTrackList.length`](https://developer.mozilla.org/docs/Web/API/ImageTrackList/length#browser_compatibility)                             | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageTrackList.ready`](https://developer.mozilla.org/docs/Web/API/ImageTrackList/ready#browser_compatibility)                               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageTrackList.selectedIndex`](https://developer.mozilla.org/docs/Web/API/ImageTrackList/selectedIndex#browser_compatibility)               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.ImageTrackList.selectedTrack`](https://developer.mozilla.org/docs/Web/API/ImageTrackList/selectedTrack#browser_compatibility)               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari ❌<br>Safari on iOS ❌          |
| [`api.VideoColorSpace`](https://developer.mozilla.org/docs/Web/API/VideoColorSpace#browser_compatibility)                                         | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 15.4<br>Safari on iOS 15.4    |
| [`api.VideoColorSpace.fullRange`](https://developer.mozilla.org/docs/Web/API/VideoColorSpace/fullRange#browser_compatibility)                     | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 15.4<br>Safari on iOS 15.4    |
| [`api.VideoColorSpace.matrix`](https://developer.mozilla.org/docs/Web/API/VideoColorSpace/matrix#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 15.4<br>Safari on iOS 15.4    |
| [`api.VideoColorSpace.primaries`](https://developer.mozilla.org/docs/Web/API/VideoColorSpace/primaries#browser_compatibility)                     | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 15.4<br>Safari on iOS 15.4    |
| [`api.VideoColorSpace.toJSON`](https://developer.mozilla.org/docs/Web/API/VideoColorSpace/toJSON#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 15.4<br>Safari on iOS 15.4    |
| [`api.VideoColorSpace.transfer`](https://developer.mozilla.org/docs/Web/API/VideoColorSpace/transfer#browser_compatibility)                       | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 15.4<br>Safari on iOS 15.4    |
| [`api.VideoColorSpace.VideoColorSpace`](https://developer.mozilla.org/docs/Web/API/VideoColorSpace/VideoColorSpace#browser_compatibility)         | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 17<br>Safari on iOS 17        |
| [`api.VideoDecoder`](https://developer.mozilla.org/docs/Web/API/VideoDecoder#browser_compatibility)                                               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoDecoder.close`](https://developer.mozilla.org/docs/Web/API/VideoDecoder/close#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoDecoder.configure`](https://developer.mozilla.org/docs/Web/API/VideoDecoder/configure#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoDecoder.decode`](https://developer.mozilla.org/docs/Web/API/VideoDecoder/decode#browser_compatibility)                                 | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoDecoder.decodeQueueSize`](https://developer.mozilla.org/docs/Web/API/VideoDecoder/decodeQueueSize#browser_compatibility)               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| `api.VideoDecoder.dequeue_event`                                                                                                                  | ❌ Not Baseline |                | Chrome 106<br>Chrome Android 106<br>Edge 106<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4 |
| [`api.VideoDecoder.flush`](https://developer.mozilla.org/docs/Web/API/VideoDecoder/flush#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| `api.VideoDecoder.isConfigSupported_static`                                                                                                       | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoDecoder.reset`](https://developer.mozilla.org/docs/Web/API/VideoDecoder/reset#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoDecoder.state`](https://developer.mozilla.org/docs/Web/API/VideoDecoder/state#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoDecoder.VideoDecoder`](https://developer.mozilla.org/docs/Web/API/VideoDecoder/VideoDecoder#browser_compatibility)                     | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoEncoder`](https://developer.mozilla.org/docs/Web/API/VideoEncoder#browser_compatibility)                                               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoEncoder.close`](https://developer.mozilla.org/docs/Web/API/VideoEncoder/close#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoEncoder.configure`](https://developer.mozilla.org/docs/Web/API/VideoEncoder/configure#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| `api.VideoEncoder.dequeue_event`                                                                                                                  | ❌ Not Baseline |                | Chrome 106<br>Chrome Android 106<br>Edge 106<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4 |
| [`api.VideoEncoder.encode`](https://developer.mozilla.org/docs/Web/API/VideoEncoder/encode#browser_compatibility)                                 | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoEncoder.encodeQueueSize`](https://developer.mozilla.org/docs/Web/API/VideoEncoder/encodeQueueSize#browser_compatibility)               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| `api.VideoEncoder.flush`                                                                                                                          | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| `api.VideoEncoder.isConfigSupported_static`                                                                                                       | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoEncoder.reset`](https://developer.mozilla.org/docs/Web/API/VideoEncoder/reset#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoEncoder.state`](https://developer.mozilla.org/docs/Web/API/VideoEncoder/state#browser_compatibility)                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoEncoder.VideoEncoder`](https://developer.mozilla.org/docs/Web/API/VideoEncoder/VideoEncoder#browser_compatibility)                     | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoFrame`](https://developer.mozilla.org/docs/Web/API/VideoFrame#browser_compatibility)                                                   | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoFrame.allocationSize`](https://developer.mozilla.org/docs/Web/API/VideoFrame/allocationSize#browser_compatibility)                     | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoFrame.clone`](https://developer.mozilla.org/docs/Web/API/VideoFrame/clone#browser_compatibility)                                       | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoFrame.close`](https://developer.mozilla.org/docs/Web/API/VideoFrame/close#browser_compatibility)                                       | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoFrame.codedHeight`](https://developer.mozilla.org/docs/Web/API/VideoFrame/codedHeight#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoFrame.codedRect`](https://developer.mozilla.org/docs/Web/API/VideoFrame/codedRect#browser_compatibility)                               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoFrame.codedWidth`](https://developer.mozilla.org/docs/Web/API/VideoFrame/codedWidth#browser_compatibility)                             | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoFrame.colorSpace`](https://developer.mozilla.org/docs/Web/API/VideoFrame/colorSpace#browser_compatibility)                             | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| `api.VideoFrame.copyTo`                                                                                                                           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoFrame.displayHeight`](https://developer.mozilla.org/docs/Web/API/VideoFrame/displayHeight#browser_compatibility)                       | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoFrame.displayWidth`](https://developer.mozilla.org/docs/Web/API/VideoFrame/displayWidth#browser_compatibility)                         | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoFrame.duration`](https://developer.mozilla.org/docs/Web/API/VideoFrame/duration#browser_compatibility)                                 | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoFrame.format`](https://developer.mozilla.org/docs/Web/API/VideoFrame/format#browser_compatibility)                                     | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoFrame.timestamp`](https://developer.mozilla.org/docs/Web/API/VideoFrame/timestamp#browser_compatibility)                               | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoFrame.VideoFrame`](https://developer.mozilla.org/docs/Web/API/VideoFrame/VideoFrame#browser_compatibility)                             | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |
| [`api.VideoFrame.visibleRect`](https://developer.mozilla.org/docs/Web/API/VideoFrame/visibleRect#browser_compatibility)                           | ❌ Not Baseline |                | Chrome 94<br>Chrome Android 94<br>Edge 94<br>Firefox ❌<br>Firefox for Android ❌<br>Safari 16.4<br>Safari on iOS 16.4    |



## webvtt

| Key                                                                                                               | Baseline | Low since date | Versions                                                                                                              |
| :---------------------------------------------------------------------------------------------------------------- | :------: | :------------- | --------------------------------------------------------------------------------------------------------------------- |
| **webvtt**                                                                                                        |  ✅ High  | 2020-01-15     | Chrome 33<br>Chrome Android 33<br>Edge 79 🔑💎<br>Firefox 31<br>Firefox for Android 31<br>Safari 8<br>Safari on iOS 8 |
| [`api.VTTCue`](https://developer.mozilla.org/docs/Web/API/VTTCue#browser_compatibility)                           |  ✅ High  | 2015-07-28     | Chrome 23<br>Chrome Android 25<br>Edge 12 🔑💎<br>Firefox 31<br>Firefox for Android 31<br>Safari 6<br>Safari on iOS 8 |
| [`api.VTTCue.VTTCue`](https://developer.mozilla.org/docs/Web/API/VTTCue/VTTCue#browser_compatibility)             |  ✅ High  | 2020-01-15     | Chrome 33<br>Chrome Android 33<br>Edge 79 🔑💎<br>Firefox 31<br>Firefox for Android 31<br>Safari 8<br>Safari on iOS 8 |
| [`api.VTTCue.align`](https://developer.mozilla.org/docs/Web/API/VTTCue/align#browser_compatibility)               |  ✅ High  | 2020-01-15     | Chrome 23<br>Chrome Android 25<br>Edge 79 🔑💎<br>Firefox 31<br>Firefox for Android 31<br>Safari 6<br>Safari on iOS 8 |
| [`api.VTTCue.getCueAsHTML`](https://developer.mozilla.org/docs/Web/API/VTTCue/getCueAsHTML#browser_compatibility) |  ✅ High  | 2015-07-28     | Chrome 23<br>Chrome Android 25<br>Edge 12 🔑💎<br>Firefox 31<br>Firefox for Android 31<br>Safari 6<br>Safari on iOS 8 |
| [`api.VTTCue.line`](https://developer.mozilla.org/docs/Web/API/VTTCue/line#browser_compatibility)                 |  ✅ High  | 2020-01-15     | Chrome 23<br>Chrome Android 25<br>Edge 79 🔑💎<br>Firefox 31<br>Firefox for Android 31<br>Safari 6<br>Safari on iOS 8 |
| [`api.VTTCue.position`](https://developer.mozilla.org/docs/Web/API/VTTCue/position#browser_compatibility)         |  ✅ High  | 2020-01-15     | Chrome 23<br>Chrome Android 25<br>Edge 79 🔑💎<br>Firefox 31<br>Firefox for Android 31<br>Safari 6<br>Safari on iOS 8 |
| [`api.VTTCue.size`](https://developer.mozilla.org/docs/Web/API/VTTCue/size#browser_compatibility)                 |  ✅ High  | 2020-01-15     | Chrome 23<br>Chrome Android 25<br>Edge 79 🔑💎<br>Firefox 31<br>Firefox for Android 31<br>Safari 6<br>Safari on iOS 8 |
| [`api.VTTCue.snapToLines`](https://developer.mozilla.org/docs/Web/API/VTTCue/snapToLines#browser_compatibility)   |  ✅ High  | 2020-01-15     | Chrome 23<br>Chrome Android 25<br>Edge 79 🔑💎<br>Firefox 31<br>Firefox for Android 31<br>Safari 6<br>Safari on iOS 8 |
| [`api.VTTCue.text`](https://developer.mozilla.org/docs/Web/API/VTTCue/text#browser_compatibility)                 |  ✅ High  | 2015-07-28     | Chrome 23<br>Chrome Android 25<br>Edge 12 🔑💎<br>Firefox 31<br>Firefox for Android 31<br>Safari 6<br>Safari on iOS 8 |
| [`api.VTTCue.vertical`](https://developer.mozilla.org/docs/Web/API/VTTCue/vertical#browser_compatibility)         |  ✅ High  | 2020-01-15     | Chrome 23<br>Chrome Android 25<br>Edge 79 🔑💎<br>Firefox 31<br>Firefox for Android 31<br>Safari 6<br>Safari on iOS 8 |

🔑💎 marks a release that contributes to the Baseline low date.<br>

## where

| Key                                                                                                                                                 | Baseline | Low since date | Versions                                                                                                                |
| :-------------------------------------------------------------------------------------------------------------------------------------------------- | :------: | :------------- | ----------------------------------------------------------------------------------------------------------------------- |
| **where**                                                                                                                                           |  ✅ High  | 2021-01-21     | Chrome 88<br>Chrome Android 88<br>Edge 88 🔑💎<br>Firefox 82<br>Firefox for Android 82<br>Safari 14<br>Safari on iOS 14 |
| [`css.selectors.where`](https://developer.mozilla.org/docs/Web/CSS/:where#browser_compatibility)                                                    |  ✅ High  | 2021-01-21     | Chrome 88<br>Chrome Android 88<br>Edge 88 🔑💎<br>Firefox 78<br>Firefox for Android 79<br>Safari 14<br>Safari on iOS 14 |
| [`css.selectors.where.forgiving_selector_list`](https://developer.mozilla.org/docs/Web/CSS/:where#Forgiving_Selector_Parsing#browser_compatibility) |  ✅ High  | 2021-01-21     | Chrome 88<br>Chrome Android 88<br>Edge 88 🔑💎<br>Firefox 82<br>Firefox for Android 82<br>Safari 14<br>Safari on iOS 14 |

🔑💎 marks a release that contributes to the Baseline low date.<br>

