### PR TITLE
`font-variant-alternates`: add `@font-feature-values` at-rule

### DIFF
--- a/feature-group-definitions/font-variant-alternates.yml
+++ b/feature-group-definitions/font-variant-alternates.yml
@@ -1,4 +1,5 @@
 name: font-variant-alternates
+description: The `font-variant-alternates` CSS property, along with the `@font-feature-values` at-rule, chooses when to use a font's alternate glyphs.
 spec: https://drafts.csswg.org/css-fonts-4/#font-variant-alternates-prop
 caniuse: font-variant-alternates
 usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/738
@@ -14,6 +15,16 @@ status:
     safari: "16.2"
     safari_ios: "16.2"
 compat_features:
+  - api.CSSFontFeatureValuesRule
+  - api.CSSFontFeatureValuesRule.fontFamily
+  - css.at-rules.font-feature-values
+  - css.at-rules.font-feature-values.annotation
+  - css.at-rules.font-feature-values.character-variant
+  - css.at-rules.font-feature-values.historical-forms
+  - css.at-rules.font-feature-values.ornaments
+  - css.at-rules.font-feature-values.styleset
+  - css.at-rules.font-feature-values.stylistic
+  - css.at-rules.font-feature-values.swash
   - css.properties.font-variant-alternates
   - css.properties.font-variant-alternates.annotation
   - css.properties.font-variant-alternates.character_variant


### PR DESCRIPTION
These are closely related—the at-rule sets values for `font-variant-alternates` to use—so I've added to the feature rather than creating a second one.

This does not have any impact on the Baseline 2023 support status.