### PR TITLE
Suggest-a-spec

### DIFF
--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -51,6 +51,20 @@ function testIsOK() {
 };
 testIsOK();
 
+
+/**
+ * Print an array of potential spec URLs.
+ */
+function suggestSpecs(bad: URL): void {
+    const searchBy = bad.pathname.replaceAll("/", "");
+    const suggestions = specUrls.filter((specUrl) => specUrl.toString().includes(searchBy)).map(u => `- ${u}`);
+    if (suggestions.length > 0) {
+        console.warn("Did you mean one of these?");
+        console.warn(`${suggestions.join('\n')}`);
+        console.warn();
+    }
+}
+
 let checked = 0;
 let errors = 0;
 
@@ -69,6 +83,7 @@ for (const [id, data] of Object.entries(features)) {
         const url = new URL(spec);
         if (!isOK(url)) {
             console.error(`URL for ${id} not in web-specs: ${url.toString()}`);
+            suggestSpecs(url)
             errors++;
         }
         checked++;

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -83,7 +83,7 @@ for (const [id, data] of Object.entries(features)) {
         const url = new URL(spec);
         if (!isOK(url)) {
             console.error(`URL for ${id} not in web-specs: ${url.toString()}`);
-            suggestSpecs(url)
+            suggestSpecs(url);
             errors++;
         }
         checked++;


### PR DESCRIPTION
I am often forgetting to set the level for CSS specs. This does an OK job of suggesting something better in those cases. We might extend this further to catch typos and the like.