### PR TITLE
Add visual viewport API feature

### DIFF
--- a/feature-group-definitions/visual-viewport.yml
+++ b/feature-group-definitions/visual-viewport.yml
@@ -1,0 +1,14 @@
+name: Visual viewport API
+spec: https://drafts.csswg.org/cssom-view-1/#visualViewport
+compat_features:
+  - api.VisualViewport
+  - api.VisualViewport.height
+  - api.VisualViewport.offsetLeft
+  - api.VisualViewport.offsetTop
+  - api.VisualViewport.pageLeft
+  - api.VisualViewport.pageTop
+  - api.VisualViewport.resize_event
+  - api.VisualViewport.scale
+  - api.VisualViewport.scroll_event
+  - api.VisualViewport.width
+  - api.Window.visualViewport


### PR DESCRIPTION
Include "API" in the name as visual viewport is a concept in its own
right which is also touched by other web-exposed features:
https://drafts.csswg.org/css-viewport/#interactive-widget-section

The entry point to the API is `window.visualViewport` or just
`visualViewport`, so those are also plausible names.

Since there's no plain "visual viewport" feature to add to web-features,
don't include API in the identifier.
