### PR TITLE
Rename the SVG <script> async/defer feature

### DIFF
--- a/feature-group-definitions/svg-async-defer.yml
+++ b/feature-group-definitions/svg-async-defer.yml
@@ -1,4 +1,5 @@
 name: SVG <script> async and defer
+alias: svg2-script-html-equivalence
 spec: https://svgwg.org/svg2-draft/interact.html#ScriptElement
 status:
   baseline: false


### PR DESCRIPTION
The type="module" support makes more sense as part of JS modules:
https://github.com/web-platform-dx/web-features/pull/676
