### PR TITLE
Add CSS 2D/3D transform features

### DIFF
--- a/feature-group-definitions/transforms2d.yml
+++ b/feature-group-definitions/transforms2d.yml
@@ -1,4 +1,5 @@
-name: CSS 2D transforms
+name: 2D transforms
+description: The `transform` CSS property and its 2D transform functions allow rotating, scaling, skewing, and translating an element. Arbitrary 2D transforms are also possible using a transformation matrix.
 caniuse: transforms2d
 spec: https://drafts.csswg.org/css-transforms-1/
 compat_features:

--- a/feature-group-definitions/transforms2d.yml
+++ b/feature-group-definitions/transforms2d.yml
@@ -1,0 +1,19 @@
+name: CSS 2D transforms
+caniuse: transforms2d
+spec: https://drafts.csswg.org/css-transforms-1/
+compat_features:
+  - css.properties.transform
+  - css.properties.transform-box
+  - css.properties.transform-origin
+  - css.types.transform-function
+  - css.types.transform-function.matrix
+  - css.types.transform-function.rotate
+  - css.types.transform-function.scale
+  - css.types.transform-function.scaleX
+  - css.types.transform-function.scaleY
+  - css.types.transform-function.skew
+  - css.types.transform-function.skewX
+  - css.types.transform-function.skewY
+  - css.types.transform-function.translate
+  - css.types.transform-function.translateX
+  - css.types.transform-function.translateY

--- a/feature-group-definitions/transforms3d.yml
+++ b/feature-group-definitions/transforms3d.yml
@@ -1,0 +1,17 @@
+name: CSS 3D transforms
+caniuse: transforms3d
+spec: https://drafts.csswg.org/css-transforms-2/
+compat_features:
+  - css.properties.transform-style
+  - css.properties.transform.3d
+  # https://drafts.csswg.org/css-transforms-2/#three-d-transform-functions
+  - css.types.transform-function.matrix3d
+  - css.types.transform-function.translate3d
+  - css.types.transform-function.translateZ
+  - css.types.transform-function.scale3d
+  - css.types.transform-function.scaleZ
+  - css.types.transform-function.rotate3d
+  - css.types.transform-function.rotateX
+  - css.types.transform-function.rotateY
+  - css.types.transform-function.rotateZ
+  - css.types.transform-function.perspective

--- a/feature-group-definitions/transforms3d.yml
+++ b/feature-group-definitions/transforms3d.yml
@@ -1,7 +1,17 @@
-name: CSS 3D transforms
+name: 3D transforms
+description: The `transform` CSS property and its 3D transform functions allow rotations and other transforms in three dimensions, including perspective transforms.
 caniuse: transforms3d
 spec: https://drafts.csswg.org/css-transforms-2/
 compat_features:
+  - css.properties.backface-visibility
+  - css.properties.perspective-origin
+  - css.properties.perspective-origin.bottom
+  - css.properties.perspective-origin.center
+  - css.properties.perspective-origin.left
+  - css.properties.perspective-origin.right
+  - css.properties.perspective-origin.top
+  - css.properties.perspective
+  - css.properties.perspective.none
   - css.properties.transform-style
   - css.properties.transform.3d
   # https://drafts.csswg.org/css-transforms-2/#three-d-transform-functions


### PR DESCRIPTION
Because transforms exist in multiple other parts of the platform
(DOMMatrix, canvas, SVG) prefix the names with "CSS".
