### PR TITLE
Add snapshots as YAML files to track name/spec

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -17,28 +17,43 @@ const omittables = [
     "snapshot"
 ]
 
-function scrub(data: FeatureData) {
+function scrub(data: any) {
     for (const key of omittables) {
         delete data[key];
     }
-    return data;
+    return data as FeatureData;
 }
 
-const filePaths = new fdir()
-    .withBasePath()
-    .filter((fp) => fp.endsWith('.yml'))
-    .crawl('feature-group-definitions')
-    .sync() as string[];
+function* yamlEntries(root: string): Generator<[string, any]> {
+    const filePaths = new fdir()
+        .withBasePath()
+        .filter((fp) => fp.endsWith('.yml'))
+        .crawl(root)
+        .sync() as string[];
+
+    for (const fp of filePaths) {
+        // The feature identifier/key is the filename without extension.
+        const key = path.parse(fp).name;
+
+        const src = fs.readFileSync(fp, { encoding: 'utf-8'});
+        const data = YAML.parse(src);
+
+        yield [key, data];
+    }
+}
+
+// Load snapshots first so that snapshot identifiers can be validated while
+// loading features.
+const snapshots: { [key: string]: any } = {};
+
+for (const [key, data] of yamlEntries('snapshots')) {
+    // Note that the data is unused and unvalidated for now.
+    snapshots[key] = data;
+}
 
 const features: { [key: string]: FeatureData } = {};
 
-for (const fp of filePaths) {
-    // The feature identifier/key is the filename without extension.
-    const key = path.parse(fp).name;
-
-    const src = fs.readFileSync(fp, { encoding: 'utf-8'});
-    const data = YAML.parse(src) as FeatureData;
-
+for (const [key, data] of yamlEntries('feature-group-definitions')) {
     // Compute Baseline high date from low date.
     if (data.status?.baseline_high_date) {
         throw new Error(`baseline_high_date is computed and should not be used in source YAML. Remove it from ${key}.yml.`);
@@ -47,6 +62,11 @@ for (const fp of filePaths) {
         const lowDate = Temporal.PlainDate.from(data.status.baseline_low_date);
         const highDate = lowDate.add({ months: monthsFromBaselineLowToHigh });
         data.status.baseline_high_date = String(highDate);
+    }
+
+    // Ensure that only known snapshot identifiers are used.
+    if (data.snapshot && !Object.hasOwn(snapshots, data.snapshot)) {
+        throw new Error(`snapshot ${data.snapshot} used in ${key}.yml is not a valid snapshot. Add it to snapshots/ if needed.`);
     }
 
     features[key] = scrub(data);

--- a/snapshots/ecmascript-1.yml
+++ b/snapshots/ecmascript-1.yml
@@ -1,0 +1,2 @@
+name: ECMAScript
+spec: https://ecma-international.org/wp-content/uploads/ECMA-262_1st_edition_june_1997.pdf

--- a/snapshots/ecmascript-2015.yml
+++ b/snapshots/ecmascript-2015.yml
@@ -1,0 +1,2 @@
+name: ECMAScript 2015
+spec: https://262.ecma-international.org/6.0/

--- a/snapshots/ecmascript-2016.yml
+++ b/snapshots/ecmascript-2016.yml
@@ -1,0 +1,2 @@
+name: ECMAScript 2016
+spec: https://262.ecma-international.org/7.0/

--- a/snapshots/ecmascript-2017.yml
+++ b/snapshots/ecmascript-2017.yml
@@ -1,0 +1,2 @@
+name: ECMAScript 2017
+spec: https://262.ecma-international.org/8.0/

--- a/snapshots/ecmascript-2018.yml
+++ b/snapshots/ecmascript-2018.yml
@@ -1,0 +1,2 @@
+name: ECMAScript 2018
+spec: https://262.ecma-international.org/9.0/

--- a/snapshots/ecmascript-2019.yml
+++ b/snapshots/ecmascript-2019.yml
@@ -1,0 +1,2 @@
+name: ECMAScript 2019
+spec: https://262.ecma-international.org/10.0/

--- a/snapshots/ecmascript-2020.yml
+++ b/snapshots/ecmascript-2020.yml
@@ -1,0 +1,2 @@
+name: ECMAScript 2020
+spec: https://262.ecma-international.org/11.0/

--- a/snapshots/ecmascript-2021.yml
+++ b/snapshots/ecmascript-2021.yml
@@ -1,0 +1,2 @@
+name: ECMAScript 2021
+spec: https://262.ecma-international.org/12.0/

--- a/snapshots/ecmascript-2022.yml
+++ b/snapshots/ecmascript-2022.yml
@@ -1,0 +1,2 @@
+name: ECMAScript 2022
+spec: https://262.ecma-international.org/13.0/

--- a/snapshots/ecmascript-2023.yml
+++ b/snapshots/ecmascript-2023.yml
@@ -1,0 +1,2 @@
+name: ECMAScript 2023
+spec: https://262.ecma-international.org/14.0/

--- a/snapshots/ecmascript-5.yml
+++ b/snapshots/ecmascript-5.yml
@@ -1,0 +1,2 @@
+name: ECMAScript 5.1
+spec: https://262.ecma-international.org/5.1/


### PR DESCRIPTION
This also ensures that only snapshots which are defined can be used by a
feature.

Snapshots are still not published, and this does not affect the built
JSON at all.
