### PR TITLE
Add Promise features

### DIFF
--- a/feature-group-definitions/promise-allsettled.yml
+++ b/feature-group-definitions/promise-allsettled.yml
@@ -1,5 +1,5 @@
 name: Promise.allSettled()
-description: Promise.allSettled() static method
+description: The Promise.allSettled() static method waits for an array of promises to settle (resolve or reject).
 snapshot: ecmascript-2020
 spec: https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.allsettled
 status:

--- a/feature-group-definitions/promise-allsettled.yml
+++ b/feature-group-definitions/promise-allsettled.yml
@@ -1,0 +1,17 @@
+name: Promise.allSettled()
+description: Promise.allSettled() static method
+snapshot: ecmascript-2020
+spec: https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.allsettled
+status:
+  baseline: high
+  baseline_low_date: 2020-07-28
+  support:
+    chrome: "76"
+    chrome_android: "76"
+    edge: "79"
+    firefox: "71"
+    firefox_android: "79"
+    safari: "13"
+    safari_ios: "13"
+compat_features:
+  - javascript.builtins.Promise.allSettled

--- a/feature-group-definitions/promise-any.yml
+++ b/feature-group-definitions/promise-any.yml
@@ -1,0 +1,17 @@
+name: Promise.any()
+description: Promise.any() static method
+snapshot: ecmascript-2021
+spec: https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.any
+status:
+  baseline: high
+  baseline_low_date: 2020-09-16
+  support:
+    chrome: "85"
+    chrome_android: "85"
+    edge: "85"
+    firefox: "79"
+    firefox_android: "79"
+    safari: "14"
+    safari_ios: "14"
+compat_features:
+  - javascript.builtins.Promise.any

--- a/feature-group-definitions/promise-finally.yml
+++ b/feature-group-definitions/promise-finally.yml
@@ -1,5 +1,6 @@
 name: Promise finally()
 description: Promise finally() method
+caniuse: promise-finally
 snapshot: ecmascript-2018
 spec: https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.prototype.finally
 status:

--- a/feature-group-definitions/promise-finally.yml
+++ b/feature-group-definitions/promise-finally.yml
@@ -1,0 +1,17 @@
+name: Promise finally()
+description: Promise finally() method
+snapshot: ecmascript-2018
+spec: https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.prototype.finally
+status:
+  baseline: high
+  baseline_low_date: 2018-04-12
+  support:
+    chrome: "63"
+    chrome_android: "63"
+    edge: "18"
+    firefox: "58"
+    firefox_android: "58"
+    safari: "11.1"
+    safari_ios: "11.3"
+compat_features:
+  - javascript.builtins.Promise.finally

--- a/feature-group-definitions/promise-withresolvers.yml
+++ b/feature-group-definitions/promise-withresolvers.yml
@@ -10,7 +10,5 @@ status:
     edge: "119"
     firefox: "121"
     firefox_android: "121"
-    safari: "17.4"
-    safari_ios: "17.4"
 compat_features:
   - javascript.builtins.Promise.withResolvers

--- a/feature-group-definitions/promise-withresolvers.yml
+++ b/feature-group-definitions/promise-withresolvers.yml
@@ -1,0 +1,16 @@
+name: Promise.withResolvers()
+description: Promise.withResolvers() static method
+spec: https://tc39.es/proposal-promise-with-resolvers/#sec-promise.withResolvers
+status:
+  baseline: false
+  # baseline_low_date: 2024-<Safari 17.4 release date>
+  support:
+    chrome: "119"
+    chrome_android: "119"
+    edge: "119"
+    firefox: "121"
+    firefox_android: "121"
+    safari: "17.4"
+    safari_ios: "17.4"
+compat_features:
+  - javascript.builtins.Promise.withResolvers

--- a/feature-group-definitions/promises.yml
+++ b/feature-group-definitions/promises.yml
@@ -1,5 +1,5 @@
 name: Promises
-description: Async programming in JavaScript
+description: A promise represents an asynchronous operation which eventually succeeds or fails.
 caniuse: promises
 snapshot: ecmascript-2015
 spec:

--- a/feature-group-definitions/promises.yml
+++ b/feature-group-definitions/promises.yml
@@ -1,5 +1,6 @@
 name: Promises
 description: Async programming in JavaScript
+caniuse: promises
 snapshot: ecmascript-2015
 spec:
   - https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise-objects

--- a/feature-group-definitions/promises.yml
+++ b/feature-group-definitions/promises.yml
@@ -1,0 +1,34 @@
+name: Promises
+description: Async programming in JavaScript
+snapshot: ecmascript-2015
+spec:
+  - https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise-objects
+  - https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-get-promise-@@species
+  - https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise-constructor
+  - https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.all
+  - https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.prototype.catch
+  - https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.race
+  - https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.reject
+  - https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.resolve
+  - https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.prototype.then
+status:
+  baseline: high
+  baseline_low_date: 2015-07-28
+  support:
+    chrome: "32"
+    chrome_android: "32"
+    edge: "12"
+    firefox: "29"
+    firefox_android: "29"
+    safari: "8"
+    safari_ios: "8"
+compat_features:
+  - javascript.builtins.Promise
+  - javascript.builtins.Promise.@@species
+  - javascript.builtins.Promise.Promise
+  - javascript.builtins.Promise.all
+  - javascript.builtins.Promise.catch
+  - javascript.builtins.Promise.race
+  - javascript.builtins.Promise.reject
+  - javascript.builtins.Promise.resolve
+  - javascript.builtins.Promise.then


### PR DESCRIPTION
The tour through ECMAScript continues...
(if we had capability groups, I would connect all _bundles_ in this PR to the _group_ "Promises").

Interesting to me was Promise.withResolvers: BCD records Safari 17.4 already but it is not a released version yet. So, it is not baseline low until we have observed the final release of Safari 17.4 with its release date. It is likely it will be baseline low soon, though.