### PR TITLE
promise-withresolvers: Baseline low as of 2024-03-05

### DIFF
--- a/feature-group-definitions/promise-withresolvers.yml
+++ b/feature-group-definitions/promise-withresolvers.yml
@@ -10,5 +10,7 @@ status:
     edge: "119"
     firefox: "121"
     firefox_android: "121"
+    safari: "17.4"
+    safari_ios: "17.4"
 compat_features:
   - javascript.builtins.Promise.withResolvers

--- a/feature-group-definitions/promise-withresolvers.yml
+++ b/feature-group-definitions/promise-withresolvers.yml
@@ -2,8 +2,8 @@ name: Promise.withResolvers()
 description: Promise.withResolvers() static method
 spec: https://tc39.es/proposal-promise-with-resolvers/#sec-promise.withResolvers
 status:
-  baseline: false
-  # baseline_low_date: 2024-<Safari 17.4 release date>
+  baseline: low
+  baseline_low_date: 2024-03-05
   support:
     chrome: "119"
     chrome_android: "119"


### PR DESCRIPTION
Safari 17.4 has been out since March 5, so it's now Baseline low.