### PR TITLE
Mark css-has baseline low

### DIFF
--- a/feature-group-definitions/has.yml
+++ b/feature-group-definitions/has.yml
@@ -2,11 +2,14 @@ spec: https://drafts.csswg.org/selectors-4/#relational
 caniuse: css-has
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4743
 status:
-  baseline: false
+  baseline: low
+  baseline_low_date: 2023-12-19
   support:
     chrome: "105"
     chrome_android: "105"
     edge: "105"
+    firefox: "121"
+    firefox_android: "121"
     safari: "15.4"
     safari_ios: "15.4"
 compat_features:


### PR DESCRIPTION
I guess css-has is now baseline low?
People want to see this updated on MDN https://github.com/mdn/browser-compat-data/issues/21682 ...

(I really don't want to author PRs like this one. I maintain BCD on a daily basis and also maintaining compat-data in another repo is not a good use of time. BCD has a `support` object with the same and **up-to-date** info as in this file. BCD could also export computed baseline statuses as well if needed. There is no need to record/maintain this info twice.)
