### PR TITLE
Update `spec` link for Relative colors

### DIFF
--- a/feature-group-definitions/relative-color.yml
+++ b/feature-group-definitions/relative-color.yml
@@ -1,6 +1,6 @@
 name: Relative colors
 description: "The `from` keyword for color functions (`color()`, `hsl()`, `oklch()`, etc.) creates a new color based on a given color by modifying the values of the input color. Also known as relative color syntax (RCS)."
-spec: https://drafts.csswg.org/css-color-5/#relative-color-function
+spec: https://drafts.csswg.org/css-color-5/#relative-colors
 caniuse: css-relative-colors
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4632
 compat_features:


### PR DESCRIPTION
Section `5.1` is only about `color(from ...)`.

While section `4` is a better general introduction to relative colors.

`https://drafts.csswg.org/css-color-5/#relative-colors` links to section `4`