### PR TITLE
Adjust names of some features

### DIFF
--- a/feature-group-definitions/canvas-context-lost.yml
+++ b/feature-group-definitions/canvas-context-lost.yml
@@ -1,4 +1,4 @@
-name: "contextlost and contextrestored events"
+name: "contextlost and contextrestored"
 spec: https://html.spec.whatwg.org/multipage/webappapis.html#context-lost-steps
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3974
 status:

--- a/feature-group-definitions/svg2-script-html-equivalence.yml
+++ b/feature-group-definitions/svg2-script-html-equivalence.yml
@@ -1,4 +1,4 @@
-name: "SVG <script> async & defer"
+name: "SVG <script> async and defer"
 spec: https://svgwg.org/svg2-draft/interact.html#ScriptElement
 status:
   baseline: false

--- a/feature-group-definitions/trusted-types.yml
+++ b/feature-group-definitions/trusted-types.yml
@@ -1,4 +1,4 @@
-name: Trusted Types
+name: Trusted types
 spec: https://w3c.github.io/trusted-types/dist/spec/
 caniuse: trusted-types
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2722
@@ -6,7 +6,7 @@ status:
   baseline: false
   support:
     # Chrome 83 is an editorial override. The toJSON() methods were shipped in
-    # Chrome 90, but are not needed to use Trusted Types in the idiomatic way.
+    # Chrome 90, but are not needed to use trusted types in the idiomatic way.
     chrome: "83"
     chrome_android: "83"
     edge: "83"


### PR DESCRIPTION
Omit the "event" suffix and use "and" instead of "&".

Use sentence case.