### PR TITLE
Use (initial support) as the suffix for "basic" features

### DIFF
--- a/feature-group-definitions/array.yml
+++ b/feature-group-definitions/array.yml
@@ -1,5 +1,5 @@
-name: Arrays
-description: Basic JavaScript arrays
+name: Arrays (initial support)
+description: Arrays are ordered lists of JavaScript values.
 spec:
   - https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array-objects
   - https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array-constructor

--- a/feature-group-definitions/typed-arrays.yml
+++ b/feature-group-definitions/typed-arrays.yml
@@ -1,5 +1,5 @@
-name: Typed arrays
-description: Basic typed arrays
+name: Typed arrays (initial support)
+description: "Typed arrays are ordered lists of JavaScript values, where all values are of the same numerical type, for example 8-bit integers or 32-bit floating point numbers."
 spec:
   - https://tc39.es/ecma262/multipage/indexed-collections.html#table-49
   - https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors


### PR DESCRIPTION
This puts the suffix in the short name as it will be needed to
disambiguate the feature in a list of short names. This made it
necessary to write new descriptions, and an attempt was made.
