### PR TITLE
Refresh Baseline statuses for 2024-01-09

### DIFF
--- a/feature-group-definitions/array-at.yml
+++ b/feature-group-definitions/array-at.yml
@@ -1,7 +1,7 @@
 spec: https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.at
 status:
   baseline: low
-  baseline_low_date: 2022-03-15
+  baseline_low_date: 2022-03-14
   support:
     chrome: "92"
     chrome_android: "92"

--- a/feature-group-definitions/broadcast-channel.yml
+++ b/feature-group-definitions/broadcast-channel.yml
@@ -3,7 +3,7 @@ caniuse: broadcastchannel
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1447
 status:
   baseline: low
-  baseline_low_date: 2022-03-15
+  baseline_low_date: 2022-03-14
   support:
     chrome: "60"
     chrome_android: "60"

--- a/feature-group-definitions/cascade-layers.yml
+++ b/feature-group-definitions/cascade-layers.yml
@@ -3,7 +3,7 @@ caniuse: css-cascade-layers
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4007
 status:
   baseline: low
-  baseline_low_date: 2022-03-15
+  baseline_low_date: 2022-03-14
   support:
     chrome: "99"
     chrome_android: "99"

--- a/feature-group-definitions/fetch-priority.yml
+++ b/feature-group-definitions/fetch-priority.yml
@@ -7,6 +7,8 @@ status:
     chrome: "102"
     chrome_android: "102"
     edge: "102"
+    safari: "17.2"
+    safari_ios: "17.2"
 compat_features:
   - api.fetch.init_priority_parameter
   - api.HTMLImageElement.fetchPriority

--- a/feature-group-definitions/focus-visible.yml
+++ b/feature-group-definitions/focus-visible.yml
@@ -3,7 +3,7 @@ caniuse: css-focus-visible
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2388
 status:
   baseline: low
-  baseline_low_date: 2022-03-15
+  baseline_low_date: 2022-03-14
   support:
     chrome: "86"
     chrome_android: "86"

--- a/feature-group-definitions/nesting.yml
+++ b/feature-group-definitions/nesting.yml
@@ -1,10 +1,16 @@
 spec: https://drafts.csswg.org/css-nesting-1/
 caniuse: css-nesting
 status:
-  baseline: false
+  baseline: low
+  baseline_low_date: 2023-12-11
   support:
+    chrome: "120"
+    chrome_android: "120"
+    edge: "120"
     firefox: "117"
     firefox_android: "117"
+    safari: "17.2"
+    safari_ios: "17.2"
 compat_features:
   - css.selectors.nesting
   - api.CSSStyleRule.cssRules

--- a/feature-group-definitions/structured-clone.yml
+++ b/feature-group-definitions/structured-clone.yml
@@ -1,7 +1,7 @@
 spec: https://html.spec.whatwg.org/multipage/structured-data.html#structured-cloning
 status:
   baseline: low
-  baseline_low_date: 2022-03-15
+  baseline_low_date: 2022-03-14
   support:
     chrome: "98"
     chrome_android: "98"

--- a/feature-group-definitions/subgrid.yml
+++ b/feature-group-definitions/subgrid.yml
@@ -9,7 +9,7 @@ status:
     chrome_android: "117"
     edge: "117"
     firefox: "71"
-    firefox_android: "71"
+    firefox_android: "79"
     safari: "16"
     safari_ios: "16"
 compat_features:

--- a/feature-group-definitions/webtransport.yml
+++ b/feature-group-definitions/webtransport.yml
@@ -3,7 +3,10 @@ caniuse: webtransport
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3472
 status:
   baseline: false
-  support: {}
+  support:
+    chrome: "97"
+    chrome_android: "97"
+    edge: "97"
 compat_features:
   - api.WebTransport
   - api.WebTransport.WebTransport


### PR DESCRIPTION
(I'm not actually here right now, but this fixes a glaring error in our published status for `nesting`.)