### PR TITLE
Migrate compat keys for cap/ic/lh to BCD tags

### DIFF
--- a/feature-group-definitions/cap.yml
+++ b/feature-group-definitions/cap.yml
@@ -1,7 +1,3 @@
 name: cap unit
 description: The CSS `cap` unit corresponds to the height of Latin capital letters.
 spec: https://drafts.csswg.org/css-values-4/#cap
-compat_features:
-  - api.CSS.cap_static
-  - css.types.length-percentage.cap
-  - css.types.length.cap

--- a/feature-group-definitions/ic.yml
+++ b/feature-group-definitions/ic.yml
@@ -1,7 +1,3 @@
 name: ic unit
 description: The CSS `ic` unit corresponds to the width of CJK ideographic characters.
 spec: https://drafts.csswg.org/css-values-4/#ic
-compat_features:
-  - api.CSS.ic_static
-  - css.types.length-percentage.ic
-  - css.types.length.ic

--- a/feature-group-definitions/lh.yml
+++ b/feature-group-definitions/lh.yml
@@ -1,7 +1,3 @@
 name: lh unit
 description: The CSS `lh` unit corresponds to the requested line height, the computed value of the `line-height` property. Some lines may be higher than this based on their content.
 spec: https://drafts.csswg.org/css-values-4/#lh
-compat_features:
-  - api.CSS.lh_static
-  - css.types.length-percentage.lh
-  - css.types.length.lh


### PR DESCRIPTION
Tags added in https://github.com/mdn/browser-compat-data/pull/22697.

Fixes https://github.com/web-platform-dx/web-features/issues/730.
