### PR TITLE
`mathml`: Add MathML (also known as MathML Core)

### DIFF
--- a/feature-group-definitions/mathml.yml
+++ b/feature-group-definitions/mathml.yml
@@ -1,0 +1,70 @@
+name: MathML
+description: MathML, or the Mathematical Markup Language, describes mathematical notation, such as expressions and formulas. Also known as MathML Core.
+spec: https://w3c.github.io/mathml-core/
+caniuse: mathml
+compat_features:
+  - api.MathMLElement
+  - api.MathMLElement.autofocus
+  - api.MathMLElement.blur
+  - api.MathMLElement.dataset
+  - api.MathMLElement.focus
+  - api.MathMLElement.style
+  - api.MathMLElement.tabIndex
+  - mathml.elements.math
+  - mathml.elements.math.display
+  - mathml.elements.merror
+  - mathml.elements.mfrac
+  - mathml.elements.mfrac.linethickness
+  - mathml.elements.mi
+  - mathml.elements.mi.mathvariant
+  - mathml.elements.mmultiscripts
+  - mathml.elements.mn
+  - mathml.elements.mo
+  - mathml.elements.mo.form
+  - mathml.elements.mo.largeop
+  - mathml.elements.mo.lspace
+  - mathml.elements.mo.maxsize
+  - mathml.elements.mo.minsize
+  - mathml.elements.mo.moveablelimits
+  - mathml.elements.mo.rspace
+  - mathml.elements.mo.stretchy
+  - mathml.elements.mo.symmetric
+  - mathml.elements.mover
+  - mathml.elements.mover.accent
+  - mathml.elements.mpadded
+  - mathml.elements.mpadded.depth
+  - mathml.elements.mpadded.height
+  - mathml.elements.mpadded.lspace
+  - mathml.elements.mpadded.voffset
+  - mathml.elements.mpadded.width
+  - mathml.elements.mphantom
+  - mathml.elements.mroot
+  - mathml.elements.mrow
+  - mathml.elements.ms
+  - mathml.elements.mspace
+  - mathml.elements.mspace.depth
+  - mathml.elements.mspace.height
+  - mathml.elements.mspace.width
+  - mathml.elements.msqrt
+  - mathml.elements.mstyle
+  - mathml.elements.msub
+  - mathml.elements.msubsup
+  - mathml.elements.msup
+  - mathml.elements.mtable
+  - mathml.elements.mtd
+  - mathml.elements.mtd.columnspan
+  - mathml.elements.mtd.rowspan
+  - mathml.elements.mtext
+  - mathml.elements.mtr
+  - mathml.elements.munder
+  - mathml.elements.munder.accentunder
+  - mathml.elements.munderover
+  - mathml.elements.munderover.accent
+  - mathml.elements.munderover.accentunder
+  - mathml.elements.semantics
+  - mathml.global_attributes.dir
+  - mathml.global_attributes.displaystyle
+  - mathml.global_attributes.mathbackground
+  - mathml.global_attributes.mathcolor
+  - mathml.global_attributes.mathsize
+  - mathml.global_attributes.scriptlevel # TODO: when setting Baseline status, we'll probably want to ignore this. It's the one piece not interopable and has an odd story.


### PR DESCRIPTION
This is a likely Baseline 2023 feature.