### PR TITLE
`class-syntax`: Add `super` operator

### DIFF
--- a/feature-group-definitions/class-syntax.yml
+++ b/feature-group-definitions/class-syntax.yml
@@ -18,4 +18,5 @@ compat_features:
   - javascript.classes.constructor
   - javascript.classes.extends
   - javascript.classes.static
+  - javascript.operators.super
   - javascript.statements.class


### PR DESCRIPTION
I _think_ this belongs with the rest of the class syntax stuff (excluding the private class properties stuff).

Inspired by looking at this feature for https://github.com/web-platform-dx/web-features/pull/751/files#r1547468185.