### PR TITLE
`compression-streams`: add compression types

### DIFF
--- a/feature-group-definitions/compression-streams.yml
+++ b/feature-group-definitions/compression-streams.yml
@@ -6,9 +6,15 @@ usage_stats:
 compat_features:
   - api.CompressionStream
   - api.CompressionStream.CompressionStream
+  - api.CompressionStream.CompressionStream.deflate
+  - api.CompressionStream.CompressionStream.deflate-raw
+  - api.CompressionStream.CompressionStream.gzip
   - api.CompressionStream.readable
   - api.CompressionStream.writable
   - api.DecompressionStream
   - api.DecompressionStream.DecompressionStream
+  - api.DecompressionStream.DecompressionStream.deflate
+  - api.DecompressionStream.DecompressionStream.deflate-raw
+  - api.DecompressionStream.DecompressionStream.gzip
   - api.DecompressionStream.readable
   - api.DecompressionStream.writable


### PR DESCRIPTION
The supported compression types are also part of this and have a support history equivalent to that of the constructors themselves.

This improves coverage of Baseline 2023 compat keys.