### PR TITLE
Adding missing descriptions and making them mandatory/published

### DIFF
--- a/feature-group-definitions/aborting.yml
+++ b/feature-group-definitions/aborting.yml
@@ -1,5 +1,5 @@
 name: AbortController and AbortSignal
-description: AbortController and AbortSignal are used by certain Web APIs as a mechanism to allow aborting asynchronous operations, such as fetch requests.
+description: The `AbortController` and `AbortSignal` interfaces allow you to cancel an ongoing operation, such as a `fetch()` request.
 spec: https://dom.spec.whatwg.org/#aborting-ongoing-activities
 caniuse: abortcontroller
 compat_features:

--- a/feature-group-definitions/aborting.yml
+++ b/feature-group-definitions/aborting.yml
@@ -1,4 +1,5 @@
 name: AbortController and AbortSignal
+description: AbortController and AbortSignal are used by certain Web APIs as a mechanism to allow aborting asynchronous operations, such as fetch requests.
 spec: https://dom.spec.whatwg.org/#aborting-ongoing-activities
 caniuse: abortcontroller
 compat_features:

--- a/feature-group-definitions/array-group.yml
+++ b/feature-group-definitions/array-group.yml
@@ -1,4 +1,5 @@
 name: Array grouping
+description: The `Object.groupBy()` and `Map.groupBy()` static methods group elements of iterables based on a function that returns a key for each element of the iterable.
 spec: https://tc39.es/proposal-array-grouping/
 group: maps
 status:

--- a/feature-group-definitions/async-await.yml
+++ b/feature-group-definitions/async-await.yml
@@ -1,4 +1,5 @@
 name: Async functions
+description: The `async` and `await` keywords enable the asynchronous, promise-based behavior of a function to be written without using promise chains.
 spec: https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-async-function-definitions
 caniuse: async-functions
 snapshot: ecmascript-2017

--- a/feature-group-definitions/async-clipboard.yml
+++ b/feature-group-definitions/async-clipboard.yml
@@ -1,4 +1,5 @@
 name: Async clipboard
+description: The Clipboard API provides asynchronous read and write access to the content of the system clipboard, by requesting permission from the user.
 spec: https://w3c.github.io/clipboard-apis/#async-clipboard-api
 caniuse: async-clipboard
 status:

--- a/feature-group-definitions/avif.yml
+++ b/feature-group-definitions/avif.yml
@@ -1,4 +1,5 @@
 name: AVIF
+description: The AV1 Image File Format (AVIF) is an image format specification for storing images or image sequences compressed with AV1.
 spec: https://aomediacodec.github.io/av1-avif/
 caniuse: avif
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3798

--- a/feature-group-definitions/backdrop-filter.yml
+++ b/feature-group-definitions/backdrop-filter.yml
@@ -1,4 +1,5 @@
 name: backdrop-filter
+description: The `backdrop-filter` CSS property applies graphical effects such as blurring or color shifting to the area behind an element.
 spec: https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty
 caniuse: css-backdrop-filter
 compat_features:

--- a/feature-group-definitions/background-fetch.yml
+++ b/feature-group-definitions/background-fetch.yml
@@ -1,4 +1,5 @@
 name: Background fetch
+description: The Background Fetch API allows service workers to delegate downloading large amounts of data to the system, even when the web page is closed.
 spec: https://wicg.github.io/background-fetch/
 status:
   baseline: false

--- a/feature-group-definitions/background-gradients.yml
+++ b/feature-group-definitions/background-gradients.yml
@@ -1,4 +1,5 @@
 name: Background gradients
+description: The CSS gradient functions create background images consisting of progressive transitions between two or more colors.
 spec: https://drafts.csswg.org/css-images-4/#gradients
 caniuse:
   - css-gradients

--- a/feature-group-definitions/bigint.yml
+++ b/feature-group-definitions/bigint.yml
@@ -1,4 +1,5 @@
 name: BigInt
+description: BigInt is a built-in JavaScript type that represents numeric values which are too large to be represented by the Number type.
 spec: https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint-objects
 caniuse: bigint
 snapshot: ecmascript-2020

--- a/feature-group-definitions/border-image.yml
+++ b/feature-group-definitions/border-image.yml
@@ -1,4 +1,5 @@
 name: Border images
+description: The `border-image` CSS property draws an image around an element's border.
 spec: https://drafts.csswg.org/css-backgrounds-3/#border-images
 caniuse: border-image
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/43

--- a/feature-group-definitions/broadcast-channel.yml
+++ b/feature-group-definitions/broadcast-channel.yml
@@ -1,4 +1,5 @@
 name: BroadcastChannel
+description: The BroadcastChannel API allows communication between different browser contexts, such as tabs, windows, or iframes, and workers on the same origin.
 spec: https://html.spec.whatwg.org/multipage/web-messaging.html#broadcasting-to-other-browsing-contexts
 caniuse: broadcastchannel
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1447

--- a/feature-group-definitions/broadcast-channel.yml
+++ b/feature-group-definitions/broadcast-channel.yml
@@ -1,5 +1,5 @@
 name: BroadcastChannel
-description: The BroadcastChannel API allows communication between different browser contexts, such as tabs, windows, or iframes, and workers on the same origin.
+description: The `BroadcastChannel` interface allows you to send messages between same-origin browsing contexts, such as between the same page loaded in multiple tabs.
 spec: https://html.spec.whatwg.org/multipage/web-messaging.html#broadcasting-to-other-browsing-contexts
 caniuse: broadcastchannel
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1447

--- a/feature-group-definitions/canvas-context-lost.yml
+++ b/feature-group-definitions/canvas-context-lost.yml
@@ -1,4 +1,5 @@
 name: contextlost and contextrestored
+description: The `contextlost` and `contextrestored` events are fired on a canvas element when the rendering context is lost or restored, such as when a graphics device crashes or runs out of memory.
 spec: https://html.spec.whatwg.org/multipage/webappapis.html#context-lost-steps
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3974
 status:

--- a/feature-group-definitions/cascade-layers.yml
+++ b/feature-group-definitions/cascade-layers.yml
@@ -1,4 +1,5 @@
 name: Cascade layers
+description: CSS Cascade Layers solve CSS rule specificity conflicts by providing priority levels for different groups of CSS rules, such as low-priority styles like resets, and high-priority styles like UI components.
 spec: https://drafts.csswg.org/css-cascade-5/#layering
 caniuse: css-cascade-layers
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4007

--- a/feature-group-definitions/check-visibility.yml
+++ b/feature-group-definitions/check-visibility.yml
@@ -1,4 +1,5 @@
 name: checkVisibility()
+description: The `Element.checkVisibility()` method checks if an element is visible.
 spec: https://drafts.csswg.org/cssom-view-1/#dom-element-checkvisibility
 compat_features:
   - api.Element.checkVisibility

--- a/feature-group-definitions/class-syntax.yml
+++ b/feature-group-definitions/class-syntax.yml
@@ -1,4 +1,5 @@
 name: Classes
+description: The `class` JavaScript keyword defines a new class, which is a type of function that can be instantiated multiple times by using the `new` keyword.
 caniuse: es6-class
 spec: https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions
 snapshot: ecmascript-2015

--- a/feature-group-definitions/colrv1.yml
+++ b/feature-group-definitions/colrv1.yml
@@ -1,4 +1,5 @@
 name: COLRv1
+description: The COLRv1 font format is used by color fonts to support multi-color glyphs.
 spec: https://www.iso.org/standard/87621.html
 caniuse: colr-v1
 compat_features:

--- a/feature-group-definitions/compression-streams.yml
+++ b/feature-group-definitions/compression-streams.yml
@@ -1,4 +1,5 @@
 name: Compression streams
+description: The JavaScript Compression Streams API compresses and decompresses streams of data using the gzip or deflate formats.
 spec: https://wicg.github.io/compression/
 usage_stats:
   - https://chromestatus.com/metrics/feature/timeline/popularity/3060 # CompressionStream

--- a/feature-group-definitions/constraint-validation.yml
+++ b/feature-group-definitions/constraint-validation.yml
@@ -1,4 +1,5 @@
 name: Constraint validation API
+description: The Constraint Validation API provides a programmatic way to validate form controls.
 spec: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api
 caniuse: constraint-validation
 status:

--- a/feature-group-definitions/contain-intrinsic-size.yml
+++ b/feature-group-definitions/contain-intrinsic-size.yml
@@ -1,4 +1,5 @@
 name: contain-intrinsic-size
+description: The `contain-intrinsic-size` CSS property sets the size of an element that the browser will use for layout calculations when the element is subject to size containment, within a CSS query container.
 spec: https://drafts.csswg.org/css-sizing-4/#intrinsic-size-override
 # Shown as "intrinsic-size" on chromestatus.com, but 651 is contain-intrinsic-size.
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/651

--- a/feature-group-definitions/container-queries.yml
+++ b/feature-group-definitions/container-queries.yml
@@ -1,4 +1,5 @@
 name: Container queries
+description: CSS container queries apply styles to an element based on the size of its container.
 spec: https://drafts.csswg.org/css-contain-3/#container-queries
 caniuse: css-container-queries
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4165

--- a/feature-group-definitions/container-style-queries.yml
+++ b/feature-group-definitions/container-style-queries.yml
@@ -1,4 +1,5 @@
 name: Container style queries
+description: CSS style container queries apply styles to an element based on the computed styles of its container.
 spec: https://drafts.csswg.org/css-contain-3/#style-container
 caniuse: css-container-queries-style
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4550

--- a/feature-group-definitions/content-visibility.yml
+++ b/feature-group-definitions/content-visibility.yml
@@ -1,4 +1,5 @@
 name: content-visibility
+description: The `content-visibility` CSS property controls whether the browser should skip an element's rendering, including layout and painting, until it is needed.
 spec: https://drafts.csswg.org/css-contain-2/#content-visibility
 caniuse: css-content-visibility
 status:

--- a/feature-group-definitions/custom-elements.yml
+++ b/feature-group-definitions/custom-elements.yml
@@ -1,4 +1,5 @@
 name: Custom elements
+description: Custom elements are HTML elements whose behavior is defined by the web developer.
 spec: https://html.spec.whatwg.org/multipage/custom-elements.html
 caniuse: custom-elementsv1
 status:

--- a/feature-group-definitions/custom-properties.yml
+++ b/feature-group-definitions/custom-properties.yml
@@ -1,4 +1,5 @@
 name: Custom properties
+description: Custom properties (also known as CSS variables) are CSS properties prefixed with `--`, and whose values can be reused throughout CSS rules by using the `var()` function.
 spec: https://drafts.csswg.org/css-variables-1/
 caniuse: css-variables
 status:

--- a/feature-group-definitions/default.yml
+++ b/feature-group-definitions/default.yml
@@ -1,4 +1,5 @@
 name: ":default"
+description: The `:default` CSS pseudo-class selects form elements that are the default in a group of related elements, such as radio input elements which are initially checked, or option elements which are initially checked.
 spec: https://drafts.csswg.org/selectors-4/#the-default-pseudo
 caniuse: css-default-pseudo
 status:

--- a/feature-group-definitions/details-name.yml
+++ b/feature-group-definitions/details-name.yml
@@ -1,4 +1,5 @@
 name: Mutually exclusive <details> elements
+description: Multiple `<details>` elements which use the same `name` attribute are mutually exclusive. When one member of the group is opened, all other members are closed.
 spec: https://html.spec.whatwg.org/multipage/interactive-elements.html#attr-details-name
 compat_features:
   - api.HTMLDetailsElement.name

--- a/feature-group-definitions/details.yml
+++ b/feature-group-definitions/details.yml
@@ -1,4 +1,5 @@
 name: <details>
+description: The `<details>` element creates a disclosure widget which content is visible only when the widget is toggled open, such as when using a nested `<summary>` element.
 spec: https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element
 compat_features:
   - api.HTMLDetailsElement

--- a/feature-group-definitions/device-posture.yml
+++ b/feature-group-definitions/device-posture.yml
@@ -1,5 +1,5 @@
 name: Device posture
-desscription: The Device Posture API provides information about the physical posture of a device, such as whether a foldable device is folded or unfolded.
+description: The Device Posture API provides information about the physical posture of a device, such as whether a foldable device is folded or unfolded.
 spec: https://w3c.github.io/device-posture/
 status:
   baseline: false

--- a/feature-group-definitions/device-posture.yml
+++ b/feature-group-definitions/device-posture.yml
@@ -1,4 +1,5 @@
 name: Device posture
+desscription: The Device Posture API provides information about the physical posture of a device, such as whether a foldable device is folded or unfolded.
 spec: https://w3c.github.io/device-posture/
 status:
   baseline: false

--- a/feature-group-definitions/dialog.yml
+++ b/feature-group-definitions/dialog.yml
@@ -1,4 +1,5 @@
 name: "<dialog>"
+description: The `<dialog>` HTML element represents a modal or non-modal dialog box.
 spec: https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element
 caniuse: dialog
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/481

--- a/feature-group-definitions/document-picture-in-picture.yml
+++ b/feature-group-definitions/document-picture-in-picture.yml
@@ -1,3 +1,4 @@
 name: Document picture-in-picture
+description: The Document Picture-in-Picture API makes it possible to open an always-on-top window that can be populated with arbitrary HTML content.
 spec: https://wicg.github.io/document-picture-in-picture/
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4397

--- a/feature-group-definitions/edit-context.yml
+++ b/feature-group-definitions/edit-context.yml
@@ -1,2 +1,3 @@
 name: EditContext
+description: The EditContext API is used to build rich text editors that support advanced text input experiences, such as Input Method Editor (IME) composition, emoji picker, or any other platform-specific editing-related UI surfaces.
 spec: https://w3c.github.io/edit-context/

--- a/feature-group-definitions/fetch-priority.yml
+++ b/feature-group-definitions/fetch-priority.yml
@@ -1,4 +1,5 @@
 name: Fetch priority
+description: The optional `priority` parameter of the `fetch()` method, and the `fetchPriority` HTML attribute specifies the priority of the fetch request, relative to other requests of the same type.
 spec:
   - https://fetch.spec.whatwg.org/#request-priority
   - https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attributes

--- a/feature-group-definitions/flexbox-gap.yml
+++ b/feature-group-definitions/flexbox-gap.yml
@@ -1,3 +1,4 @@
 name: Flexbox gap
+description: The `gap` CSS property in a flexbox layout specifies the size of the gap between flex items and between flex lines.
 spec: https://drafts.csswg.org/css-align-3/#gaps
 caniuse: flexbox-gap

--- a/feature-group-definitions/flexbox.yml
+++ b/feature-group-definitions/flexbox.yml
@@ -1,4 +1,5 @@
 name: Flexbox
+description: CSS Flexbox Layout is a one-dimensional layout system, which lays content out in a linear direction, with optional wrapping.
 spec: https://drafts.csswg.org/css-flexbox-1/
 caniuse: flexbox
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1692

--- a/feature-group-definitions/focus-visible.yml
+++ b/feature-group-definitions/focus-visible.yml
@@ -1,4 +1,5 @@
 name: ":focus-visible"
+description: The `:focus-visible` CSS pseudo-class selects elements that match the `:focus` pseudo-class and are determined by the browser to be focused using the keyboard or a similar input device.
 spec: https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo
 caniuse: css-focus-visible
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2388

--- a/feature-group-definitions/font-optical-sizing.yml
+++ b/feature-group-definitions/font-optical-sizing.yml
@@ -1,4 +1,5 @@
 name: font-optical-sizing
+description: The `font-optical-sizing` CSS property sets whether text rendering is optimized for viewing at different sizes.
 spec: https://drafts.csswg.org/css-fonts-4/#font-optical-sizing-def
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/647
 compat_features:

--- a/feature-group-definitions/font-palette-animation.yml
+++ b/feature-group-definitions/font-palette-animation.yml
@@ -1,4 +1,5 @@
 name: font-palette animation
+description: The `palette-mix()` CSS function creates a new `font-palette` value by blending together two `font-palette` values contained in a color font.
 spec: https://drafts.csswg.org/css-fonts-4/#font-palette-prop
 usage_stats: https://chromestatus.com/metrics/css/timeline/animated/709
 compat_features:

--- a/feature-group-definitions/font-palette.yml
+++ b/feature-group-definitions/font-palette.yml
@@ -1,4 +1,5 @@
 name: font-palette and @font-palette-values
+description: The `font-palette` CSS property specifies one of the many palettes contained in a color font that browser should use for that font.
 spec:
   - https://drafts.csswg.org/css-fonts-4/#font-palette-prop
   - https://drafts.csswg.org/css-fonts-4/#font-palette-values

--- a/feature-group-definitions/font-synthesis.yml
+++ b/feature-group-definitions/font-synthesis.yml
@@ -1,4 +1,5 @@
 name: font-synthesis
+description: The `font-synthesis` CSS shorthand property specifies whether or not the browser should synthesize bold, italic, small-caps, and other typefaces when they're missing from the specified font-family.
 spec: https://drafts.csswg.org/css-fonts-4/#font-synthesis-intro
 usage_stats:
   - https://chromestatus.com/metrics/css/timeline/popularity/700 # font-synthesis-weight

--- a/feature-group-definitions/font-variant-alternates.yml
+++ b/feature-group-definitions/font-variant-alternates.yml
@@ -1,4 +1,5 @@
 name: font-variant-alternates
+description: The `font-variant-alternates` CSS property controls the usage of alternate glyphs for characters, as defined in `@font-feature-values` at-rules.
 spec: https://drafts.csswg.org/css-fonts-4/#font-variant-alternates-prop
 caniuse: font-variant-alternates
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/738

--- a/feature-group-definitions/fonts.yml
+++ b/feature-group-definitions/fonts.yml
@@ -1,4 +1,5 @@
 name: "@font-face"
+description: The `@font-face` CSS at-rule specifies a custom font with which to display text, which can be loaded from either a remote server or a locally-installed font on the device.
 spec: https://drafts.csswg.org/css-fonts-5/
 caniuse: fontface
 status:

--- a/feature-group-definitions/fullscreen.yml
+++ b/feature-group-definitions/fullscreen.yml
@@ -1,4 +1,5 @@
 name: Fullscreen API
+description: The Fullscreen API is used to present a specific element in fullscreen mode.
 spec: https://fullscreen.spec.whatwg.org/
 caniuse: fullscreen
 compat_features:

--- a/feature-group-definitions/grid-animation.yml
+++ b/feature-group-definitions/grid-animation.yml
@@ -1,4 +1,5 @@
 name: Grid animation
+description: Grid animation allows to animate the `grid-template-columns` and `grid-template-rows` CSS properties.
 spec: https://drafts.csswg.org/css-grid-2/#track-sizing
 status:
   baseline: low

--- a/feature-group-definitions/grid.yml
+++ b/feature-group-definitions/grid.yml
@@ -1,4 +1,5 @@
 name: Grid
+description: CSS Grid Layout is a two-dimensional layout system, which lays content out in rows and columns.
 spec: https://drafts.csswg.org/css-grid-3/
 caniuse: css-grid
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1693

--- a/feature-group-definitions/has.yml
+++ b/feature-group-definitions/has.yml
@@ -1,4 +1,5 @@
 name: ":has()"
+description: The `:has()` CSS pseudo-class selects an element if any of the selectors passed as parameters would match at least one element.
 spec: https://drafts.csswg.org/selectors-4/#relational
 caniuse: css-has
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4743

--- a/feature-group-definitions/html-media-capture.yml
+++ b/feature-group-definitions/html-media-capture.yml
@@ -1,4 +1,5 @@
 name: HTML media capture
+description: The `capture` HTML attribute for `<input type="file">` elements allows the user to, optionally, capture media using the device's camera, microphone, or other media-capture capabilities.
 spec: https://w3c.github.io/html-media-capture/
 caniuse: html-media-capture
 compat_features:

--- a/feature-group-definitions/http11.yml
+++ b/feature-group-definitions/http11.yml
@@ -1,4 +1,5 @@
 name: HTTP/1.1
+description: HTTP/1.1 is a revision of the HTTP network protocol used by the World Wide Web.
 spec: https://httpwg.org/specs/rfc9112.html
 compat_features:
   - http.headers.Accept

--- a/feature-group-definitions/http2.yml
+++ b/feature-group-definitions/http2.yml
@@ -1,3 +1,4 @@
 name: HTTP/2
+description: The HTTP/2 protocol is a major revision of the HTTP network protocol, providing improved performance and efficiency by using a single TCP connection to send multiple streams of data at once.
 spec: https://httpwg.org/specs/rfc9113.html
 caniuse: http2

--- a/feature-group-definitions/http3.yml
+++ b/feature-group-definitions/http3.yml
@@ -1,3 +1,4 @@
 name: HTTP/3
+description: HTTP/3 is a major revision of the HTTP network protocol, providing improved performance and efficiency by using QUIC as the underlying transport protocol.
 spec: https://httpwg.org/specs/rfc9114.html
 caniuse: http3

--- a/feature-group-definitions/idle-detection.yml
+++ b/feature-group-definitions/idle-detection.yml
@@ -1,4 +1,5 @@
 name: Idle detection
+description: The Idle Detection API is used to notify a webpage of the user's idle, active, and locked state.
 spec: https://wicg.github.io/idle-detection/
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2834
 status:

--- a/feature-group-definitions/image-set.yml
+++ b/feature-group-definitions/image-set.yml
@@ -1,3 +1,4 @@
 name: image-set()
+description: The `image-set()` CSS function defines a set of images for at different resolutions or pixel densities, which the browser can pick from, depending on the device capabilities.
 spec: https://drafts.csswg.org/css-images-4/#image-set-notation
 caniuse: css-image-set

--- a/feature-group-definitions/import-maps.yml
+++ b/feature-group-definitions/import-maps.yml
@@ -1,4 +1,5 @@
 name: Import maps
+description: The `type="importmap"` attribute for the `<script>` HTML element indicates that the body of the element contains an import map. An import map is a JSON object that controls how the browser should resolve module specifiers when importing JavaScript modules.
 spec: https://html.spec.whatwg.org/multipage/webappapis.html#import-maps
 caniuse: import-maps
 status:

--- a/feature-group-definitions/indeterminate.yml
+++ b/feature-group-definitions/indeterminate.yml
@@ -1,4 +1,5 @@
-name: ":indeterminate()"
+name: ":indeterminate"
+description: The `:indeterminate` CSS pseudo-class selects any form element whose state is indeterminate, such as checkboxes that have been set to an indeterminate state with JavaScript, or radio buttons which are members of a group in which all radio buttons are unchecked.
 spec:
   - https://drafts.csswg.org/selectors-4/#indeterminate
   - https://html.spec.whatwg.org/multipage/semantics-other.html#selector-indeterminate

--- a/feature-group-definitions/intersection-observer.yml
+++ b/feature-group-definitions/intersection-observer.yml
@@ -1,4 +1,5 @@
 name: Intersection observer
+description: The Intersection Observer API asynchronously observes changes in the intersection of a target element with an ancestor element or with a top-level document's viewport.
 spec: https://w3c.github.io/IntersectionObserver/
 caniuse: intersectionobserver
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1368

--- a/feature-group-definitions/is.yml
+++ b/feature-group-definitions/is.yml
@@ -1,4 +1,5 @@
 name: ":is()"
+description: "The `:is()` CSS pseudo-class function takes a selector list as its argument, and selects any element that can be selected by one of the selectors in that list."
 spec: https://drafts.csswg.org/selectors-4/#matches
 caniuse: css-matches-pseudo
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2322

--- a/feature-group-definitions/jpegxl.yml
+++ b/feature-group-definitions/jpegxl.yml
@@ -1,4 +1,5 @@
 name: JPEG XL
+description: The JPEG XL format is a raster graphics file format that supports both lossy and lossless compression.
 spec: https://www.iso.org/standard/85253.html
 caniuse: jpegxl
 status:

--- a/feature-group-definitions/line-clamp.yml
+++ b/feature-group-definitions/line-clamp.yml
@@ -1,4 +1,5 @@
 name: line-clamp
+description: The `line-clamp` CSS property limits the text in a block container to a certain number of lines.
 spec: https://drafts.csswg.org/css-overflow-3/#line-clamp
 caniuse: css-line-clamp
 compat_features:

--- a/feature-group-definitions/media-query-range-syntax.yml
+++ b/feature-group-definitions/media-query-range-syntax.yml
@@ -1,4 +1,5 @@
 name: Media query range syntax
+description: The range syntax of CSS media queries allows to use mathematical comparison operators such as `<`, `>`, `<=`, and `>=` to define a range of values for a media feature.
 caniuse: css-media-range-syntax
 spec: https://drafts.csswg.org/mediaqueries-4/#mq-range-context
 status:

--- a/feature-group-definitions/modulepreload.yml
+++ b/feature-group-definitions/modulepreload.yml
@@ -1,4 +1,5 @@
 name: '<link rel="modulepreload">'
+description: The `rel="modulepreload"` attribute for the `<link>` HTML element indicates that a module script should be fetched, parsed, and compiled preemptively, and stored for later execution.
 spec: https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload
 caniuse: link-rel-modulepreload
 compat_features:

--- a/feature-group-definitions/motion-path.yml
+++ b/feature-group-definitions/motion-path.yml
@@ -1,4 +1,5 @@
 name: Motion path
+description: The `offset` shorthand CSS property animates an element along a defined motion path.
 spec: https://drafts.fxtf.org/motion-1/
 caniuse: css-motion-paths
 status:

--- a/feature-group-definitions/navigation.yml
+++ b/feature-group-definitions/navigation.yml
@@ -1,2 +1,3 @@
 name: Navigation API
+description: The Navigation API provides mechanisms to initiate, intercept, and manage browser navigation actions.
 spec: https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api

--- a/feature-group-definitions/nesting.yml
+++ b/feature-group-definitions/nesting.yml
@@ -1,4 +1,5 @@
 name: Nesting
+description: For shorter selectors, easier reading, and more modularity, CSS rules can be nested inside other rules.
 spec: https://drafts.csswg.org/css-nesting-1/
 caniuse: css-nesting
 status:

--- a/feature-group-definitions/offscreen-canvas.yml
+++ b/feature-group-definitions/offscreen-canvas.yml
@@ -1,4 +1,5 @@
 name: Offscreen canvas
+description: The `OffscreenCanvas` interface provides a canvas that can be drawn to off screen, with no dependencies on the DOM, which can be used to run heavy rendering operations inside a worker context.
 spec: https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-interface
 caniuse: offscreencanvas
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1624

--- a/feature-group-definitions/overflow-shorthand.yml
+++ b/feature-group-definitions/overflow-shorthand.yml
@@ -1,4 +1,5 @@
 name: overflow
+description: The `overflow` shorthand CSS property sets the values of the `overflow-x` and `overflow-y` properties.
 spec: https://drafts.csswg.org/css-overflow-3/#propdef-overflow
 caniuse: css-overflow
 status:

--- a/feature-group-definitions/picture-in-picture.yml
+++ b/feature-group-definitions/picture-in-picture.yml
@@ -1,4 +1,5 @@
 name: Picture-in-picture
+description: The Picture-in-Picture API allow websites to create a floating, always-on-top video window.
 spec: https://w3c.github.io/picture-in-picture/
 caniuse: picture-in-picture
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2444

--- a/feature-group-definitions/popover.yml
+++ b/feature-group-definitions/popover.yml
@@ -1,4 +1,5 @@
 name: Popover
+description: The Popover API is used to display content on top of other page content, and is controlled either declaratively using HTML attributes, or via JavaScript.
 spec: https://html.spec.whatwg.org/multipage/popover.html
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4191
 status:

--- a/feature-group-definitions/read-write-pseudos.yml
+++ b/feature-group-definitions/read-write-pseudos.yml
@@ -1,4 +1,5 @@
-name: ":read and :write"
+name: ":read-only and :read-write"
+description: The `:read-only` and `:read-write` CSS pseudo-classes match elements that are read-only or read-write, respectively, such as when `<input>` or `<textarea>` elements have the `readonly` attribute set or not set, respectively.
 spec:
   - https://html.spec.whatwg.org/multipage/semantics-other.html#selector-read-only
   - https://drafts.csswg.org/selectors-4/#rw-pseudos

--- a/feature-group-definitions/registered-custom-properties.yml
+++ b/feature-group-definitions/registered-custom-properties.yml
@@ -1,4 +1,5 @@
 name: Registered custom properties
+description: The `CSS.registerProperty()` static method, and the `@property` CSS at-rule register custom properties which types and behaviors can be defined.
 spec: https://drafts.css-houdini.org/css-properties-values-api-1/
 status:
   baseline: false

--- a/feature-group-definitions/sanitizer.yml
+++ b/feature-group-definitions/sanitizer.yml
@@ -1,2 +1,3 @@
 name: Sanitizer
+description: The Sanitizer API sanitizes untrusted strings of HTML, Document and DocumentFragment objects. After sanitization, unwanted elements or attributes are removed, and the returned objects can safely be inserted into a document's DOM.
 spec: https://wicg.github.io/sanitizer-api/

--- a/feature-group-definitions/scheduler.yml
+++ b/feature-group-definitions/scheduler.yml
@@ -1,4 +1,5 @@
 name: Scheduler API
+description: The Prioritized Task Scheduling API provides a way to prioritize all tasks belonging to an application.
 spec: https://wicg.github.io/scheduling-apis/
 status:
   baseline: false

--- a/feature-group-definitions/scope.yml
+++ b/feature-group-definitions/scope.yml
@@ -1,3 +1,4 @@
 name: "@scope"
+description: The `@scope` CSS at-rule defines the scope for a group of rules.
 spec: https://drafts.csswg.org/css-cascade-6/#scope-atrule
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4212

--- a/feature-group-definitions/scroll-driven-animations.yml
+++ b/feature-group-definitions/scroll-driven-animations.yml
@@ -1,4 +1,5 @@
 name: Scroll-driven animations
+description: CSS scroll-driven animations are a type of CSS animations that don't run over time, but instead are driven by the user's scroll position through the page.
 spec: https://drafts.csswg.org/scroll-animations-1/
 compat_features:
   - api.ScrollTimeline

--- a/feature-group-definitions/scroll-into-view.yml
+++ b/feature-group-definitions/scroll-into-view.yml
@@ -1,4 +1,5 @@
 name: scrollIntoView()
+description: An element's `scrollIntoView()` method scrolls the element's ancestor containers such that the element is visible to the user.
 spec: https://drafts.csswg.org/cssom-view-1/#dom-element-scrollintoview
 alias: scrollintoview
 caniuse: scrollintoview

--- a/feature-group-definitions/scroll-snap.yml
+++ b/feature-group-definitions/scroll-snap.yml
@@ -1,4 +1,5 @@
 name: Scroll snap
+description: CSS scroll snap properties control the panning and scrolling behavior within a scroll container.
 spec: https://drafts.csswg.org/css-scroll-snap-1/
 caniuse: css-snappoints
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/499

--- a/feature-group-definitions/scrollbar-color.yml
+++ b/feature-group-definitions/scrollbar-color.yml
@@ -1,4 +1,5 @@
 name: scrollbar-color
+description: The `scrollbar-color` CSS property sets the color of the scrollbar track and thumb.
 spec: https://drafts.csswg.org/css-scrollbars-1/#scrollbar-color
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/763
 compat_features:

--- a/feature-group-definitions/scrollbar-gutter.yml
+++ b/feature-group-definitions/scrollbar-gutter.yml
@@ -1,4 +1,5 @@
 name: scrollbar-gutter
+description: The `scrollbar-gutter` CSS property reserves space for the scrollbar, preventing unwanted layout changes as the scrollbar appears and disappears.
 spec: https://drafts.csswg.org/css-overflow-3/#scrollbar-gutter-property
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/671
 compat_features:

--- a/feature-group-definitions/scrollbar-width.yml
+++ b/feature-group-definitions/scrollbar-width.yml
@@ -1,4 +1,5 @@
 name: scrollbar-width
+description: The `scrollbar-width` CSS property sets the width of the scrollbar.
 spec: https://drafts.csswg.org/css-scrollbars-1/#scrollbar-width
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/680
 compat_features:

--- a/feature-group-definitions/search-input-type.yml
+++ b/feature-group-definitions/search-input-type.yml
@@ -1,4 +1,5 @@
 name: '<input type="search">'
+description: The `<input>` HTML element with the `type="search"` attribute represents a text field that's used for users to enter search queries, and that might be styled differently by the browser.
 spec: https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)
 caniuse: input-search
 compat_features:

--- a/feature-group-definitions/search.yml
+++ b/feature-group-definitions/search.yml
@@ -1,4 +1,5 @@
 name: <search>
+description: The `<search>` HTML element is a container that represents the parts of the web page with search functionality.
 spec: https://html.spec.whatwg.org/multipage/grouping-content.html#the-search-element
 compat_features:
   - html.elements.search

--- a/feature-group-definitions/server-timing.yml
+++ b/feature-group-definitions/server-timing.yml
@@ -1,4 +1,5 @@
 name: Server timing
+description: Server timing is part of the Performance API and allows to annotate network requests with server timing information.
 spec: https://w3c.github.io/server-timing/
 caniuse: server-timing
 status:

--- a/feature-group-definitions/set-methods.yml
+++ b/feature-group-definitions/set-methods.yml
@@ -1,4 +1,5 @@
 name: Set methods
+description: "`difference()`, `intersection()`, `isDisjointFrom()`, `isSubsetOf()`, `isSupersetOf()`, `symmetricDifference()`, and `union()` methods of the JavaScript `Set` object."
 spec: https://tc39.es/proposal-set-methods/
 group: sets
 status:

--- a/feature-group-definitions/shadow-dom.yml
+++ b/feature-group-definitions/shadow-dom.yml
@@ -1,4 +1,5 @@
 name: Shadow DOM
+description: Shadow DOM is a part of Web Components. It allows for attaching encapsulated "shadow" DOM trees to the DOM. A shadow DOM tree is rendered separately from the main DOM, avoiding the component's scripts and styles to collide with other parts of the document.
 spec: https://dom.spec.whatwg.org/#shadow-trees
 caniuse: shadowdomv1
 status:

--- a/feature-group-definitions/slot.yml
+++ b/feature-group-definitions/slot.yml
@@ -1,4 +1,5 @@
 name: <slot>
+description: The `<slot>` HTML element, part of Web Components, is a placeholder inside a web component where consumers of the component can insert their own markup.
 spec: https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1898
 compat_features:

--- a/feature-group-definitions/speech-recognition.yml
+++ b/feature-group-definitions/speech-recognition.yml
@@ -1,4 +1,5 @@
 name: Speech recognition
+description: The `SpeechRecognition` interface of the Web Speech API controls the speech recognition service that might be available in the browser.
 spec: https://wicg.github.io/speech-api/#speechreco-section
 caniuse: speech-recognition
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2014

--- a/feature-group-definitions/speech-synthesis.yml
+++ b/feature-group-definitions/speech-synthesis.yml
@@ -1,4 +1,5 @@
 name: Speech synthesis
+description: The `SpeechSynthesis` interface of the Web Speech API controls the speech synthesis service that might be available in the browser.
 spec: https://wicg.github.io/speech-api/#tts-section
 caniuse: speech-synthesis
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2483

--- a/feature-group-definitions/starting-style.yml
+++ b/feature-group-definitions/starting-style.yml
@@ -1,4 +1,5 @@
 name: "@starting-style"
+description: The `@starting-style` CSS at-rule defines the starting values for properties that are transitioning when the target element's style is first updated.
 spec: https://drafts.csswg.org/css-transitions-2/#defining-before-change-style
 compat_features:
   - api.CSSStartingStyleRule

--- a/feature-group-definitions/sticky-positioning.yml
+++ b/feature-group-definitions/sticky-positioning.yml
@@ -1,4 +1,5 @@
 name: Sticky positioning
+description: "The `position: sticky` CSS declaration positions an element in the normal flow until it crosses a specified threshold, at which points it becomes fixed."
 spec: https://drafts.csswg.org/css-position-3/#stickypos-insets
 caniuse: css-sticky
 status:

--- a/feature-group-definitions/storage-buckets.yml
+++ b/feature-group-definitions/storage-buckets.yml
@@ -1,4 +1,5 @@
 name: Storage buckets
+description: The Storage Buckets API allows a site to organize locally stored data into groups called storage buckets, allowing the site, or the browser to manage and delete buckets independently rather than applying the same treatment to all.
 spec: https://wicg.github.io/storage-buckets/
 status:
   baseline: false

--- a/feature-group-definitions/structured-clone.yml
+++ b/feature-group-definitions/structured-clone.yml
@@ -1,4 +1,5 @@
 name: structuredClone()
+description: The global `structuredClone()` JavaScript method creates a deep clone of an object by using the structured clone algorithm. The method also allows for transferring values from the original object to the cloned object.
 spec: https://html.spec.whatwg.org/multipage/structured-data.html#structured-cloning
 status:
   baseline: low

--- a/feature-group-definitions/subgrid.yml
+++ b/feature-group-definitions/subgrid.yml
@@ -1,4 +1,5 @@
 name: Subgrid
+description: "The `subgrid` value for the `grid-template-columns` and `grid-template-rows` properties allows a grid item to inherit the grid definition of its parent grid container."
 spec: https://drafts.csswg.org/css-grid-2/#subgrids
 caniuse: css-subgrid
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4680

--- a/feature-group-definitions/svg2-script-html-equivalence.yml
+++ b/feature-group-definitions/svg2-script-html-equivalence.yml
@@ -1,4 +1,5 @@
 name: SVG <script> async and defer
+description: The `async` and `defer` attributes of the `<script>` SVG element allow to control the load and execution of scripts in SVG documents.
 spec: https://svgwg.org/svg2-draft/interact.html#ScriptElement
 status:
   baseline: false

--- a/feature-group-definitions/tabindex.yml
+++ b/feature-group-definitions/tabindex.yml
@@ -1,4 +1,5 @@
 name: tabindex
+description: The `tabindex` HTML attribute makes elements focusable, and defines the elements' relative ordering for sequential focus navigation.
 spec: https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex
 caniuse: tabindex-attr
 status:

--- a/feature-group-definitions/template.yml
+++ b/feature-group-definitions/template.yml
@@ -1,4 +1,5 @@
 name: <template>
+description: The `<template>` HTML element holds HTML fragments, which can be cloned and inserted into the document by JavaScript.
 spec: https://html.spec.whatwg.org/multipage/scripting.html#the-template-element
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2769
 compat_features:

--- a/feature-group-definitions/temporal.yml
+++ b/feature-group-definitions/temporal.yml
@@ -1,3 +1,4 @@
 name: Temporal
+description: The Temporal API provides a way to work with dates and times in JavaScript.
 spec: https://tc39.es/proposal-temporal/
 caniuse: temporal

--- a/feature-group-definitions/text-box-trim.yml
+++ b/feature-group-definitions/text-box-trim.yml
@@ -1,4 +1,4 @@
 name: text-box-trim
-description: The `text-box-trim` CSS property trims the additional space above and below the first and last lines of a block that's normally reserved for ascenders and descenders one a line of text. 
+description: The `text-box-trim` CSS property trims the additional space above and below the first and last lines of a block that's normally reserved for ascenders and descenders one a line of text.
 spec: https://drafts.csswg.org/css-inline-3/#leading-trim
 alias: leading-trim

--- a/feature-group-definitions/text-box-trim.yml
+++ b/feature-group-definitions/text-box-trim.yml
@@ -1,3 +1,4 @@
 name: text-box-trim
+description: The `text-box-trim` CSS property trims the additional space above and below the first and last lines of a block that's normally reserved for ascenders and descenders one a line of text. 
 spec: https://drafts.csswg.org/css-inline-3/#leading-trim
 alias: leading-trim

--- a/feature-group-definitions/text-indent.yml
+++ b/feature-group-definitions/text-indent.yml
@@ -1,4 +1,5 @@
 name: text-indent
+description: The `text-indent` CSS property sets the length of empty space (indentation) that is put before lines of text in a block.
 spec: https://drafts.csswg.org/css-text-3/#text-indent-property
 caniuse: css-text-indent
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/130

--- a/feature-group-definitions/text-wrap-balance.yml
+++ b/feature-group-definitions/text-wrap-balance.yml
@@ -1,4 +1,5 @@
 name: "text-wrap: balance"
+description: "The `text-wrap: balance` CSS declaration wraps text content across lines, while using an algorithm that balances that number of characters on each line, enhancing legibility."
 spec: https://drafts.csswg.org/css-text-4/#valdef-text-wrap-style-balance
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4673
 compat_features:

--- a/feature-group-definitions/text-wrap-pretty.yml
+++ b/feature-group-definitions/text-wrap-pretty.yml
@@ -1,4 +1,5 @@
 name: "text-wrap: pretty"
+description: "The `text-wrap: pretty` CSS declaration wraps text content across lines, while using an algorithm that favors better layout over speed."
 spec: https://drafts.csswg.org/css-text-4/#valdef-text-wrap-style-pretty
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4674
 compat_features:

--- a/feature-group-definitions/transition-behavior.yml
+++ b/feature-group-definitions/transition-behavior.yml
@@ -1,4 +1,5 @@
 name: transition-behavior
+description: The `transition-behavior` CSS property specifies whether transitions will be started for properties whose animation behavior is discrete. Properties with a discrete animation type can't be interpolated and swap from their start value to the end value at 50%.
 spec: https://drafts.csswg.org/css-transitions-2/#transition-behavior-property
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/766
 compat_features:

--- a/feature-group-definitions/trusted-types.yml
+++ b/feature-group-definitions/trusted-types.yml
@@ -1,4 +1,5 @@
 name: Trusted types
+description: The Trusted Types API is used to lock down insecure parts of the DOM API, to prevent client-side cross-site scripting (XSS) attacks.
 spec: https://w3c.github.io/trusted-types/dist/spec/
 caniuse: trusted-types
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2722

--- a/feature-group-definitions/user-pseudos.yml
+++ b/feature-group-definitions/user-pseudos.yml
@@ -1,4 +1,5 @@
 name: ":user-valid and :user-invalid"
+description: The `:user-valid` and `:user-invalid` pseudo-classes match form controls that have been marked as valid or invalid based on their validation constraints.
 spec: https://drafts.csswg.org/selectors-4/#user-pseudos
 compat_features:
   - css.selectors.user-invalid

--- a/feature-group-definitions/view-transitions.yml
+++ b/feature-group-definitions/view-transitions.yml
@@ -1,4 +1,5 @@
 name: View transitions
+description: The View Transitions API transitions between different states of a document, or between different documents.
 spec: https://drafts.csswg.org/css-view-transitions-1/
 caniuse: view-transitions
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4383

--- a/feature-group-definitions/viewport-relative-unit-variants.yml
+++ b/feature-group-definitions/viewport-relative-unit-variants.yml
@@ -1,4 +1,5 @@
 name: sv*, lv*, and dv* viewport units
+description: CSS small, large, and dynamic viewport units are relative to the size of the viewport, and are used to size elements in relation to the viewport's dimensions.
 spec:
   - https://drafts.csswg.org/css-values-4/#viewport-variants
   - https://drafts.csswg.org/css-values-4/#viewport-relative-lengths

--- a/feature-group-definitions/viewport-relative-units.yml
+++ b/feature-group-definitions/viewport-relative-units.yml
@@ -1,4 +1,5 @@
 name: vw, vh, vmin, and vmax viewport units
+description: CSS viewport units are relative to the size of the viewport, and are used to size elements in relation to the viewport's dimensions.
 spec: https://drafts.csswg.org/css-values-4/#viewport-relative-lengths
 caniuse: viewport-units
 status:

--- a/feature-group-definitions/visual-viewport.yml
+++ b/feature-group-definitions/visual-viewport.yml
@@ -1,4 +1,5 @@
 name: Visual viewport API
+description: The Visual Viewport API provides a way to query and modify the visual viewport of a web page.
 spec: https://drafts.csswg.org/cssom-view-1/#visualViewport
 compat_features:
   - api.VisualViewport

--- a/feature-group-definitions/web-animations.yml
+++ b/feature-group-definitions/web-animations.yml
@@ -1,4 +1,5 @@
 name: Web animations
+description: The Web Animations API allows to animate, and synchronize the animations of DOM elements.
 spec: https://drafts.csswg.org/web-animations-1/
 caniuse: web-animation
 status:

--- a/feature-group-definitions/webcodecs.yml
+++ b/feature-group-definitions/webcodecs.yml
@@ -1,4 +1,5 @@
 name: WebCodecs
+description: The WebCodecs API provides low-level access to individual video frames and chunks of audio samples, for full control over the way media is processed.
 spec: https://w3c.github.io/webcodecs/
 caniuse: webcodecs
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3464

--- a/feature-group-definitions/webdriver-bidi.yml
+++ b/feature-group-definitions/webdriver-bidi.yml
@@ -1,4 +1,5 @@
 name: WebDriver BiDi
+description: WebDriver BiDi is a bidirectional protocol that allows a WebDriver client and a browser to communicate with each other.
 spec: https://w3c.github.io/webdriver-bidi/
 # WebDriver BiDi is not in BCD, see https://github.com/mdn/browser-compat-data/issues/20207
 # The browser releases listed here are from:

--- a/feature-group-definitions/webhid.yml
+++ b/feature-group-definitions/webhid.yml
@@ -1,4 +1,5 @@
 name: WebHID
+description: The WebHID API provides access to Human Interface Devices (HID) that are connected to the user's device.
 spec: https://wicg.github.io/webhid/
 caniuse: webhid
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2865

--- a/feature-group-definitions/webp.yml
+++ b/feature-group-definitions/webp.yml
@@ -1,4 +1,5 @@
 name: WebP
+description: The WebP image format is a raster graphics file format that supports animation, alpha transparency, and lossy and lossless compression.
 spec: https://www.ietf.org/archive/id/draft-zern-webp-13.html
 caniuse: webp
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3797

--- a/feature-group-definitions/webtransport.yml
+++ b/feature-group-definitions/webtransport.yml
@@ -1,4 +1,5 @@
 name: WebTransport
+description: The WebTransport API transmits data between a client and a server, by using the HTTP/3 protocol.
 spec: https://w3c.github.io/webtransport/
 caniuse: webtransport
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3472

--- a/feature-group-definitions/webusb.yml
+++ b/feature-group-definitions/webusb.yml
@@ -1,4 +1,5 @@
 name: WebUSB
+description: The WebUSB API exposes USB compatible devices to web pages.
 spec: https://wicg.github.io/webusb/
 caniuse: webusb
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1519

--- a/feature-group-definitions/where.yml
+++ b/feature-group-definitions/where.yml
@@ -1,4 +1,5 @@
 name: ":where()"
+description: The `:where()` CSS pseudo-class function takes a selector list as its argument, and selects any element that can be selected by one of the selectors in that list. It is functionally equivalent to the selectors in the list, but doesn't affect the CSS rule specificity.
 spec: https://drafts.csswg.org/selectors-4/#zero-matches
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2431
 status:

--- a/index.ts
+++ b/index.ts
@@ -16,7 +16,6 @@ const descriptionMaxLength = 300;
 // Some FeatureData keys aren't (and may never) be ready for publishing.
 // They're not part of the public schema (yet).
 const omittables = [
-    "description",
     "snapshot",
     "group"
 ]

--- a/schemas/defs.schema.json
+++ b/schemas/defs.schema.json
@@ -44,14 +44,13 @@
           },
           "type": "array"
         },
+        "description": {
+          "description": "Short description",
+          "type": "string"
+        },
         "name": {
           "description": "Short name",
           "type": "string"
-        },
-        "description": {
-          "description": "Short description of the feature",
-          "type": "string",
-          "maxLength": 300
         },
         "spec": {
           "anyOf": [
@@ -153,8 +152,8 @@
       },
       "required": [
         "name",
-        "spec",
-        "description"
+        "description",
+        "spec"
       ],
       "type": "object"
     }

--- a/schemas/defs.schema.json
+++ b/schemas/defs.schema.json
@@ -48,6 +48,11 @@
           "description": "Short name",
           "type": "string"
         },
+        "description": {
+          "description": "Short description of the feature",
+          "type": "string",
+          "maxLength": 300
+        },
         "spec": {
           "anyOf": [
             {
@@ -148,7 +153,8 @@
       },
       "required": [
         "name",
-        "spec"
+        "spec",
+        "description"
       ],
       "type": "object"
     }

--- a/types.ts
+++ b/types.ts
@@ -3,6 +3,8 @@
 export interface FeatureData {
     /** Short name */
     name: string;
+    /** Short description */
+    description: string;
     /** Alias identifier */
     alias?: string | [string, string, ...string[]];
     /** Specification */


### PR DESCRIPTION
This PR describes all the features that don't yet have a description field. Fixes  #736.
This PR also makes the description field mandatory so that, going forward, we have to have descriptions.

Reviewers: most of this is taken from MDN, Can I Use, specs, and Wikipedia. My goal was to cover 100% of files, not to be 100% correct on all of them. I believe that once we have the descriptions in place, at least, we can't introduce new features without descriptions, but we can always improve the existing ones.