### PR TITLE
Add a group for Server Timing

### DIFF
--- a/feature-group-definitions/server-timing.yml
+++ b/feature-group-definitions/server-timing.yml
@@ -1,0 +1,14 @@
+name: "Server timing"
+spec: https://w3c.github.io/server-timing
+caniuse: server-timing
+status:
+  baseline: low
+  baseline_low_date: 2023-03-27
+  support:
+    chrome: "65"
+    chrome_android: "65"
+    edge: "79"
+    firefox: "61"
+    firefox_android: "61"
+    safari: "16.4"
+    safari_ios: "16.4"

--- a/feature-group-definitions/server-timing.yml
+++ b/feature-group-definitions/server-timing.yml
@@ -1,5 +1,5 @@
 name: "Server timing"
-spec: https://w3c.github.io/server-timing
+spec: https://w3c.github.io/server-timing/
 caniuse: server-timing
 status:
   baseline: low


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/pull/22110

Drive-by comment: analog to the caniuse pointer, I wondered if there should be BCD (and WPT) pointers:

```
name: "Server timing"
spec: https://w3c.github.io/server-timing
bcd: server-timing
caniuse: server-timing
wpt: server-timing
```