### PR TITLE
Add an HTML group with subgroups

### DIFF
--- a/feature-group-definitions/audio-video-tracks.yml
+++ b/feature-group-definitions/audio-video-tracks.yml
@@ -1,5 +1,6 @@
 name: Audio and video tracks
 description: The `audioTracks` and `videoTracks` APIs for media elements switch audio and video tracks during playback.
+group: media-elements
 spec: https://html.spec.whatwg.org/multipage/media.html#media-resources-with-multiple-media-tracks
 caniuse:
   - audiotracks

--- a/feature-group-definitions/autofill.dist.yml
+++ b/feature-group-definitions/autofill.dist.yml
@@ -4,6 +4,7 @@
 name: ":autofill"
 description: "The `:autofill` pseudo-class matches `<input>` elements that have been filled in automatically by the browser."
 spec: https://html.spec.whatwg.org/multipage/semantics-other.html#selector-autofill
+group: forms
 status:
   baseline: low
   baseline_low_date: 2023-02-09

--- a/feature-group-definitions/autofill.yml
+++ b/feature-group-definitions/autofill.yml
@@ -1,5 +1,6 @@
 name: ":autofill"
 description: "The `:autofill` pseudo-class matches `<input>` elements that have been filled in automatically by the browser."
 spec: https://html.spec.whatwg.org/multipage/semantics-other.html#selector-autofill
+group: forms
 compat_features:
   - css.selectors.autofill

--- a/feature-group-definitions/blocking-render.dist.yml
+++ b/feature-group-definitions/blocking-render.dist.yml
@@ -10,6 +10,7 @@ description: 'The `blocking="render"` attribute for `<link>`, `<script>`, and `<
 #  - Doesn't work on non-async classic scripts
 #  - Only works for on <link rel=stylesheet> and <link rel=expect>, not other <link>s
 spec: https://html.spec.whatwg.org/multipage/urls-and-fetching.html#blocking-attributes
+group: html
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4183
 status:
   baseline: false

--- a/feature-group-definitions/blocking-render.yml
+++ b/feature-group-definitions/blocking-render.yml
@@ -7,6 +7,7 @@ description: 'The `blocking="render"` attribute for `<link>`, `<script>`, and `<
 #  - Doesn't work on non-async classic scripts
 #  - Only works for on <link rel=stylesheet> and <link rel=expect>, not other <link>s
 spec: https://html.spec.whatwg.org/multipage/urls-and-fetching.html#blocking-attributes
+group: html
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4183
 compat_features:
   - api.HTMLLinkElement.blocking

--- a/feature-group-definitions/constraint-validation.dist.yml
+++ b/feature-group-definitions/constraint-validation.dist.yml
@@ -4,6 +4,7 @@
 name: Constraint validation API
 description: Methods that validate form controls before submission, such as `checkValidity()`, `reportValidity()` and `setCustomValidity()`.
 spec: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api
+group: forms
 caniuse: constraint-validation
 status:
   baseline: low

--- a/feature-group-definitions/constraint-validation.yml
+++ b/feature-group-definitions/constraint-validation.yml
@@ -1,4 +1,5 @@
 name: Constraint validation API
 description: Methods that validate form controls before submission, such as `checkValidity()`, `reportValidity()` and `setCustomValidity()`.
 spec: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api
+group: forms
 caniuse: constraint-validation

--- a/feature-group-definitions/custom-elements.dist.yml
+++ b/feature-group-definitions/custom-elements.dist.yml
@@ -4,6 +4,7 @@
 name: Custom elements
 description: Custom elements are HTML elements with behavior that you define.
 spec: https://html.spec.whatwg.org/multipage/custom-elements.html
+group: html
 caniuse: custom-elementsv1
 status:
   baseline: false

--- a/feature-group-definitions/custom-elements.yml
+++ b/feature-group-definitions/custom-elements.yml
@@ -1,4 +1,5 @@
 name: Custom elements
 description: Custom elements are HTML elements with behavior that you define.
 spec: https://html.spec.whatwg.org/multipage/custom-elements.html
+group: html
 caniuse: custom-elementsv1

--- a/feature-group-definitions/declarative-shadow-dom.dist.yml
+++ b/feature-group-definitions/declarative-shadow-dom.dist.yml
@@ -4,6 +4,7 @@
 name: Declarative shadow DOM
 description: The `shadowrootmode` attribute on `<template>` creates a shadow root without the use of JavaScript. It is a declarative alternative to the `attachShadow()` method.
 spec: https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootmode
+group: html
 # Caniuse doesn't match our data because of https://github.com/Fyrd/caniuse/issues/7025.
 caniuse: declarative-shadow-dom
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4421

--- a/feature-group-definitions/declarative-shadow-dom.yml
+++ b/feature-group-definitions/declarative-shadow-dom.yml
@@ -1,6 +1,7 @@
 name: Declarative shadow DOM
 description: The `shadowrootmode` attribute on `<template>` creates a shadow root without the use of JavaScript. It is a declarative alternative to the `attachShadow()` method.
 spec: https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootmode
+group: html
 # Caniuse doesn't match our data because of https://github.com/Fyrd/caniuse/issues/7025.
 caniuse: declarative-shadow-dom
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4421

--- a/feature-group-definitions/details-name.dist.yml
+++ b/feature-group-definitions/details-name.dist.yml
@@ -3,6 +3,7 @@
 
 name: Mutually exclusive <details> elements
 spec: https://html.spec.whatwg.org/multipage/interactive-elements.html#attr-details-name
+group: html
 status:
   baseline: false
   support:

--- a/feature-group-definitions/details-name.yml
+++ b/feature-group-definitions/details-name.yml
@@ -1,5 +1,6 @@
 name: Mutually exclusive <details> elements
 spec: https://html.spec.whatwg.org/multipage/interactive-elements.html#attr-details-name
+group: html
 compat_features:
   - api.HTMLDetailsElement.name
   - html.elements.details.name

--- a/feature-group-definitions/details.dist.yml
+++ b/feature-group-definitions/details.dist.yml
@@ -3,6 +3,7 @@
 
 name: <details>
 spec: https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element
+group: html
 caniuse: details
 status:
   baseline: high

--- a/feature-group-definitions/details.yml
+++ b/feature-group-definitions/details.yml
@@ -1,5 +1,6 @@
 name: <details>
 spec: https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element
+group: html
 caniuse: details
 compat_features:
   - api.HTMLDetailsElement

--- a/feature-group-definitions/dialog.dist.yml
+++ b/feature-group-definitions/dialog.dist.yml
@@ -3,6 +3,7 @@
 
 name: "<dialog>"
 spec: https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element
+group: html
 caniuse: dialog
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/481
 status:

--- a/feature-group-definitions/dialog.yml
+++ b/feature-group-definitions/dialog.yml
@@ -1,4 +1,5 @@
 name: "<dialog>"
 spec: https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element
+group: html
 caniuse: dialog
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/481

--- a/feature-group-definitions/fast-seek.yml
+++ b/feature-group-definitions/fast-seek.yml
@@ -1,6 +1,7 @@
 name: fastSeek()
 description: The `fastSeek()` method seeks an `<audio>` or `<video>` element as fast as possible, by seeking to a keyframe instead of exactly the requested time.
 spec: https://html.spec.whatwg.org/multipage/media.html#dom-media-fastseek-dev
+group: media-elements
 status:
   baseline: false
   support:

--- a/feature-group-definitions/indeterminate.dist.yml
+++ b/feature-group-definitions/indeterminate.dist.yml
@@ -5,6 +5,7 @@ name: ":indeterminate()"
 spec:
   - https://drafts.csswg.org/selectors-4/#indeterminate
   - https://html.spec.whatwg.org/multipage/semantics-other.html#selector-indeterminate
+group: forms
 caniuse: css-indeterminate-pseudo
 status:
   baseline: high

--- a/feature-group-definitions/indeterminate.yml
+++ b/feature-group-definitions/indeterminate.yml
@@ -2,4 +2,5 @@ name: ":indeterminate()"
 spec:
   - https://drafts.csswg.org/selectors-4/#indeterminate
   - https://html.spec.whatwg.org/multipage/semantics-other.html#selector-indeterminate
+group: forms
 caniuse: css-indeterminate-pseudo

--- a/feature-group-definitions/media-pseudos.dist.yml
+++ b/feature-group-definitions/media-pseudos.dist.yml
@@ -6,6 +6,7 @@ description: The `:playing`, `:paused`, `:seeking`, `:buffering`, `:stalled`, `:
 spec:
   - https://drafts.csswg.org/selectors-4/#resource-pseudos
   - https://html.spec.whatwg.org/multipage/semantics-other.html#pseudo-classes
+group: media-elements
 status:
   baseline: false
   support:

--- a/feature-group-definitions/media-pseudos.yml
+++ b/feature-group-definitions/media-pseudos.yml
@@ -3,6 +3,7 @@ description: The `:playing`, `:paused`, `:seeking`, `:buffering`, `:stalled`, `:
 spec:
   - https://drafts.csswg.org/selectors-4/#resource-pseudos
   - https://html.spec.whatwg.org/multipage/semantics-other.html#pseudo-classes
+group: media-elements
 compat_features:
   - css.selectors.buffering
   - css.selectors.muted

--- a/feature-group-definitions/popover.yml
+++ b/feature-group-definitions/popover.yml
@@ -1,6 +1,7 @@
 name: Popover
 description: The `popover` HTML attribute creates an overlay to display content on top of other page content. Popovers can be shown declaratively using HTML, or using the `showPopover()` method.
 spec: https://html.spec.whatwg.org/multipage/popover.html
+group: html
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4191
 status:
   baseline: false

--- a/feature-group-definitions/read-write-pseudos.yml
+++ b/feature-group-definitions/read-write-pseudos.yml
@@ -3,6 +3,7 @@ description: The `:read-only` and `:read-write` CSS pseudo-classes match element
 spec:
   - https://html.spec.whatwg.org/multipage/semantics-other.html#selector-read-only
   - https://drafts.csswg.org/selectors-4/#rw-pseudos
+group: forms
 alias: read-write-pseudo-classes
 caniuse: css-read-only-write
 status:

--- a/feature-group-definitions/search-input-type.yml
+++ b/feature-group-definitions/search-input-type.yml
@@ -1,5 +1,6 @@
 name: '<input type="search">'
 spec: https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)
+group: forms
 caniuse: input-search
 compat_features:
   - html.elements.input.type_search

--- a/feature-group-definitions/search.dist.yml
+++ b/feature-group-definitions/search.dist.yml
@@ -3,6 +3,7 @@
 
 name: <search>
 spec: https://html.spec.whatwg.org/multipage/grouping-content.html#the-search-element
+group: html
 status:
   baseline: low
   baseline_low_date: 2023-10-13

--- a/feature-group-definitions/search.yml
+++ b/feature-group-definitions/search.yml
@@ -1,4 +1,5 @@
 name: <search>
 spec: https://html.spec.whatwg.org/multipage/grouping-content.html#the-search-element
+group: html
 compat_features:
   - html.elements.search

--- a/feature-group-definitions/show-picker-input.yml
+++ b/feature-group-definitions/show-picker-input.yml
@@ -1,6 +1,7 @@
 name: showPicker() for <input>
 description: The `showPicker()` method for `<input>` elements shows the user interface for picking a value. For example, for `<input type="date">` it shows the interface for picking a date.
 spec: https://html.spec.whatwg.org/multipage/input.html#dom-input-showpicker
+group: forms
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4097
 compat_features:
   - api.HTMLInputElement.showPicker

--- a/feature-group-definitions/show-picker-select.dist.yml
+++ b/feature-group-definitions/show-picker-select.dist.yml
@@ -4,6 +4,7 @@
 name: showPicker() for <select>
 description: The `showPicker()` method for `<select>` elements shows the dropdown menu or other user interface for picking one of the options.
 spec: https://html.spec.whatwg.org/multipage/input.html#dom-select-showpicker
+group: forms
 status:
   baseline: false
   support:

--- a/feature-group-definitions/show-picker-select.yml
+++ b/feature-group-definitions/show-picker-select.yml
@@ -1,5 +1,6 @@
 name: showPicker() for <select>
 description: The `showPicker()` method for `<select>` elements shows the dropdown menu or other user interface for picking one of the options.
 spec: https://html.spec.whatwg.org/multipage/input.html#dom-select-showpicker
+group: forms
 compat_features:
   - api.HTMLSelectElement.showPicker

--- a/feature-group-definitions/slot.yml
+++ b/feature-group-definitions/slot.yml
@@ -1,5 +1,6 @@
 name: <slot>
 spec: https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element
+group: html
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1898
 compat_features:
   - api.Element.assignedSlot

--- a/feature-group-definitions/tabindex.dist.yml
+++ b/feature-group-definitions/tabindex.dist.yml
@@ -3,6 +3,7 @@
 
 name: tabindex
 spec: https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex
+group: html
 caniuse: tabindex-attr
 status:
   baseline: high

--- a/feature-group-definitions/tabindex.yml
+++ b/feature-group-definitions/tabindex.yml
@@ -1,3 +1,4 @@
 name: tabindex
 spec: https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex
+group: html
 caniuse: tabindex-attr

--- a/feature-group-definitions/template.dist.yml
+++ b/feature-group-definitions/template.dist.yml
@@ -3,6 +3,7 @@
 
 name: <template>
 spec: https://html.spec.whatwg.org/multipage/scripting.html#the-template-element
+group: html
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2769
 status:
   baseline: high

--- a/feature-group-definitions/template.yml
+++ b/feature-group-definitions/template.yml
@@ -1,5 +1,6 @@
 name: <template>
 spec: https://html.spec.whatwg.org/multipage/scripting.html#the-template-element
+group: html
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2769
 compat_features:
   - api.HTMLTemplateElement

--- a/groups/forms.yml
+++ b/groups/forms.yml
@@ -1,0 +1,4 @@
+# This group is for <form>, all form controls, and APIs or CSS features
+# specific to them.
+name: Forms
+parent: html

--- a/groups/html.yml
+++ b/groups/html.yml
@@ -1,0 +1,8 @@
+# This group isn't intended for everything defined in HTML:
+# spec: https://html.spec.whatwg.org/multipage/
+#
+# It is for the markup language, and not for all APIs and infrastructure
+# defined in HTML. For example, structuredClone() should not be in this group.
+# APIs on HTML*Element and CSS features specific to an HTML element generally
+# do make sense to group under HTML, however.
+name: HTML

--- a/groups/media-elements.yml
+++ b/groups/media-elements.yml
@@ -1,0 +1,4 @@
+# Media elements are <audio> and <video>, but the <track> element is also
+# included in this group.
+name: Media elements
+parent: html


### PR DESCRIPTION
This is mainly to group forms and media elements, but a few features make sense in the parent group too.

These features defined by HTML are not in any of these groups:

- `<link rel="modulepreload">`
- BroadcastChannel
- contextlost and contextrestored
- Fetch priority
- Import maps
- JavaScript modules
- Navigation API
- Offscreen canvas
- structuredClone()

`<link rel="modulepreload">` is a borderline case, maybe it's HTML, maybe it's Modules, or maybe it's both. This can be revisted.
