### PR TITLE
`media-capture`: set Baseline status

### DIFF
--- a/feature-group-definitions/line-clamp.yml
+++ b/feature-group-definitions/line-clamp.yml
@@ -1,5 +1,16 @@
 spec: https://drafts.csswg.org/css-overflow-3/#line-clamp
 caniuse: css-line-clamp
+status:
+  baseline: high
+  baseline_low_date: 2019-07-09
+  support:
+    chrome: "6"
+    chrome_android: "18"
+    edge: "17"
+    firefox: "68"
+    firefox_android: "68"
+    safari: "5"
+    safari_ios: "4.2"
 compat_features:
   # This is a weird one! Specified with a prefix:
   # https://drafts.csswg.org/css-overflow-4/#propdef--webkit-line-clamp

--- a/feature-group-definitions/media-capture.yml
+++ b/feature-group-definitions/media-capture.yml
@@ -1,5 +1,11 @@
 spec: https://w3c.github.io/html-media-capture/
 caniuse: html-media-capture
+status:
+  baseline: false
+  support:
+    chrome_android: "25"
+    firefox_android: "79"
+    safari_ios: "10"
 compat_features:
   - api.HTMLInputElement.capture
   - html.elements.input.capture


### PR DESCRIPTION
We probably need a note field now, to explain why this will (never?) be non-Baseline.

> media-capture is an interesting feature: it's implemented in, and arguably more targeted at, mobile browsers, and using the HTML `capture` attribute on desktop should not break anything (using the IDL attribute may though, since it's going to be undefined).
>
> In a way, [`html.elements.input.capture`](https://developer.mozilla.org/docs/Web/HTML/Attributes/capture#browser_compatibility) could be seen as having a high baseline status. I don't suggest doing that. That just seems like a good candidate feature for statuses beyond baseline that might be worth calling out to developers: you can use the attribute everywhere, just be aware that it won't do anything on some platforms.

_Originally posted by @tidoust in https://github.com/web-platform-dx/web-features/issues/461#issuecomment-1839195349_
            