### PR TITLE
`default`: set Baseline status

### DIFF
--- a/feature-group-definitions/default.yml
+++ b/feature-group-definitions/default.yml
@@ -1,4 +1,15 @@
 spec: https://drafts.csswg.org/selectors-4/#the-default-pseudo
 caniuse: css-default-pseudo
+status:
+  baseline: high
+  baseline_low_date: 2020-01-15
+  support:
+    chrome: "10"
+    chrome_android: "18"
+    edge: "79"
+    firefox: "4"
+    firefox_android: "4"
+    safari: "5"
+    safari_ios: "5"
 compat_features:
   - css.selectors.default


### PR DESCRIPTION
Separating `default` out from https://github.com/web-platform-dx/web-features/pull/455/.


| Key                   | Baseline | Low since date | Versions                                                                                                            |
| :-------------------- | :------: | :------------- | ------------------------------------------------------------------------------------------------------------------- |
| **default**           |  ✅ High  | 2020-01-15     | Chrome 10<br>Chrome Android 18<br>Edge 79 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5 |
| css.selectors.default |  ✅ High  | 2020-01-15     | Chrome 10<br>Chrome Android 18<br>Edge 79 🔑💎<br>Firefox 4<br>Firefox for Android 4<br>Safari 5<br>Safari on iOS 5 |