### PR TITLE
Upgrade compute-baseline dependencies automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     directory: packages/web-features
     schedule:
       interval: daily
+  - package-ecosystem: npm
+    directory: packages/compute-baseline
+    schedule:
+      interval: daily

--- a/packages/compute-baseline/package-lock.json
+++ b/packages/compute-baseline/package-lock.json
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.5.10",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.5.10.tgz",
-      "integrity": "sha512-s2GGND9oLhEuksOFtICYOBZdMWPANBXTMqAXh89q6g1Mi3+OuWEmp9WFzw2v/nmS175vqeewpC1kDJA7taaxyA==",
+      "version": "5.5.19",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.5.19.tgz",
+      "integrity": "sha512-ntKBZtwWCy4XvJosdTJKqIMdmzgbxjopfoiMxgpzsml3dXqA7MIHCE/amidfQc06a6KvmMrpiVuYHIBt2feDog==",
       "peer": true
     },
     "node_modules/@types/chai": {

--- a/packages/compute-baseline/src/baseline/index.test.ts
+++ b/packages/compute-baseline/src/baseline/index.test.ts
@@ -70,7 +70,7 @@ describe("computeBaseline", function () {
       checkAncestors: false,
     });
     assert.equal(result.baseline, "high");
-    assert.equal(result.baseline_low_date, "2015-07-28"); // The first release of Edge, the youngest release in consideration
-    assert.equal(result.baseline_high_date, "2018-01-28"); // 30 months later
+    assert.equal(result.baseline_low_date, "2015-07-29"); // The first release of Edge, the youngest release in consideration
+    assert.equal(result.baseline_high_date, "2018-01-29"); // 30 months later
   });
 });

--- a/packages/compute-baseline/src/baseline/index.test.ts.snap
+++ b/packages/compute-baseline/src/baseline/index.test.ts.snap
@@ -11,8 +11,8 @@ Object {
 }",
   "html.elements.form.target": "{
   \\"baseline\\": \\"high\\",
-  \\"baseline_low_date\\": \\"2015-07-28\\",
-  \\"baseline_high_date\\": \\"2018-01-28\\",
+  \\"baseline_low_date\\": \\"2015-07-29\\",
+  \\"baseline_high_date\\": \\"2018-01-29\\",
   \\"support\\": {
     \\"chrome\\": \\"1\\",
     \\"chrome_android\\": \\"18\\",


### PR DESCRIPTION
This does three things:

- Turn on Dependabot upgrades for `compute-baseline`
- Upgrades `compute-baseline`'s BCD to the latest version
- Fixes a test and test snapshot to reflect a change in BCD's release date for Edge 12