### PR TITLE
Update Baseline dates to refect Edge 12 release date

### DIFF
--- a/feature-group-definitions/array-isarray.yml
+++ b/feature-group-definitions/array-isarray.yml
@@ -4,7 +4,7 @@ spec: https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.isarr
 snapshot: ecmascript-5
 status:
   baseline: high
-  baseline_low_date: 2015-07-28
+  baseline_low_date: 2015-07-29
   support:
     chrome: "4"
     chrome_android: "18"

--- a/feature-group-definitions/array-iteration-methods.yml
+++ b/feature-group-definitions/array-iteration-methods.yml
@@ -13,7 +13,7 @@ spec:
 snapshot: ecmascript-5
 status:
   baseline: high
-  baseline_low_date: 2015-07-28
+  baseline_low_date: 2015-07-29
   support:
     chrome: "1"
     chrome_android: "18"

--- a/feature-group-definitions/array-splice.yml
+++ b/feature-group-definitions/array-splice.yml
@@ -4,7 +4,7 @@ spec: https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.proto
 snapshot: ecmascript-2015
 status:
   baseline: high
-  baseline_low_date: 2015-07-28
+  baseline_low_date: 2015-07-29
   support:
     chrome: "1"
     chrome_android: "18"

--- a/feature-group-definitions/array.yml
+++ b/feature-group-definitions/array.yml
@@ -19,7 +19,7 @@ spec:
 snapshot: ecmascript-1
 status:
   baseline: high
-  baseline_low_date: 2015-07-28
+  baseline_low_date: 2015-07-29
   support:
     chrome: "1"
     chrome_android: "18"

--- a/feature-group-definitions/text-indent.yml
+++ b/feature-group-definitions/text-indent.yml
@@ -4,7 +4,7 @@ caniuse: css-text-indent
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/130
 status:
   baseline: high
-  baseline_low_date: 2015-07-28
+  baseline_low_date: 2015-07-29
   support:
     chrome: "1"
     chrome_android: "18"

--- a/feature-group-definitions/typed-arrays.yml
+++ b/feature-group-definitions/typed-arrays.yml
@@ -21,7 +21,7 @@ spec:
 snapshot: ecmascript-2015
 status:
   baseline: high
-  baseline_low_date: 2015-07-28
+  baseline_low_date: 2015-07-29
   support:
     chrome: "7"
     chrome_android: "18"


### PR DESCRIPTION
This was updated in BCD in https://github.com/mdn/browser-compat-data/pull/22286.
