### PR TITLE
Rename scrollintoview to scroll-into-view

### DIFF
--- a/feature-group-definitions/scroll-into-view.yml
+++ b/feature-group-definitions/scroll-into-view.yml
@@ -1,5 +1,6 @@
 name: scrollIntoView()
 spec: https://drafts.csswg.org/cssom-view-1/#dom-element-scrollintoview
+alias: scrollintoview
 caniuse: scrollintoview
 status:
   baseline: high


### PR DESCRIPTION
Hyphenation of identifiers is not covered by our guidlines, but it is the emergent convention for other features named after methods, like checkVisibility() structuredClone().