### PR TITLE
Clarify that Baseline does not cover assistive technology

### DIFF
--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -60,7 +60,7 @@ Baseline status cannot or will not satisfy the following non-goals:
   If a web developer needs to support a globally uncommon or discontinued browser (e.g., Internet Explorer 11), then the developer needs to know the specific limitations of that browser, not a broad overview of developers’ most commonly required browsers.
   Baseline can’t be both.
 * **Identify support in assistive technology.**
-  Baseline does not cover support for screen readers, screen magnifiers, voice control, and other assistive technology that browsers do not expose to developers.
+  Baseline does not cover support for screen readers, screen magnifiers, voice control, and other assistive technology that is not built into browsers.
   See also: [Future considerations](#future-considerations).
 * **Identify support in non-web environments.**
   Developers use web technologies in non-web settings, such as JavaScript in Node.js, Web APIs in Deno, or HTML and CSS in Electron-based applications.

--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -179,6 +179,6 @@ Here are some areas for future consideration and not currently in-scope for Base
 * Progressive enhancement safe (i.e., limited penalties for support failures)
 * Developer feedback requested
 * Buggy (e.g., supported but in ways that are surprising and semi-interoperable)
-* Not exposed to platform accessibility APIs (AAPIs) as specified
+* Support in assistive technology that is not built into browsers.
 * Obsolete/deprecated/legacy/etc. (i.e., flagged as such in the specification or dropped from newer versions of the specification)
 * Having high-quality polyfills available

--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -60,7 +60,7 @@ Baseline status cannot or will not satisfy the following non-goals:
   If a web developer needs to support a globally uncommon or discontinued browser (e.g., Internet Explorer 11), then the developer needs to know the specific limitations of that browser, not a broad overview of developers’ most commonly required browsers.
   Baseline can’t be both.
 * **Identify support in assistive technology.**
-  Baseline should cover core accessibility support in browsers but it does not cover support in assistive tools (e.g., screen magnifiers, screen readers, alternative keyboards) that may be used along a browser to meet the requirements of people with disabilities.
+  Baseline does not cover support in assistive technology (AT), which includes screen readers, screen magnifiers, voice control, and so on.
   See also: [Future considerations](#future-considerations).
 * **Identify support in non-web environments.**
   Developers use web technologies in non-web settings, such as JavaScript in Node.js, Web APIs in Deno, or HTML and CSS in Electron-based applications.
@@ -178,7 +178,6 @@ Here are some areas for future consideration and not currently in-scope for Base
 * Upcoming (e.g., not yet shipped in all browsers)
 * Progressive enhancement safe (i.e., limited penalties for support failures)
 * Developer feedback requested
-* Buggy (e.g., supported but in ways that are surprising and semi-interoperable)
-* Buggy or unsupported in assistive tools
+* Buggy (e.g., supported but in ways that are surprising and semi-interoperable, not exposed to platform accessibility APIs (AAPIs) as specified)
 * Obsolete/deprecated/legacy/etc. (i.e., flagged as such in the specification or dropped from newer versions of the specification)
 * Having high-quality polyfills available

--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -178,6 +178,7 @@ Here are some areas for future consideration and not currently in-scope for Base
 * Upcoming (e.g., not yet shipped in all browsers)
 * Progressive enhancement safe (i.e., limited penalties for support failures)
 * Developer feedback requested
-* Buggy (e.g., supported but in ways that are surprising and semi-interoperable, not exposed to platform accessibility APIs (AAPIs) as specified)
+* Buggy (e.g., supported but in ways that are surprising and semi-interoperable)
+* Not exposed to platform accessibility APIs (AAPIs) as specified
 * Obsolete/deprecated/legacy/etc. (i.e., flagged as such in the specification or dropped from newer versions of the specification)
 * Having high-quality polyfills available

--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -59,6 +59,9 @@ Baseline status cannot or will not satisfy the following non-goals:
   Many Baseline features will not achieve 100% user reach soon or perhaps ever.
   If a web developer needs to support a globally uncommon or discontinued browser (e.g., Internet Explorer 11), then the developer needs to know the specific limitations of that browser, not a broad overview of developers’ most commonly required browsers.
   Baseline can’t be both.
+* **Identify support in assistive technology.**
+  Baseline should cover core accessibility support in browsers but it does not cover support in assistive tools (e.g., screen magnifiers, screen readers, alternative keyboards) that may be used along a browser to meet the requirements of people with disabilities.
+  See also: [Future considerations](#future-considerations).
 * **Identify support in non-web environments.**
   Developers use web technologies in non-web settings, such as JavaScript in Node.js, Web APIs in Deno, or HTML and CSS in Electron-based applications.
   For good reasons, web technologies in non-web settings often depart from interoperability with web browsers.
@@ -176,5 +179,6 @@ Here are some areas for future consideration and not currently in-scope for Base
 * Progressive enhancement safe (i.e., limited penalties for support failures)
 * Developer feedback requested
 * Buggy (e.g., supported but in ways that are surprising and semi-interoperable)
+* Buggy or unsupported in assistive tools
 * Obsolete/deprecated/legacy/etc. (i.e., flagged as such in the specification or dropped from newer versions of the specification)
 * Having high-quality polyfills available

--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -60,7 +60,7 @@ Baseline status cannot or will not satisfy the following non-goals:
   If a web developer needs to support a globally uncommon or discontinued browser (e.g., Internet Explorer 11), then the developer needs to know the specific limitations of that browser, not a broad overview of developers’ most commonly required browsers.
   Baseline can’t be both.
 * **Identify support in assistive technology.**
-  Baseline does not cover support in assistive technology (AT), which includes screen readers, screen magnifiers, voice control, and so on.
+  Baseline does not cover support for screen readers, screen magnifiers, voice control, and other assistive technology that browsers do not expose to developers.
   See also: [Future considerations](#future-considerations).
 * **Identify support in non-web environments.**
   Developers use web technologies in non-web settings, such as JavaScript in Node.js, Web APIs in Deno, or HTML and CSS in Electron-based applications.


### PR DESCRIPTION
This adds an item to non-goals to clarify that support in assistive tools that may be used along a browser is not (yet?) covered by Baseline.

See discussion in https://github.com/web-platform-dx/web-features/issues/498