### PR TITLE
Fix broken BCD paths in compat_keys

### DIFF
--- a/feature-group-definitions/appearance.yml
+++ b/feature-group-definitions/appearance.yml
@@ -5,7 +5,6 @@ usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/658
 compat_features:
   - css.properties.appearance
   - css.properties.appearance.auto
-  - css.properties.appearance.compat-auto
   - css.properties.appearance.menulist-button
   - css.properties.appearance.none
   - css.properties.appearance.textfield

--- a/feature-group-definitions/map.yml
+++ b/feature-group-definitions/map.yml
@@ -35,7 +35,7 @@ compat_features:
   - javascript.builtins.Map.Map
   - javascript.builtins.Map.Map.iterable_allowed
   - javascript.builtins.Map.Map.new_required
-  - javascript.builtins.Map.Map.new_required.null_allowed
+  - javascript.builtins.Map.Map.null_allowed
   - javascript.builtins.Map.clear
   - javascript.builtins.Map.delete
   - javascript.builtins.Map.entries

--- a/feature-group-definitions/modulepreload.yml
+++ b/feature-group-definitions/modulepreload.yml
@@ -2,4 +2,4 @@ name: '<link rel="modulepreload">'
 spec: https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload
 caniuse: link-rel-modulepreload
 compat_features:
-  - html.elements.link.modulepreload
+  - html.elements.link.rel.modulepreload


### PR DESCRIPTION
One has been removed:
https://github.com/mdn/browser-compat-data/pull/22546

The others look like typos.
