### PR TITLE
Adding the Web Bluetooth API feature

### DIFF
--- a/feature-group-definitions/bluetooth.yml
+++ b/feature-group-definitions/bluetooth.yml
@@ -1,0 +1,4 @@
+name: bluetooth
+description: The Web Bluetooth API allows to communicate over GATT with nearby user-selected Bluetooth devices.
+spec: https://webbluetoothcg.github.io/web-bluetooth/
+caniuse: web-bluetooth

--- a/feature-group-definitions/bluetooth.yml
+++ b/feature-group-definitions/bluetooth.yml
@@ -1,4 +1,4 @@
 name: bluetooth
-description: The Web Bluetooth API allows to communicate over GATT with nearby user-selected Bluetooth devices.
+description: The Web Bluetooth API enables selecting and communicating with nearby Bluetooth devices.
 spec: https://webbluetoothcg.github.io/web-bluetooth/
 caniuse: web-bluetooth

--- a/feature-group-definitions/web-bluetooth.yml
+++ b/feature-group-definitions/web-bluetooth.yml
@@ -1,4 +1,4 @@
-name: bluetooth
+name: Web Bluetooth
 description: The Web Bluetooth API enables selecting and communicating with nearby Bluetooth devices.
 spec: https://webbluetoothcg.github.io/web-bluetooth/
 caniuse: web-bluetooth


### PR DESCRIPTION
This depends on https://github.com/mdn/browser-compat-data/pull/22627 which introduces the `web-features:bluetooth` tag to the corresponding BCD entries.