### PR TITLE
Bump web-specs from 2.79.0 to 3.0.0 and adjust code accordingly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "ts-json-schema-generator": "^1.5.0",
         "tsx": "^4.7.0",
         "typescript": "^5.3.3",
-        "web-specs": "^2.79.0",
+        "web-specs": "^3.0.0",
         "winston": "^3.11.0",
         "yaml": "^2.3.4",
         "yargs": "^17.7.2"
@@ -1150,9 +1150,9 @@
       "dev": true
     },
     "node_modules/web-specs": {
-      "version": "2.79.0",
-      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-2.79.0.tgz",
-      "integrity": "sha512-364IxMgYLUjWDeTPrfNtO/+zZxIJ2ZzV4STzbOdVn6DANptLBo3aNTEJ0SS2Qe2P331apSfnU0b4K6wxl6cuew==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-3.0.0.tgz",
+      "integrity": "sha512-iFIqX1Zu13dJ9slgPlnxs0ndb1v/oB3WilmTAQRIm/RxyuAdjghoxWWnG6ypYOKdr+zv9lX+q/p9JLMZ1gi1GQ==",
       "dev": true
     },
     "node_modules/winston": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ts-json-schema-generator": "^1.5.0",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3",
-    "web-specs": "^2.79.0",
+    "web-specs": "^3.0.0",
     "winston": "^3.11.0",
     "yaml": "^2.3.4",
     "yargs": "^17.7.2"

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -6,8 +6,8 @@ import features from '../index.js';
 
 const specUrls: URL[] = webSpecs.flatMap(spec => {
     return [
-        new URL(spec.nightly.url),
-        ...(spec.nightly.pages ?? []).map(page => new URL(page))
+        new URL(spec.nightly?.url ?? spec.url),
+        ...(spec.nightly?.pages ?? []).map(page => new URL(page))
     ]
 });
 
@@ -17,10 +17,6 @@ const defaultAllowlist: allowlistItem[] = [
     //     "https://example.com/spec/",
     //     "Allowed because…. Remove this exception when https://example.com/org/repo/pull/1234 merges."
     // ]
-    [
-        "https://www.iso.org/standard/85253.html",
-        "Allowed because it's supported in Safari. Remove this exception when https://github.com/w3c/browser-specs/issues/1089 is resolved."
-    ]
 ];
 
 function isOK(url: URL, allowlist: allowlistItem[] = defaultAllowlist) {


### PR DESCRIPTION
New version of web-specs contains the ISO spec for JPEG XL (see #580), but adding that spec, which does not have a public version, required making a breaking change in web-specs, to allow entries without a `nightly` property.

This update adjusts the code that processes web-specs entries accordingly, and removes the JPEG XL exception as it is no longer needed.