### PR TITLE
Find input_event on api.Element

### DIFF
--- a/feature-group-definitions/input-event.yml
+++ b/feature-group-definitions/input-event.yml
@@ -12,7 +12,7 @@ status:
     safari: "16.4"
     safari_ios: "16.4"
 compat_features:
-  - api.HTMLElement.input_event
+  - api.Element.input_event
   - api.InputEvent
   - api.InputEvent.InputEvent
   - api.InputEvent.data


### PR DESCRIPTION
See the BCD change: https://github.com/mdn/browser-compat-data/pull/21640

(I can only recommend to get the `compat_features` from BCD directly using BCD's `tags`. Moves like this are somewhat rare but they happen. I think https://github.com/web-platform-dx/web-features/pull/489 switches to use BCD's tags?)