### PR TITLE
Mark AVIF as Baseline low

### DIFF
--- a/feature-group-definitions/avif.yml
+++ b/feature-group-definitions/avif.yml
@@ -1,3 +1,14 @@
 spec: https://aomediacodec.github.io/av1-avif/
 caniuse: avif
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3798
+status:
+  baseline: low
+  baseline_low_date: 2024-01-25?
+  support:
+    chrome: "85"
+    chrome_android: "85"
+    edge: "121"
+    firefox: "93"
+    firefox_android: "93"
+    safari: "16"
+    safari_ios: "16"

--- a/feature-group-definitions/avif.yml
+++ b/feature-group-definitions/avif.yml
@@ -3,7 +3,7 @@ caniuse: avif
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3798
 status:
   baseline: low
-  baseline_low_date: 2024-01-25?
+  baseline_low_date: 2024-01-26
   support:
     chrome: "85"
     chrome_android: "85"


### PR DESCRIPTION
Opening this after seeing @captainbrosset post https://mas.to/@patrickbrosset/111606297691549413.

Leaving this as draft until Edge 121 is released. The versions for the other browsers also need to be confirmed.