### PR TITLE
Remove compat keys for line-clamp

### DIFF
--- a/feature-group-definitions/line-clamp.yml
+++ b/feature-group-definitions/line-clamp.yml
@@ -1,9 +1,3 @@
 name: line-clamp
 spec: https://drafts.csswg.org/css-overflow-3/#line-clamp
 caniuse: css-line-clamp
-compat_features:
-  # This is a weird one! Specified with a prefix:
-  # https://drafts.csswg.org/css-overflow-4/#propdef--webkit-line-clamp
-  - css.properties.-webkit-line-clamp
-  # This doesn't exist yet, but might in the future:
-  # - css.properties.line-clamp


### PR DESCRIPTION
We will most likely need to handle this feature manually and decide if we want it to cover just the unprefixed `line-clamp` or also `-webkit-line-clamp`. To avoid computing anything automatically, remove the compat keys.