### PR TITLE
Find popover attributes on input/button elements

### DIFF
--- a/feature-group-definitions/popover.yml
+++ b/feature-group-definitions/popover.yml
@@ -26,5 +26,7 @@ compat_features:
   - css.selectors.backdrop.popover
   - css.selectors.popover-open
   - html.global_attributes.popover
-  - html.global_attributes.popovertarget
-  - html.global_attributes.popovertargetaction
+  - html.elements.button.popovertarget
+  - html.elements.button.popovertargetaction
+  - html.elements.input.popovertarget
+  - html.elements.input.popovertargetaction


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/pull/21875 for the move in BCD.

Like I said in https://github.com/web-platform-dx/web-features/pull/513, I can only recommend to get the `compat_features` from BCD directly using BCD's `tags`. See also https://github.com/web-platform-dx/web-features/pull/489 which I think switches us to use BCD's tags.