### PR TITLE
Add feature for individual transform properties

### DIFF
--- a/feature-group-definitions/individual-transforms.yml
+++ b/feature-group-definitions/individual-transforms.yml
@@ -1,0 +1,10 @@
+name: CSS translate, scale, and rotate properties
+spec: https://drafts.csswg.org/css-transforms-2/#individual-transforms
+usage_stats:
+  - https://chromestatus.com/metrics/css/timeline/popularity/504 # translate
+  - https://chromestatus.com/metrics/css/timeline/popularity/505 # rotate
+  - https://chromestatus.com/metrics/css/timeline/popularity/506 # scale
+compat_features:
+  - css.properties.rotate
+  - css.properties.scale
+  - css.properties.translate

--- a/feature-group-definitions/individual-transforms.yml
+++ b/feature-group-definitions/individual-transforms.yml
@@ -1,4 +1,5 @@
-name: CSS translate, scale, and rotate properties
+name: Individual transform properties
+description: Transform elements with separate `translate`, `rotate`, and `scale` CSS properties.
 spec: https://drafts.csswg.org/css-transforms-2/#individual-transforms
 usage_stats:
   - https://chromestatus.com/metrics/css/timeline/popularity/504 # translate


### PR DESCRIPTION
The shortest plausible name for this is "translate, scale, and rotate",
but these are concepts that appear also in DOMMatrix and 2D canvas, so
to disambigutate include "CSS" as a prefix. Also include "properties" as
a suffix to make it clear that it's no about the ability to
translate/scale/rotate, which the `transform` property has, but the
indivudal properties.
