### PR TITLE
Make `.prettierignore` opt-ins easier to apply

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,16 +1,13 @@
-/*
+# Exclude all files (but not directories)
+/**/*.*
 
 # Opt-ins
 !GOVERNANCE.md
 
-!/feature-group-definitions/
-/feature-group-definitions/*
 !/feature-group-definitions/*.yml
 
-!/packages/
-/packages/web-features/
+!/packages/compute-baseline/**
+!/packages/web-features/**
 
-!/scripts/
-/scripts/*
-!/scripts/release.ts
 !/scripts/feature-init.ts
+!/scripts/release.ts

--- a/packages/web-features/README.md
+++ b/packages/web-features/README.md
@@ -9,7 +9,7 @@ npm install web-features
 ```
 
 ```js
-import webFeatures from 'web-features';
+import webFeatures from "web-features";
 ```
 
 ## Rendering Baseline statuses with `web-features`

--- a/packages/web-features/index.ts
+++ b/packages/web-features/index.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from "node:url";
 import { FeatureData } from "./types";
 
 const jsonPath = fileURLToPath(new URL("./index.json", import.meta.url));
-const features = JSON.parse(readFileSync(jsonPath, { encoding: "utf-8" })) as { [id: string]: FeatureData };
+const features = JSON.parse(readFileSync(jsonPath, { encoding: "utf-8" })) as {
+  [id: string]: FeatureData;
+};
 
 export default features;


### PR DESCRIPTION
As written before, it opted-out directories too. This makes adding more files to the configuration a bit of a pain: you have to opt-in the directory first. This PR fixes that (and cleans up a couple files probably erroneously left out).