### PR TITLE
Only allow specs in "good" standing

### DIFF
--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -4,16 +4,20 @@ import webSpecs from 'web-specs' assert { type: 'json' };
 
 import features from '../index.js';
 
-// Allowed spec URLs are nightly URLs from web-specs, or the snapshot/versioned URL
-// if a nightly does not exist:
+// Specs needs to be in "good standing". Nightly URLs are used if available,
+// otherwise the snapshot/versioned URL is used. See browser-specs/web-specs
+// docs for more details:
+// https://github.com/w3c/browser-specs/blob/main/README.md#standing
 // https://github.com/w3c/browser-specs/blob/main/README.md#nightly
 // https://github.com/w3c/browser-specs/blob/main/README.md#url
-const specUrls: URL[] = webSpecs.flatMap(spec => {
-    return [
-        new URL(spec.nightly?.url ?? spec.url),
-        ...(spec.nightly?.pages ?? []).map(page => new URL(page))
-    ]
-});
+const specUrls: URL[] = webSpecs
+    .filter((spec) => spec.standing === 'good')
+    .flatMap(spec => {
+        return [
+            new URL(spec.nightly?.url ?? spec.url),
+            ...(spec.nightly?.pages ?? []).map(page => new URL(page))
+        ]
+    });
 
 type allowlistItem = [url: string, message: string];
 const defaultAllowlist: allowlistItem[] = [


### PR DESCRIPTION
https://github.com/w3c/browser-specs/blob/main/README.md#standing

There are no exceptions to this rule now, but exceptions could still be
made via defaultAllowlist.

BCD also has this rule:
https://github.com/mdn/browser-compat-data/blob/fd1cb702c59712fc3ef2056ed3a846292e3ae8c3/test/linter/test-spec-urls.ts#L43
