### PR TITLE
Remove import assertions from README

### DIFF
--- a/packages/web-features/README.md
+++ b/packages/web-features/README.md
@@ -10,7 +10,6 @@ npm install web-features
 
 ```js
 import webFeatures from 'web-features';
-// import webFeatures from 'web-features/index.json' assert { type: 'json' }
 ```
 
 ## Rendering Baseline statuses with `web-features`


### PR DESCRIPTION
The syntax has changed, and we don't really need this example.