### PR TITLE
Adding the Web MIDI API feature

### DIFF
--- a/feature-group-definitions/midi.yml
+++ b/feature-group-definitions/midi.yml
@@ -1,4 +1,4 @@
-name: Midi
+name: MIDI
 description: The Web MIDI API enables selecting MIDI input and output devices and sending and receiving MIDI messages.
 spec: https://webaudio.github.io/web-midi-api/
 caniuse: midi

--- a/feature-group-definitions/midi.yml
+++ b/feature-group-definitions/midi.yml
@@ -1,0 +1,4 @@
+name: Midi
+description: The Web MIDI API enables selecting MIDI input and output devices and sending and receiving MIDI messages.
+spec: https://webaudio.github.io/web-midi-api/
+caniuse: midi

--- a/feature-group-definitions/web-midi.yml
+++ b/feature-group-definitions/web-midi.yml
@@ -1,4 +1,4 @@
-name: MIDI
+name: Web MIDI
 description: The Web MIDI API enables selecting MIDI input and output devices and sending and receiving MIDI messages.
 spec: https://webaudio.github.io/web-midi-api/
 caniuse: midi


### PR DESCRIPTION
This depends on https://github.com/mdn/browser-compat-data/pull/22626 which adds the `web-features:midi` tag to the corresponding BCD entries.