### PR TITLE
Add utilities for finding BCD tag data

### DIFF
--- a/packages/compute-baseline/src/browser-compat-data/compat.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/compat.test.ts
@@ -52,7 +52,7 @@ describe("Compat()", function () {
       const c = new Compat();
       const walker = c.walk();
 
-      // Running for the whole tree is a little, so let's just check the first few.
+      // Running for the whole tree is a little slow, so let's just check the first few.
       let index = 100;
       while (index--) {
         const { value } = walker.next();
@@ -62,8 +62,8 @@ describe("Compat()", function () {
 
     it("generates only items in specified entry points", function () {
       const c = new Compat();
-      for (const f of c.walk(["css"])) {
-        assert(f.id.startsWith("css."));
+      for (const f of c.walk(["http"])) {
+        assert(f.id.startsWith("http."));
       }
     });
   });

--- a/packages/compute-baseline/src/browser-compat-data/compat.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/compat.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 
 import { Compat } from "./compat";
+import { Feature } from ".";
 
 describe("Compat()", function () {
   describe("constructor", function () {
@@ -43,6 +44,27 @@ describe("Compat()", function () {
       const f = c.feature("css.properties.display");
       assert(f.mdn_url);
       assert(f.id);
+    });
+  });
+
+  describe("walk()", function () {
+    it("generates many Feature objects by default", function () {
+      const c = new Compat();
+      const walker = c.walk();
+
+      // Running for the whole tree is a little, so let's just check the first few.
+      let index = 100;
+      while (index--) {
+        const { value } = walker.next();
+        assert(value instanceof Feature);
+      }
+    });
+
+    it("generates only items in specified entry points", function () {
+      const c = new Compat();
+      for (const f of c.walk(["css"])) {
+        assert(f.id.startsWith("css."));
+      }
     });
   });
 });

--- a/packages/compute-baseline/src/browser-compat-data/compat.ts
+++ b/packages/compute-baseline/src/browser-compat-data/compat.ts
@@ -32,10 +32,11 @@ export class Compat {
    * @param {string[]} [entryPoints] An array of dotted paths to compat features (e.g., `css.properties.background-color`)
    */
   *walk(entryPoints?: string[]): Generator<Feature> {
-    const defaultEntryPoints = Object.keys(this.data as CompatData).filter(
-      (key) => !["__meta", "browsers"].includes(key),
-    );
-    entryPoints = entryPoints ?? defaultEntryPoints;
+    if (!entryPoints) {
+      entryPoints = Object.keys(this.data as CompatData).filter(
+        (key) => !["__meta", "browsers"].includes(key),
+      );
+    }
 
     for (const { path } of walk(entryPoints, this.data as CompatData)) {
       yield this.feature(path);

--- a/packages/compute-baseline/src/browser-compat-data/compat.ts
+++ b/packages/compute-baseline/src/browser-compat-data/compat.ts
@@ -1,5 +1,5 @@
-import bcd from "@mdn/browser-compat-data";
-import { Browser, Feature, browser, feature, query } from ".";
+import bcd, { CompatData } from "@mdn/browser-compat-data";
+import { Browser, Feature, browser, feature, query, walk } from ".";
 
 export class Compat {
   data: unknown;
@@ -22,6 +22,24 @@ export class Compat {
 
   feature(id: string): Feature {
     return feature(id, this);
+  }
+
+  /**
+   * Generate `Feature` objects by walking tree of features.
+   *
+   * Similar to the `traverse` command in mdn/browser-compat-data.
+   *
+   * @param {string[]} [entryPoints] An array of dotted paths to compat features (e.g., `css.properties.background-color`)
+   */
+  *walk(entryPoints?: string[]): Generator<Feature> {
+    const defaultEntryPoints = Object.keys(this.data as CompatData).filter(
+      (key) => !["__meta", "browsers"].includes(key),
+    );
+    entryPoints = entryPoints ?? defaultEntryPoints;
+
+    for (const { path } of walk(entryPoints, this.data as CompatData)) {
+      yield this.feature(path);
+    }
   }
 }
 

--- a/packages/compute-baseline/src/browser-compat-data/feature.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.test.ts
@@ -25,5 +25,21 @@ describe("features", function () {
         assert.equal(releases, expectedReleases);
       });
     });
+
+    describe("tags", function () {
+      it("returns an array for features with tags", function () {
+        const f = feature("css.types.length.cap");
+        assert(Array.isArray(f.data.__compat?.tags));
+        assert(Array.isArray(f.tags));
+        assert(f.tags.length > 0);
+      });
+
+      it("returns an array for features without tags", function () {
+        const f = feature("webextensions.manifest.author");
+        assert.equal(f.data.__compat?.tags, undefined);
+        assert(Array.isArray(f.tags));
+        assert(f.tags.length === 0);
+      });
+    });
   });
 });

--- a/packages/compute-baseline/src/browser-compat-data/feature.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.ts
@@ -38,6 +38,15 @@ export class Feature {
     return `[Feature ${this.id}]`;
   }
 
+  /**
+   * Return the feature's tags as an array (wthether there are any tags or not).
+   */
+  get tags(): string[] {
+    return Array.isArray(this.data.__compat?.tags)
+      ? this.data.__compat?.tags
+      : [];
+  }
+
   get mdn_url(): string | undefined {
     return this.data.__compat?.mdn_url;
   }

--- a/packages/compute-baseline/src/browser-compat-data/feature.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.ts
@@ -42,9 +42,7 @@ export class Feature {
    * Return the feature's tags as an array (wthether there are any tags or not).
    */
   get tags(): string[] {
-    return Array.isArray(this.data.__compat?.tags)
-      ? this.data.__compat?.tags
-      : [];
+    return this.data.__compat?.tags ?? [];
   }
 
   get mdn_url(): string | undefined {


### PR DESCRIPTION
This PR adds two new helpers to compute-baseline:

- A `walk()` generator on `Compat`, to offer something a bit like BCD's `traverse` command. This code (mostly) already exists, just not attached to the `Compat` interface.
- A `tags` getter on feature objects, to have checking for an array of tags in a BCD `__compat` object in one place.

This is the last of the table setting for generating statuses from authored YAML files.