### PR TITLE
Remove unneeded async keyword in schema validation script

### DIFF
--- a/scripts/schema.ts
+++ b/scripts/schema.ts
@@ -26,7 +26,7 @@ function checkDefsConsistency(): void {
     }
 }
 
-async function validate() {
+function validate() {
     const ajv = new Ajv({allErrors: true, schemas: [defs]});
     addFormats(ajv);
 


### PR DESCRIPTION
Because validate() was called without awaiting the result, if validate()
was actually async and would fail after some time, this script would
exit with success before that happened.
