### PR TITLE
Check consistency of TS types and JSON schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "scripts": {
     "build": "ts-node scripts/build.ts",
-    "generate-schema-defs": "ts-json-schema-generator --tsconfig ./tsconfig.json --type FeatureData --path ./index.ts --id defs --out ./schemas/defs.schema.json",
+    "schema-defs": "ts-json-schema-generator --tsconfig ./tsconfig.json --type FeatureData --path ./index.ts --id defs",
+    "schema-defs:write": "npm run schema-defs -- --out ./schemas/defs.schema.json",
     "test": "npm run test:caniuse -- --quiet && npm run test:schema && npm run test:specs && npm run test:format",
     "test:caniuse": "ts-node scripts/caniuse.ts",
     "test:schema": "ts-node scripts/schema.ts",

--- a/scripts/schema.ts
+++ b/scripts/schema.ts
@@ -1,10 +1,30 @@
+import child_process from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import url from 'url';
+
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 
 import features from '../index.js';
 
+import defs from '../schemas/defs.schema.json' assert { type: 'json' };
 import schema from '../schemas/features.schema.json' assert { type: 'json' };
-import defs from '../schemas/defs.schema.json' assert { type: 'json' }
+
+let status: 0 | 1 = 0;
+
+function checkDefsConsistency(): void {
+    const defsPath: string = path.join(path.dirname(url.fileURLToPath(import.meta.url)), "../schemas/defs.schema.json");
+    const defsOnDisk: string = fs.readFileSync(defsPath, { encoding: "utf-8"});
+    const defsGenerated: string = child_process.execSync("npm run --silent schema-defs", { encoding: "utf-8"}).trim();
+
+    if (defsOnDisk !== defsGenerated) {
+        console.error("There's a mismatch between the schema defs on disk and types in `index.ts`.");
+        console.error("This may produce misleading results for feature validation.");
+        console.error("To fix this, run `npm run schema-defs:write`.");
+        status = 1;
+    }
+}
 
 async function validate() {
     const ajv = new Ajv({allErrors: true, schemas: [defs]});
@@ -17,8 +37,10 @@ async function validate() {
         for (const error of validate.errors) {
             console.error(`${error.instancePath}: ${error.message}`);
         }
-        process.exit(1);
+        status = 1;
     }
 }
 
+checkDefsConsistency();
 validate();
+process.exit(status);


### PR DESCRIPTION
Inspired by https://github.com/web-platform-dx/web-features/pull/481 and other PRs.

Previously, we don't do anything to ensure that the JSON schema generator is doing so consistently from one version to the next, or that the generated schema is not stale. This will hopefully fix both issues, by asserting that the generated schema matches the schema on disk.