### PR TITLE
Rename and restore the SVG <script> parity feature

### DIFF
--- a/feature-group-definitions/svg-script-parity.yml
+++ b/feature-group-definitions/svg-script-parity.yml
@@ -1,4 +1,5 @@
-name: SVG <script> async and defer
+name: SVG <script> parity with HTML
+details: 'SVG `<script>` elememt support for `async`, `defer`, and `type="module"` like in HTML'
 spec: https://svgwg.org/svg2-draft/interact.html#ScriptElement
 status:
   baseline: false
@@ -10,3 +11,4 @@ compat_features:
   - api.SVGScriptElement.defer
   - svg.elements.script.async
   - svg.elements.script.defer
+  - svg.elements.script.type.module

--- a/feature-group-definitions/svg-script-parity.yml
+++ b/feature-group-definitions/svg-script-parity.yml
@@ -1,5 +1,5 @@
 name: SVG <script> parity with HTML
-details: 'SVG `<script>` elememt support for `async`, `defer`, and `type="module"` like in HTML'
+description: 'SVG `<script>` elememt support for `async`, `defer`, and `type="module"` like in HTML'
 spec: https://svgwg.org/svg2-draft/interact.html#ScriptElement
 status:
   baseline: false


### PR DESCRIPTION
An alternative to https://github.com/web-platform-dx/web-features/pull/677.