### PR TITLE
`compute-baseline`: fix incorrect status for future-dated "high" statuses

### DIFF
--- a/packages/compute-baseline/src/baseline/index.test.ts
+++ b/packages/compute-baseline/src/baseline/index.test.ts
@@ -77,7 +77,7 @@ describe("computeBaseline", function () {
 });
 
 describe("keystoneDateToStatus()", function () {
-  it('returns `"low"` for recent dates', function () {
+  it('returns "low" for recent dates', function () {
     const status = keystoneDateToStatus(
       Temporal.Now.plainDateISO().subtract({ days: 7 }),
     );

--- a/packages/compute-baseline/src/baseline/index.test.ts
+++ b/packages/compute-baseline/src/baseline/index.test.ts
@@ -3,7 +3,8 @@ import assert from "node:assert/strict";
 import * as chai from "chai";
 import chaiJestSnapshot from "chai-jest-snapshot";
 
-import { computeBaseline } from ".";
+import { computeBaseline, keystoneDateToStatus } from ".";
+import { Temporal } from "@js-temporal/polyfill";
 
 chai.use(chaiJestSnapshot);
 
@@ -72,5 +73,39 @@ describe("computeBaseline", function () {
     assert.equal(result.baseline, "high");
     assert.equal(result.baseline_low_date, "2015-07-29"); // The first release of Edge, the youngest release in consideration
     assert.equal(result.baseline_high_date, "2018-01-29"); // 30 months later
+  });
+});
+
+describe("keystoneDateToStatus()", function () {
+  it('returns `"low"` for recent dates', function () {
+    const status = keystoneDateToStatus(
+      Temporal.Now.plainDateISO().subtract({ days: 7 }),
+    );
+    assert.equal(status.baseline, "low");
+    assert.equal(typeof status.baseline_low_date, "string");
+    assert.equal(status.baseline_high_date, null);
+  });
+
+  it('returns `"high"` for long past dates', function () {
+    const status = keystoneDateToStatus(Temporal.PlainDate.from("2020-01-01"));
+    assert.equal(status.baseline, "high");
+    assert.equal(typeof status.baseline_low_date, "string");
+    assert.equal(typeof status.baseline_high_date, "string");
+  });
+
+  it("returns `false` for future dates", function () {
+    const status = keystoneDateToStatus(
+      Temporal.Now.plainDateISO().add({ days: 90 }),
+    );
+    assert.equal(status.baseline, false);
+    assert.equal(status.baseline_low_date, null);
+    assert.equal(status.baseline_high_date, null);
+  });
+
+  it("returns `false` for null dates", function () {
+    const status = keystoneDateToStatus(null);
+    assert.equal(status.baseline, false);
+    assert.equal(status.baseline_low_date, null);
+    assert.equal(status.baseline_high_date, null);
   });
 });

--- a/packages/compute-baseline/src/baseline/index.test.ts
+++ b/packages/compute-baseline/src/baseline/index.test.ts
@@ -86,14 +86,14 @@ describe("keystoneDateToStatus()", function () {
     assert.equal(status.baseline_high_date, null);
   });
 
-  it('returns `"high"` for long past dates', function () {
+  it('returns "high" for long past dates', function () {
     const status = keystoneDateToStatus(Temporal.PlainDate.from("2020-01-01"));
     assert.equal(status.baseline, "high");
     assert.equal(typeof status.baseline_low_date, "string");
     assert.equal(typeof status.baseline_high_date, "string");
   });
 
-  it("returns `false` for future dates", function () {
+  it("returns false for future dates", function () {
     const status = keystoneDateToStatus(
       Temporal.Now.plainDateISO().add({ days: 90 }),
     );
@@ -102,7 +102,7 @@ describe("keystoneDateToStatus()", function () {
     assert.equal(status.baseline_high_date, null);
   });
 
-  it("returns `false` for null dates", function () {
+  it("returns false for null dates", function () {
     const status = keystoneDateToStatus(null);
     assert.equal(status.baseline, false);
     assert.equal(status.baseline_low_date, null);

--- a/packages/compute-baseline/src/baseline/index.ts
+++ b/packages/compute-baseline/src/baseline/index.ts
@@ -146,7 +146,7 @@ function collateSupport(
  * Given several dates, find the most-recent date and determine the
  * corresponding Baseline status and high and low dates.
  */
-function keystoneDateToStatus(date: Temporal.PlainDate | null): {
+export function keystoneDateToStatus(date: Temporal.PlainDate | null): {
   baseline: BaselineStatus;
   baseline_low_date: BaselineDate;
   baseline_high_date: BaselineDate;
@@ -168,7 +168,7 @@ function keystoneDateToStatus(date: Temporal.PlainDate | null): {
   if (baseline === "low") {
     assert(date !== null);
     const possibleHighDate = toHighDate(date);
-    if (isFuture(date)) {
+    if (isFuture(possibleHighDate)) {
       baseline_high_date = null;
     } else {
       baseline = "high";


### PR DESCRIPTION
Presently, an actual Baseline `"low"` status can result in an erroneous `"high"` status with a future-dated `baseline_high_date`. For example, given the keystone date of 2024-04-04 (today), you'd get this back:

```js
{
  baseline: "high",
  baseline_low_date: "2024-04-04",
  baseline_high_date: "2026-10-04"
}
```

This PR fixes the faulty check for future `baseline_high_date` values and puts in some tests to prevent it from happening again.