### PR TITLE
Remove quotes around names where "obviously" not needed

### DIFF
--- a/feature-group-definitions/anchor-positioning.yml
+++ b/feature-group-definitions/anchor-positioning.yml
@@ -1,2 +1,2 @@
-name: "Anchor positioning"
+name: Anchor positioning
 spec: https://drafts.csswg.org/css-anchor-position-1/#anchoring

--- a/feature-group-definitions/array-at.yml
+++ b/feature-group-definitions/array-at.yml
@@ -1,4 +1,4 @@
-name: "Array at()"
+name: Array at()
 spec: https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.at
 status:
   baseline: low

--- a/feature-group-definitions/array-flat.yml
+++ b/feature-group-definitions/array-flat.yml
@@ -1,4 +1,4 @@
-name: "Array flat() and flatMap()"
+name: Array flat() and flatMap()
 caniuse: array-flat
 spec: https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.flat
 status:

--- a/feature-group-definitions/array-group.yml
+++ b/feature-group-definitions/array-group.yml
@@ -1,4 +1,4 @@
-name: "Array grouping"
+name: Array grouping
 spec: https://tc39.es/proposal-array-grouping/
 status:
   baseline: false

--- a/feature-group-definitions/async-await.yml
+++ b/feature-group-definitions/async-await.yml
@@ -1,4 +1,4 @@
-name: "Async functions"
+name: Async functions
 spec: https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-async-function-definitions
 caniuse: async-functions
 status:

--- a/feature-group-definitions/async-clipboard.yml
+++ b/feature-group-definitions/async-clipboard.yml
@@ -1,4 +1,4 @@
-name: "Async clipboard"
+name: Async clipboard
 spec: https://w3c.github.io/clipboard-apis/#async-clipboard-api
 caniuse: async-clipboard
 status:

--- a/feature-group-definitions/avif.yml
+++ b/feature-group-definitions/avif.yml
@@ -1,4 +1,4 @@
-name: "AVIF"
+name: AVIF
 spec: https://aomediacodec.github.io/av1-avif/
 caniuse: avif
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3798

--- a/feature-group-definitions/background-fetch.yml
+++ b/feature-group-definitions/background-fetch.yml
@@ -1,4 +1,4 @@
-name: "Background fetch"
+name: Background fetch
 spec: https://wicg.github.io/background-fetch/
 status:
   baseline: false

--- a/feature-group-definitions/background-gradients.yml
+++ b/feature-group-definitions/background-gradients.yml
@@ -1,4 +1,4 @@
-name: "Background gradients"
+name: Background gradients
 spec: https://drafts.csswg.org/css-images-4/#gradients
 caniuse:
   - css-gradients

--- a/feature-group-definitions/bigint.yml
+++ b/feature-group-definitions/bigint.yml
@@ -1,4 +1,4 @@
-name: "BigInt"
+name: BigInt
 spec: https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint-objects
 caniuse: bigint
 status:

--- a/feature-group-definitions/border-image.yml
+++ b/feature-group-definitions/border-image.yml
@@ -1,4 +1,4 @@
-name: "Border images"
+name: Border images
 spec: https://drafts.csswg.org/css-backgrounds-3/#border-images
 caniuse: border-image
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/43

--- a/feature-group-definitions/broadcast-channel.yml
+++ b/feature-group-definitions/broadcast-channel.yml
@@ -1,4 +1,4 @@
-name: "BroadcastChannel"
+name: BroadcastChannel
 spec: https://html.spec.whatwg.org/multipage/web-messaging.html#broadcasting-to-other-browsing-contexts
 caniuse: broadcastchannel
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1447

--- a/feature-group-definitions/canvas-context-lost.yml
+++ b/feature-group-definitions/canvas-context-lost.yml
@@ -1,4 +1,4 @@
-name: "contextlost and contextrestored"
+name: contextlost and contextrestored
 spec: https://html.spec.whatwg.org/multipage/webappapis.html#context-lost-steps
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3974
 status:

--- a/feature-group-definitions/cascade-layers.yml
+++ b/feature-group-definitions/cascade-layers.yml
@@ -1,4 +1,4 @@
-name: "Cascade layers"
+name: Cascade layers
 spec: https://drafts.csswg.org/css-cascade-5/#layering
 caniuse: css-cascade-layers
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4007

--- a/feature-group-definitions/class-syntax.yml
+++ b/feature-group-definitions/class-syntax.yml
@@ -1,4 +1,4 @@
-name: "Classes"
+name: Classes
 caniuse: es6-class
 spec: https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions
 status:

--- a/feature-group-definitions/constraint-validation.yml
+++ b/feature-group-definitions/constraint-validation.yml
@@ -1,4 +1,4 @@
-name: "Constraint validation API"
+name: Constraint validation API
 spec: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api
 caniuse: constraint-validation
 status:

--- a/feature-group-definitions/container-queries.yml
+++ b/feature-group-definitions/container-queries.yml
@@ -1,4 +1,4 @@
-name: "Container queries"
+name: Container queries
 spec: https://drafts.csswg.org/css-contain-3/#container-queries
 caniuse: css-container-queries
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4165

--- a/feature-group-definitions/content-visibility.yml
+++ b/feature-group-definitions/content-visibility.yml
@@ -1,4 +1,4 @@
-name: "content-visibility"
+name: content-visibility
 spec: https://drafts.csswg.org/css-contain-2/#content-visibility
 caniuse: css-content-visibility
 status:

--- a/feature-group-definitions/custom-elements.yml
+++ b/feature-group-definitions/custom-elements.yml
@@ -1,4 +1,4 @@
-name: "Custom elements"
+name: Custom elements
 spec: https://html.spec.whatwg.org/multipage/custom-elements.html
 caniuse: custom-elementsv1
 status:

--- a/feature-group-definitions/custom-properties.yml
+++ b/feature-group-definitions/custom-properties.yml
@@ -1,4 +1,4 @@
-name: "Custom properties"
+name: Custom properties
 spec: https://drafts.csswg.org/css-variables-1/
 caniuse: css-variables
 status:

--- a/feature-group-definitions/document-picture-in-picture.yml
+++ b/feature-group-definitions/document-picture-in-picture.yml
@@ -1,3 +1,3 @@
-name: "Document picture-in-picture"
+name: Document picture-in-picture
 spec: https://wicg.github.io/document-picture-in-picture/
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4397

--- a/feature-group-definitions/edit-context.yml
+++ b/feature-group-definitions/edit-context.yml
@@ -1,2 +1,2 @@
-name: "EditContext"
+name: EditContext
 spec: https://w3c.github.io/edit-context/

--- a/feature-group-definitions/fetch-priority.yml
+++ b/feature-group-definitions/fetch-priority.yml
@@ -1,4 +1,4 @@
-name: "Fetch priority"
+name: Fetch priority
 spec:
   - https://fetch.spec.whatwg.org/#request-priority
   - https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attributes

--- a/feature-group-definitions/flexbox-gap.yml
+++ b/feature-group-definitions/flexbox-gap.yml
@@ -1,3 +1,3 @@
-name: "Flexbox gap"
+name: Flexbox gap
 spec: https://drafts.csswg.org/css-align-3/#gaps
 caniuse: flexbox-gap

--- a/feature-group-definitions/flexbox.yml
+++ b/feature-group-definitions/flexbox.yml
@@ -1,4 +1,4 @@
-name: "Flexbox"
+name: Flexbox
 spec: https://drafts.csswg.org/css-flexbox-1/
 caniuse: flexbox
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1692

--- a/feature-group-definitions/font-variant-alternates.yml
+++ b/feature-group-definitions/font-variant-alternates.yml
@@ -1,4 +1,4 @@
-name: "font-variant-alternates"
+name: font-variant-alternates
 spec: https://drafts.csswg.org/css-fonts-4/#font-variant-alternates-prop
 caniuse: font-variant-alternates
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/738

--- a/feature-group-definitions/fullscreen.yml
+++ b/feature-group-definitions/fullscreen.yml
@@ -1,4 +1,4 @@
-name: "Fullscreen API"
+name: Fullscreen API
 spec: https://fullscreen.spec.whatwg.org/
 caniuse: fullscreen
 compat_features:

--- a/feature-group-definitions/grid-animation.yml
+++ b/feature-group-definitions/grid-animation.yml
@@ -1,4 +1,4 @@
-name: "Grid animation"
+name: Grid animation
 spec: https://drafts.csswg.org/css-grid-2/#track-sizing
 status:
   baseline: low

--- a/feature-group-definitions/grid.yml
+++ b/feature-group-definitions/grid.yml
@@ -1,4 +1,4 @@
-name: "Grid"
+name: Grid
 spec: https://drafts.csswg.org/css-grid-3/
 caniuse: css-grid
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1693

--- a/feature-group-definitions/html-media-capture.yml
+++ b/feature-group-definitions/html-media-capture.yml
@@ -1,4 +1,4 @@
-name: "HTML media capture"
+name: HTML media capture
 spec: https://w3c.github.io/html-media-capture/
 caniuse: html-media-capture
 compat_features:

--- a/feature-group-definitions/idle-detection.yml
+++ b/feature-group-definitions/idle-detection.yml
@@ -1,4 +1,4 @@
-name: "Idle detection"
+name: Idle detection
 spec: https://wicg.github.io/idle-detection/
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2834
 status:

--- a/feature-group-definitions/image-set.yml
+++ b/feature-group-definitions/image-set.yml
@@ -1,3 +1,3 @@
-name: "image-set()"
+name: image-set()
 spec: https://drafts.csswg.org/css-images-4/#image-set-notation
 caniuse: css-image-set

--- a/feature-group-definitions/import-maps.yml
+++ b/feature-group-definitions/import-maps.yml
@@ -1,4 +1,4 @@
-name: "Import maps"
+name: Import maps
 spec: https://html.spec.whatwg.org/multipage/webappapis.html#import-maps
 caniuse: import-maps
 status:

--- a/feature-group-definitions/input-event.yml
+++ b/feature-group-definitions/input-event.yml
@@ -1,4 +1,4 @@
-name: "input event"
+name: input event
 spec: https://w3c.github.io/uievents/#event-type-input
 caniuse: input-event
 status:

--- a/feature-group-definitions/line-clamp.yml
+++ b/feature-group-definitions/line-clamp.yml
@@ -1,4 +1,4 @@
-name: "line-clamp"
+name: line-clamp
 spec: https://drafts.csswg.org/css-overflow-3/#line-clamp
 caniuse: css-line-clamp
 compat_features:

--- a/feature-group-definitions/masonry.yml
+++ b/feature-group-definitions/masonry.yml
@@ -1,4 +1,4 @@
-name: "Masonry"
+name: Masonry
 spec: https://drafts.csswg.org/css-grid-3/
 status:
   baseline: false

--- a/feature-group-definitions/motion-path.yml
+++ b/feature-group-definitions/motion-path.yml
@@ -1,4 +1,4 @@
-name: "Motion path"
+name: Motion path
 spec: https://drafts.fxtf.org/motion-1/
 caniuse: css-motion-paths
 status:

--- a/feature-group-definitions/navigation.yml
+++ b/feature-group-definitions/navigation.yml
@@ -1,2 +1,2 @@
-name: "Navigation API"
+name: Navigation API
 spec: https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api

--- a/feature-group-definitions/nesting.yml
+++ b/feature-group-definitions/nesting.yml
@@ -1,4 +1,4 @@
-name: "Nesting"
+name: Nesting
 spec: https://drafts.csswg.org/css-nesting-1/
 caniuse: css-nesting
 status:

--- a/feature-group-definitions/offscreen-canvas.yml
+++ b/feature-group-definitions/offscreen-canvas.yml
@@ -1,4 +1,4 @@
-name: "Offscreen canvas"
+name: Offscreen canvas
 spec: https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-interface
 caniuse: offscreencanvas
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1624

--- a/feature-group-definitions/overflow-shorthand.yml
+++ b/feature-group-definitions/overflow-shorthand.yml
@@ -1,4 +1,4 @@
-name: "overflow"
+name: overflow
 spec: https://drafts.csswg.org/css-overflow-3/#propdef-overflow
 caniuse: css-overflow
 status:

--- a/feature-group-definitions/picture-in-picture.yml
+++ b/feature-group-definitions/picture-in-picture.yml
@@ -1,4 +1,4 @@
-name: "Picture-in-picture"
+name: Picture-in-picture
 spec: https://w3c.github.io/picture-in-picture/
 caniuse: picture-in-picture
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2444

--- a/feature-group-definitions/popover.yml
+++ b/feature-group-definitions/popover.yml
@@ -1,4 +1,4 @@
-name: "Popover"
+name: Popover
 spec: https://html.spec.whatwg.org/multipage/popover.html
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4191
 status:

--- a/feature-group-definitions/registered-custom-properties.yml
+++ b/feature-group-definitions/registered-custom-properties.yml
@@ -1,4 +1,4 @@
-name: "Registered custom properties"
+name: Registered custom properties
 spec: https://drafts.css-houdini.org/css-properties-values-api-1/
 status:
   baseline: false

--- a/feature-group-definitions/sanitizer.yml
+++ b/feature-group-definitions/sanitizer.yml
@@ -1,2 +1,2 @@
-name: "Sanitizer"
+name: Sanitizer
 spec: https://wicg.github.io/sanitizer-api/

--- a/feature-group-definitions/scheduler.yml
+++ b/feature-group-definitions/scheduler.yml
@@ -1,4 +1,4 @@
-name: "Scheduler API"
+name: Scheduler API
 spec: https://wicg.github.io/scheduling-apis/
 status:
   baseline: false

--- a/feature-group-definitions/scrollintoview.yml
+++ b/feature-group-definitions/scrollintoview.yml
@@ -1,4 +1,4 @@
-name: "scrollIntoView()"
+name: scrollIntoView()
 spec: https://drafts.csswg.org/cssom-view-1/#dom-element-scrollintoview
 caniuse: scrollintoview
 status:

--- a/feature-group-definitions/server-timing.yml
+++ b/feature-group-definitions/server-timing.yml
@@ -1,4 +1,4 @@
-name: "Server timing"
+name: Server timing
 spec: https://w3c.github.io/server-timing/
 caniuse: server-timing
 status:

--- a/feature-group-definitions/set-methods.yml
+++ b/feature-group-definitions/set-methods.yml
@@ -1,4 +1,4 @@
-name: "Set methods"
+name: Set methods
 spec: https://tc39.es/proposal-set-methods/
 status:
   baseline: false

--- a/feature-group-definitions/shadow-dom.yml
+++ b/feature-group-definitions/shadow-dom.yml
@@ -1,4 +1,4 @@
-name: "Shadow DOM"
+name: Shadow DOM
 spec: https://dom.spec.whatwg.org/#shadow-trees
 caniuse: shadowdomv1
 status:

--- a/feature-group-definitions/sticky-positioning.yml
+++ b/feature-group-definitions/sticky-positioning.yml
@@ -1,4 +1,4 @@
-name: "Sticky positioning"
+name: Sticky positioning
 spec: https://drafts.csswg.org/css-position-3/#stickypos-insets
 caniuse: css-sticky
 status:

--- a/feature-group-definitions/storage-buckets.yml
+++ b/feature-group-definitions/storage-buckets.yml
@@ -1,4 +1,4 @@
-name: "Storage buckets"
+name: Storage buckets
 spec: https://wicg.github.io/storage-buckets/
 status:
   baseline: false

--- a/feature-group-definitions/structured-clone.yml
+++ b/feature-group-definitions/structured-clone.yml
@@ -1,4 +1,4 @@
-name: "structuredClone()"
+name: structuredClone()
 spec: https://html.spec.whatwg.org/multipage/structured-data.html#structured-cloning
 status:
   baseline: low

--- a/feature-group-definitions/subgrid.yml
+++ b/feature-group-definitions/subgrid.yml
@@ -1,4 +1,4 @@
-name: "Subgrid"
+name: Subgrid
 spec: https://drafts.csswg.org/css-grid-2/#subgrids
 caniuse: css-subgrid
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4680

--- a/feature-group-definitions/svg2-script-html-equivalence.yml
+++ b/feature-group-definitions/svg2-script-html-equivalence.yml
@@ -1,4 +1,4 @@
-name: "SVG <script> async and defer"
+name: SVG <script> async and defer
 spec: https://svgwg.org/svg2-draft/interact.html#ScriptElement
 status:
   baseline: false

--- a/feature-group-definitions/tabindex.yml
+++ b/feature-group-definitions/tabindex.yml
@@ -1,4 +1,4 @@
-name: "tabindex"
+name: tabindex
 spec: https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex
 caniuse: tabindex-attr
 status:

--- a/feature-group-definitions/temporal.yml
+++ b/feature-group-definitions/temporal.yml
@@ -1,3 +1,3 @@
-name: "Temporal"
+name: Temporal
 spec: https://tc39.es/proposal-temporal/
 caniuse: temporal

--- a/feature-group-definitions/text-box-trim.yml
+++ b/feature-group-definitions/text-box-trim.yml
@@ -1,3 +1,3 @@
-name: "text-box-trim"
+name: text-box-trim
 spec: https://drafts.csswg.org/css-inline-3/#leading-trim
 alias: leading-trim

--- a/feature-group-definitions/text-indent.yml
+++ b/feature-group-definitions/text-indent.yml
@@ -1,4 +1,4 @@
-name: "text-indent"
+name: text-indent
 spec: https://drafts.csswg.org/css-text-3/#text-indent-property
 caniuse: css-text-indent
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/130

--- a/feature-group-definitions/view-transitions.yml
+++ b/feature-group-definitions/view-transitions.yml
@@ -1,4 +1,4 @@
-name: "View transitions"
+name: View transitions
 spec: https://drafts.csswg.org/css-view-transitions-1/
 caniuse: view-transitions
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4383

--- a/feature-group-definitions/viewport-relative-unit-variants.yml
+++ b/feature-group-definitions/viewport-relative-unit-variants.yml
@@ -1,4 +1,4 @@
-name: "sv*, lv*, and dv* viewport units"
+name: sv*, lv*, and dv* viewport units
 spec:
   - https://drafts.csswg.org/css-values-4/#viewport-variants
   - https://drafts.csswg.org/css-values-4/#viewport-relative-lengths

--- a/feature-group-definitions/viewport-relative-units.yml
+++ b/feature-group-definitions/viewport-relative-units.yml
@@ -1,4 +1,4 @@
-name: "vw, vh, vmin, and vmax viewport units"
+name: vw, vh, vmin, and vmax viewport units
 spec: https://drafts.csswg.org/css-values-4/#viewport-relative-lengths
 caniuse: viewport-units
 status:

--- a/feature-group-definitions/web-animations.yml
+++ b/feature-group-definitions/web-animations.yml
@@ -1,4 +1,4 @@
-name: "Web animations"
+name: Web animations
 spec: https://drafts.csswg.org/web-animations-1/
 caniuse: web-animation
 status:

--- a/feature-group-definitions/webcodecs.yml
+++ b/feature-group-definitions/webcodecs.yml
@@ -1,4 +1,4 @@
-name: "WebCodecs"
+name: WebCodecs
 spec: https://w3c.github.io/webcodecs/
 caniuse: webcodecs
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3464

--- a/feature-group-definitions/webdriver-bidi.yml
+++ b/feature-group-definitions/webdriver-bidi.yml
@@ -1,2 +1,2 @@
-name: "WebDriver BiDi"
+name: WebDriver BiDi
 spec: https://w3c.github.io/webdriver-bidi/

--- a/feature-group-definitions/webhid.yml
+++ b/feature-group-definitions/webhid.yml
@@ -1,4 +1,4 @@
-name: "WebHID"
+name: WebHID
 spec: https://wicg.github.io/webhid/
 caniuse: webhid
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2865

--- a/feature-group-definitions/webp.yml
+++ b/feature-group-definitions/webp.yml
@@ -1,4 +1,4 @@
-name: "WebP"
+name: WebP
 spec: https://www.ietf.org/archive/id/draft-zern-webp-13.html
 caniuse: webp
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3797

--- a/feature-group-definitions/webtransport.yml
+++ b/feature-group-definitions/webtransport.yml
@@ -1,4 +1,4 @@
-name: "WebTransport"
+name: WebTransport
 spec: https://w3c.github.io/webtransport/
 caniuse: webtransport
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3472

--- a/feature-group-definitions/webusb.yml
+++ b/feature-group-definitions/webusb.yml
@@ -1,4 +1,4 @@
-name: "WebUSB"
+name: WebUSB
 spec: https://wicg.github.io/webusb/
 caniuse: webusb
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1519

--- a/feature-group-definitions/webvtt.yml
+++ b/feature-group-definitions/webvtt.yml
@@ -1,4 +1,4 @@
-name: "WebVTT"
+name: WebVTT
 spec: https://w3c.github.io/webvtt/
 caniuse: webvtt
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/409


### PR DESCRIPTION
In many cases YAML doesn't need quotes. The rules aren't entirely
trivial, but remove the ones that "feel" unnecessary and leave the
quotes around code starting with some symbol. Some of those probably
aren't needed either.

Prettier doesn't seem to have a setting for this.
