### PR TITLE
Add experimental snapshot field (not published)

### DIFF
--- a/feature-group-definitions/array-at.yml
+++ b/feature-group-definitions/array-at.yml
@@ -1,5 +1,6 @@
 name: Array at()
 spec: https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.at
+snapshot: ecmascript-2022
 status:
   baseline: low
   baseline_low_date: 2022-03-14

--- a/feature-group-definitions/array-flat.yml
+++ b/feature-group-definitions/array-flat.yml
@@ -1,6 +1,7 @@
 name: Array flat() and flatMap()
 caniuse: array-flat
 spec: https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.flat
+snapshot: ecmascript-2019
 status:
   baseline: high
   baseline_low_date: 2020-01-15

--- a/feature-group-definitions/async-await.yml
+++ b/feature-group-definitions/async-await.yml
@@ -1,6 +1,7 @@
 name: Async functions
 spec: https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-async-function-definitions
 caniuse: async-functions
+snapshot: ecmascript-2017
 status:
   baseline: high
   baseline_low_date: 2017-04-05

--- a/feature-group-definitions/bigint.yml
+++ b/feature-group-definitions/bigint.yml
@@ -1,6 +1,7 @@
 name: BigInt
 spec: https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint-objects
 caniuse: bigint
+snapshot: ecmascript-2020
 status:
   baseline: high
   baseline_low_date: 2020-09-16

--- a/feature-group-definitions/class-syntax.yml
+++ b/feature-group-definitions/class-syntax.yml
@@ -1,6 +1,7 @@
 name: Classes
 caniuse: es6-class
 spec: https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions
+snapshot: ecmascript-2015
 status:
   baseline: high
   baseline_low_date: 2017-03-27

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,8 @@ const monthsFromBaselineLowToHigh = 30;
 // Some FeatureData keys aren't (and may never) be ready for publishing.
 // They're not part of the public schema (yet).
 const omittables = [
-    "description"
+    "description",
+    "snapshot"
 ]
 
 function scrub(data: FeatureData) {


### PR DESCRIPTION
As proposed by @foolip in https://github.com/web-platform-dx/web-features/pull/624#discussion_r1491166953 

I like snapshot tags in BCD: it's easy to find features that very likely belong to the same bundle. I'm not adding more to this PR, but for example for Classes and BigInt, I already see that we could add more BCD compat_features that were introduced in the same ecmascript snapshot.