### PR TITLE
`web-features` `package.json` tidying

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
       - dependency-name: "@types/node"
         update-types:
           - "version-update:semver-major"
+  - package-ecosystem: npm
+    directory: packages/web-features
+    schedule:
+      interval: daily

--- a/packages/web-features/package-lock.json
+++ b/packages/web-features/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "web-features",
       "version": "0.5.0-alpha.1",
+      "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.0.4"
       }

--- a/packages/web-features/package.json
+++ b/packages/web-features/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/web-platform-dx/web-features.git"
+    "url": "git+https://github.com/web-platform-dx/web-features.git"
   },
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
When putting out the pre-releases, `npm` advised running `npm pkg fix` to correct the discrepancy between the actual repo and the `url` field. This corrects that.

In the process of reviewing the above, I also noticed that we use a different version of typescript for packaging than we do the rest of the project. Turning on dependabot for the published package should correct this.