### PR TITLE
Capitalize short names

### DIFF
--- a/feature-group-definitions/anchor-positioning.yml
+++ b/feature-group-definitions/anchor-positioning.yml
@@ -1,2 +1,2 @@
-name: "Anchor positioning"
+name: "Anchor Positioning"
 spec: https://drafts.csswg.org/css-anchor-position-1/#anchoring

--- a/feature-group-definitions/array-group.yml
+++ b/feature-group-definitions/array-group.yml
@@ -1,4 +1,4 @@
-name: "Array grouping"
+name: "Array Grouping"
 spec: https://tc39.es/proposal-array-grouping/
 status:
   baseline: false

--- a/feature-group-definitions/async-await.yml
+++ b/feature-group-definitions/async-await.yml
@@ -1,4 +1,4 @@
-name: "Async functions"
+name: "Async Functions"
 spec: https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-async-function-definitions
 caniuse: async-functions
 status:

--- a/feature-group-definitions/async-clipboard.yml
+++ b/feature-group-definitions/async-clipboard.yml
@@ -1,4 +1,4 @@
-name: "Async clipboard"
+name: "Async Clipboard"
 spec: https://w3c.github.io/clipboard-apis/#async-clipboard-api
 caniuse: async-clipboard
 status:

--- a/feature-group-definitions/background-fetch.yml
+++ b/feature-group-definitions/background-fetch.yml
@@ -1,4 +1,4 @@
-name: "Background fetch"
+name: "Background Fetch"
 spec: https://wicg.github.io/background-fetch/
 status:
   baseline: false

--- a/feature-group-definitions/background-gradients.yml
+++ b/feature-group-definitions/background-gradients.yml
@@ -1,4 +1,4 @@
-name: "Background gradients"
+name: "Background Gradients"
 spec: https://drafts.csswg.org/css-images-4/#gradients
 caniuse:
   - css-gradients

--- a/feature-group-definitions/border-image.yml
+++ b/feature-group-definitions/border-image.yml
@@ -1,4 +1,4 @@
-name: "Border images"
+name: "Border Images"
 spec: https://drafts.csswg.org/css-backgrounds-3/#border-images
 caniuse: border-image
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/43

--- a/feature-group-definitions/canvas-context-lost.yml
+++ b/feature-group-definitions/canvas-context-lost.yml
@@ -1,4 +1,4 @@
-name: "contextlost and contextrestored events"
+name: "contextlost and contextrestored Events"
 spec: https://html.spec.whatwg.org/multipage/webappapis.html#context-lost-steps
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3974
 status:

--- a/feature-group-definitions/cascade-layers.yml
+++ b/feature-group-definitions/cascade-layers.yml
@@ -1,4 +1,4 @@
-name: "Cascade layers"
+name: "Cascade Layers"
 spec: https://drafts.csswg.org/css-cascade-5/#layering
 caniuse: css-cascade-layers
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4007

--- a/feature-group-definitions/compression-streams.yml
+++ b/feature-group-definitions/compression-streams.yml
@@ -1,4 +1,4 @@
-name: Compression streams
+name: Compression Streams
 spec: https://wicg.github.io/compression/
 usage_stats:
   - https://chromestatus.com/metrics/feature/timeline/popularity/3060

--- a/feature-group-definitions/constraint-validation.yml
+++ b/feature-group-definitions/constraint-validation.yml
@@ -1,4 +1,4 @@
-name: "Constraint validation API"
+name: "Constraint Validation API"
 spec: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api
 caniuse: constraint-validation
 status:

--- a/feature-group-definitions/container-queries.yml
+++ b/feature-group-definitions/container-queries.yml
@@ -1,4 +1,4 @@
-name: "Container queries"
+name: "Container Queries"
 spec: https://drafts.csswg.org/css-contain-3/#container-queries
 caniuse: css-container-queries
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4165

--- a/feature-group-definitions/custom-elements.yml
+++ b/feature-group-definitions/custom-elements.yml
@@ -1,4 +1,4 @@
-name: "Custom elements"
+name: "Custom Elements"
 spec: https://html.spec.whatwg.org/multipage/custom-elements.html
 caniuse: custom-elementsv1
 status:

--- a/feature-group-definitions/custom-properties.yml
+++ b/feature-group-definitions/custom-properties.yml
@@ -1,4 +1,4 @@
-name: "Custom properties"
+name: "Custom Properties"
 spec: https://drafts.csswg.org/css-variables-1/
 caniuse: css-variables
 status:

--- a/feature-group-definitions/device-posture.yml
+++ b/feature-group-definitions/device-posture.yml
@@ -1,4 +1,4 @@
-name: Device posture
+name: Device Posture
 spec: https://w3c.github.io/device-posture/
 status:
   baseline: false

--- a/feature-group-definitions/document-picture-in-picture.yml
+++ b/feature-group-definitions/document-picture-in-picture.yml
@@ -1,3 +1,3 @@
-name: "Document picture-in-picture"
+name: "Document Picture-in-Picture"
 spec: https://wicg.github.io/document-picture-in-picture/
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4397

--- a/feature-group-definitions/fetch-priority.yml
+++ b/feature-group-definitions/fetch-priority.yml
@@ -1,4 +1,4 @@
-name: "Fetch priority"
+name: "Fetch Priority"
 spec:
   - https://fetch.spec.whatwg.org/#request-priority
   - https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attributes

--- a/feature-group-definitions/flexbox-gap.yml
+++ b/feature-group-definitions/flexbox-gap.yml
@@ -1,3 +1,3 @@
-name: "Flexbox gap"
+name: "Flexbox Gap"
 spec: https://drafts.csswg.org/css-align-3/#gaps
 caniuse: flexbox-gap

--- a/feature-group-definitions/grid-animation.yml
+++ b/feature-group-definitions/grid-animation.yml
@@ -1,4 +1,4 @@
-name: "Grid animation"
+name: "Grid Animation"
 spec: https://drafts.csswg.org/css-grid-2/#track-sizing
 status:
   baseline: low

--- a/feature-group-definitions/idle-detection.yml
+++ b/feature-group-definitions/idle-detection.yml
@@ -1,4 +1,4 @@
-name: "Idle detection"
+name: "Idle Detection"
 spec: https://wicg.github.io/idle-detection/
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2834
 status:

--- a/feature-group-definitions/import-maps.yml
+++ b/feature-group-definitions/import-maps.yml
@@ -1,4 +1,4 @@
-name: "Import maps"
+name: "Import Maps"
 spec: https://html.spec.whatwg.org/multipage/webappapis.html#import-maps
 caniuse: import-maps
 status:

--- a/feature-group-definitions/input-event.yml
+++ b/feature-group-definitions/input-event.yml
@@ -1,4 +1,4 @@
-name: "input event"
+name: "input Event"
 spec: https://w3c.github.io/uievents/#event-type-input
 caniuse: input-event
 status:

--- a/feature-group-definitions/media-capture.yml
+++ b/feature-group-definitions/media-capture.yml
@@ -1,4 +1,4 @@
-name: "HTML media capture"
+name: "HTML Media Capture"
 spec: https://w3c.github.io/html-media-capture/
 caniuse: html-media-capture
 compat_features:

--- a/feature-group-definitions/motion-path.yml
+++ b/feature-group-definitions/motion-path.yml
@@ -1,4 +1,4 @@
-name: "Motion path"
+name: "Motion Path"
 spec: https://drafts.fxtf.org/motion-1/
 caniuse: css-motion-paths
 status:

--- a/feature-group-definitions/offscreen-canvas.yml
+++ b/feature-group-definitions/offscreen-canvas.yml
@@ -1,4 +1,4 @@
-name: "Offscreen canvas"
+name: "Offscreen Canvas"
 spec: https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-interface
 caniuse: offscreencanvas
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1624

--- a/feature-group-definitions/picture-in-picture.yml
+++ b/feature-group-definitions/picture-in-picture.yml
@@ -1,4 +1,4 @@
-name: "Picture-in-picture"
+name: "Picture-in-Picture"
 spec: https://w3c.github.io/picture-in-picture/
 caniuse: picture-in-picture
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2444

--- a/feature-group-definitions/registered-custom-properties.yml
+++ b/feature-group-definitions/registered-custom-properties.yml
@@ -1,4 +1,4 @@
-name: "Registered custom properties"
+name: "Registered Custom Properties"
 spec: https://drafts.css-houdini.org/css-properties-values-api-1/
 status:
   baseline: false

--- a/feature-group-definitions/set-methods.yml
+++ b/feature-group-definitions/set-methods.yml
@@ -1,4 +1,4 @@
-name: "Set methods"
+name: "Set Methods"
 spec: https://tc39.es/proposal-set-methods/
 status:
   baseline: false

--- a/feature-group-definitions/sticky-positioning.yml
+++ b/feature-group-definitions/sticky-positioning.yml
@@ -1,4 +1,4 @@
-name: "Sticky positioning"
+name: "Sticky Positioning"
 spec: https://drafts.csswg.org/css-position-3/#stickypos-insets
 caniuse: css-sticky
 status:

--- a/feature-group-definitions/view-transitions.yml
+++ b/feature-group-definitions/view-transitions.yml
@@ -1,4 +1,4 @@
-name: "View transitions"
+name: "View Transitions"
 spec: https://drafts.csswg.org/css-view-transitions-1/
 caniuse: view-transitions
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4383

--- a/feature-group-definitions/viewport-relative-unit-variants.yml
+++ b/feature-group-definitions/viewport-relative-unit-variants.yml
@@ -1,4 +1,4 @@
-name: "sv*, lv*, and dv* viewport units"
+name: "sv*, lv*, and dv* Viewport Units"
 spec:
   - https://drafts.csswg.org/css-values-4/#viewport-variants
   - https://drafts.csswg.org/css-values-4/#viewport-relative-lengths

--- a/feature-group-definitions/viewport-relative-units.yml
+++ b/feature-group-definitions/viewport-relative-units.yml
@@ -1,4 +1,4 @@
-name: "vw, vh, vmin, and vmax viewport units"
+name: "vw, vh, vmin, and vmax Viewport Units"
 spec: https://drafts.csswg.org/css-values-4/#viewport-relative-lengths
 caniuse: viewport-units
 status:

--- a/feature-group-definitions/web-animations.yml
+++ b/feature-group-definitions/web-animations.yml
@@ -1,4 +1,4 @@
-name: "Web animations"
+name: "Web Animations"
 spec: https://drafts.csswg.org/web-animations-1/
 caniuse: web-animation
 status:


### PR DESCRIPTION
Capitalize all words that we wouldn't wrap in `<code>` and certain words
like "and" or "the".
