### PR TITLE
Add `counter-style`

### DIFF
--- a/feature-group-definitions/counter-style.yml
+++ b/feature-group-definitions/counter-style.yml
@@ -1,0 +1,28 @@
+name: "@counter-style"
+description: The `@counter-style` CSS at-rule defines custom counter styles for list items. For example, you can use a sequence of specific symbols instead of numbers for an ordered list.
+spec: https://drafts.csswg.org/css-counter-styles-3/
+caniuse: css-at-counter-style
+compat_features:
+  - css.at-rules.counter-style
+  - css.at-rules.counter-style.additive-symbols
+  - css.at-rules.counter-style.fallback
+  - css.at-rules.counter-style.negative
+  - css.at-rules.counter-style.pad
+  - css.at-rules.counter-style.prefix
+  - css.at-rules.counter-style.range
+  - css.at-rules.counter-style.speak-as
+  - css.at-rules.counter-style.suffix
+  - css.at-rules.counter-style.symbols
+  - css.at-rules.counter-style.system
+  - api.CSSCounterStyleRule
+  - api.CSSCounterStyleRule.additiveSymbols
+  - api.CSSCounterStyleRule.fallback
+  - api.CSSCounterStyleRule.name
+  - api.CSSCounterStyleRule.negative
+  - api.CSSCounterStyleRule.pad
+  - api.CSSCounterStyleRule.prefix
+  - api.CSSCounterStyleRule.range
+  - api.CSSCounterStyleRule.speakAs
+  - api.CSSCounterStyleRule.suffix
+  - api.CSSCounterStyleRule.symbols
+  - api.CSSCounterStyleRule.system


### PR DESCRIPTION
Note that when we set a status for this one, it might get a little weird: BCD says `speak-as` is not widely supported, but I'm not sure that's correct (e.g., I couldn't find a webkit bug about it). The rest of this seems boring and unobjectionable.