### PR TITLE
Refactor docs to cover both names and identifiers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,39 +2,58 @@
 
 ## Feature guidelines
 
+### Names
+
+Feature authors should (in descending order of priority):
+
+- Prefer names to known to be in widespread use by web developers.
+  Favor describing things as they are most-widely known, even if it's not the most technically correct option.
+
+  - 👍 Recommended: JavaScript
+  - 👎 Not recommended: ECMAScript
+  - 👍 Recommended: Declarative shadow DOM
+  - 👎 Not recommended: `shadowrootmode` attribute
+
+- Avoid prefixes that mark a feature as specific to a technology, such as CSS, HTML, or JavaScript.
+  Features can and do cross such boundaries.
+
+  - 👍 Recommended: Container queries
+  - 👎 Not recommended: CSS container queries
+  - 👍 Recommended: `<dialog>`
+  - 👎 Not recommended: HTML `<dialog>`
+
+- Avoid frequently-used abbreviations and nouns, such as API and Web.
+
+  - 👍 Recommended: Async clipboard
+  - 👎 Not recommended: Async clipboard API
+  - 👍 Recommended: Workers
+  - 👎 Not recommended: Web workers
+
+- Prefer common, descriptive noun phrases over abbreviations, metonymy, and syntax.
+
+  - 👍 Recommended: Offscreen canvas
+  - 👎 Not recommended: `OffscreenCanvas`
+  - 👍 Recommended: Grid
+  - 👎 Not recommended: `display: grid`
+
+- Prefer shorter names to longer names, as long as they're unique and unambiguous.
+
+  - 👍 Recommended: `:has()`
+  - 👎 Not recommended: `:has()` pseudo-class
+  - 👍 Recommended: `<dialog>`
+  - 👎 Not recommended: `<dialog>` element
+
 ### Identifiers
 
 Feature identifiers must contain only lowercase alphanumeric characters (`a`-`z` and `0-9`) plus the `-` character (hyphen or minus sign) as a word separator.
 
-Feature authors should (in descending order of priority):
+The identifier should match the name, with these additional guidelines:
 
-- Prefer identifiers to known to be in widespread use by web developers.
-  Favor describing things as they are most-widely known, even if it's not the most technically correct option.
+- Prefer shorter identifiers to longer identifiers, by avoiding common and repeated words.
 
-  - 👍 Recommended: `javascript`
-  - 👎 Not recommended: `ecmascript`
-
-- Avoid prefixing identifiers that mark a feature as specific to a technology, such as `css-` or `js-`.
-  Features can and do cross such boundaries.
-
-  - 👍 Recommended: `container-queries`
-  - 👎 Not recommended: `css-container-queries`
-
-- Avoid frequently-used abbreviations and nouns in identifiers, such as `api` or `web`.
-
-  - 👍 Recommended: `navigation`
-  - 👎 Not recommended: `navigation-api`
-
-- Prefer common, descriptive noun phrases over abbreviations, metonymy, and syntax.
-
-  - 👍 Recommended: `offscreen-canvas`
-  - 👎 Not recommended: `offscreencanvas` (as in `OffscreenCanvas`)
-  - 👍 Recommended: `grid`
-  - 👎 Not recommended: `display-grid` (as in `display: grid`)
-
-- Prefer shorter identifiers to longer identifiers, as long as they're unique and unamibguous.
-
-  - 👍 Recommended: `has`
-  - 👎 Not recommended: `has-pseudo-class`
-
-Feature identifiers may use common suffixes (such as `-api`) to resolve naming conflicts.
+  - 👍 Recommended: `aborting`
+  - 👎 Not recommended: `abort-controller-and-abort-signal`
+  - 👍 Recommended: `fullscreen`
+  - 👎 Not recommended: `fullscreen-api`
+  - 👍 Recommended: `user-pseudos`
+  - 👎 Not recommended: `user-valid-and-user-invalid`


### PR DESCRIPTION
Add more examples and document the additional shortening from names to
identifiers that we've done in many cases.
