### PR TITLE
Add Long Animation Frame Timing

### DIFF
--- a/feature-group-definitions/long-animation-frame-timing.yaml
+++ b/feature-group-definitions/long-animation-frame-timing.yaml
@@ -1,2 +1,2 @@
-name: Long Animation Frame Timing
+name: Long animation frame timing
 spec: https://w3c.github.io/longtasks/#sec-loaf-timing

--- a/feature-group-definitions/long-animation-frame-timing.yaml
+++ b/feature-group-definitions/long-animation-frame-timing.yaml
@@ -1,0 +1,2 @@
+name: Long Animation Frame Timing
+spec: https://w3c.github.io/longtasks/#sec-loaf-timing

--- a/feature-group-definitions/navigation-activation.yml
+++ b/feature-group-definitions/navigation-activation.yml
@@ -1,0 +1,2 @@
+name: Navigation Activation
+spec: https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-activation-interface

--- a/feature-group-definitions/navigation-activation.yml
+++ b/feature-group-definitions/navigation-activation.yml
@@ -1,2 +1,2 @@
-name: Navigation Activation
+name: Navigation activation
 spec: https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-activation-interface

--- a/feature-group-definitions/navigation-activation.yml
+++ b/feature-group-definitions/navigation-activation.yml
@@ -1,2 +1,0 @@
-name: Navigation activation
-spec: https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-activation-interface


### PR DESCRIPTION
Another example PR for bundles that could be exported to web-features when we run the OWD BCD collector for new browser versions and new features shipping with them: https://github.com/mdn/browser-compat-data/pull/22280

I'm pretty sure a bundle for "Long Animation Frame Timing" makes sense. 

For "Navigation Activation", I don't know if this part of something larger. It has its own entry on Chromestatus at least.