### PR TITLE
Rename read-write-pseudo-classes to read-write-pseudos

### DIFF
--- a/feature-group-definitions/read-write-pseudos.yml
+++ b/feature-group-definitions/read-write-pseudos.yml
@@ -2,6 +2,7 @@ name: ":read and :write"
 spec:
   - https://html.spec.whatwg.org/multipage/semantics-other.html#selector-read-only
   - https://drafts.csswg.org/selectors-4/#rw-pseudos
+alias: read-write-pseudo-classes
 caniuse: css-read-only-write
 status:
   baseline: high


### PR DESCRIPTION
This is a shorter name, and matches the style of user-pseudos: https://github.com/web-platform-dx/web-features/blob/main/feature-group-definitions/user-pseudos.yml