### PR TITLE
Test `computeBaseline`'s `withAncestors` option

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,4 +11,5 @@
 
 !/scripts/dist.ts
 !/scripts/feature-init.ts
+!/scripts/find-troublesome-ancestors.ts
 !/scripts/release.ts

--- a/packages/compute-baseline/src/baseline/index.test.ts
+++ b/packages/compute-baseline/src/baseline/index.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 
+import { Temporal } from "@js-temporal/polyfill";
 import * as chai from "chai";
 import chaiJestSnapshot from "chai-jest-snapshot";
 
 import { computeBaseline, keystoneDateToStatus } from ".";
-import { Temporal } from "@js-temporal/polyfill";
 
 chai.use(chaiJestSnapshot);
 
@@ -73,6 +73,20 @@ describe("computeBaseline", function () {
     assert.equal(result.baseline, "high");
     assert.equal(result.baseline_low_date, "2015-07-29"); // The first release of Edge, the youngest release in consideration
     assert.equal(result.baseline_high_date, "2018-01-29"); // 30 months later
+  });
+
+  it("finds discrepancies with ancestors (checkAncestors)", function () {
+    const compatKeys: [string, ...string[]] = ["api.Notification.body"];
+    const result = computeBaseline({ compatKeys, checkAncestors: false });
+    const resultWithAncestors = computeBaseline({
+      compatKeys,
+      checkAncestors: true,
+    });
+    assert.notEqual(result.baseline, resultWithAncestors.baseline);
+    assert.notEqual(
+      result.baseline_low_date?.toString(),
+      resultWithAncestors.baseline_low_date?.toString(),
+    );
   });
 });
 

--- a/scripts/find-troublesome-ancestors.ts
+++ b/scripts/find-troublesome-ancestors.ts
@@ -1,0 +1,41 @@
+import { computeBaseline } from "compute-baseline";
+import { Compat } from "compute-baseline/browser-compat-data";
+
+const c = new Compat();
+const needles = [];
+
+for (const feature of c.walk()) {
+  try {
+    const lone = computeBaseline({
+      compatKeys: [feature.id],
+      checkAncestors: false,
+    });
+    const ancestral = computeBaseline({
+      compatKeys: [feature.id],
+      checkAncestors: true,
+    });
+    if (lone.baseline !== ancestral.baseline) {
+      needles.push([
+        feature,
+        JSON.parse(lone.toJSON()),
+        JSON.parse(ancestral.toJSON()),
+      ]);
+    }
+  } catch (err) {
+    if (err instanceof Error) {
+      err.message.includes("contains non-real values");
+      console.warn(
+        `${feature.id} or an ancestor contains non-real-values. Skipping.`,
+      );
+      continue;
+    }
+  }
+}
+
+console.log("| Compat key | Baseline status | With ancestors |");
+console.log("| --- | --- | --- |");
+for (const [feature, lone, ancestral] of needles) {
+  console.log(
+    `| \`${feature.id}\` | \`${lone.baseline}\` | \`${ancestral.baseline}\` |`,
+  );
+}


### PR DESCRIPTION
This PR tests the `withAncestors` option. There are two things in this PR:

1. A test that asserts that the results of the Baseline calculation `api.Notification.body` is different with and without ancestor features (i.e., the reported support for `api.Notification.body` is _greater_ than the reported supported for `api.Notification` and `api.Notification.body`).

   Why is this important? See the MDN page [Notification: body property](https://developer.mozilla.org/en-US/docs/Web/API/Notification/body#browser_compatibility) and compare it to what you see in [Notification](https://developer.mozilla.org/en-US/docs/Web/API/Notification#browser_compatibility).
   
   If you look at [this gist of such features](https://gist.github.com/ddbeck/e3e78201c60170152b020fc983bb163b) you'll see that there are dozens that are hypothetically like it—fewer than I expected! However, cases like `api.Notification.body`, where there's a standalone MDN page for the feature, represent the most-risky cases of this.
  
2. The script I used to find that feature (and several others like it): `scripts/find-troublesome-ancestors.ts`.