### PR TITLE
Add BCD as a dev dependency

### DIFF
--- a/feature-group-definitions/starting-style.dist.yml
+++ b/feature-group-definitions/starting-style.dist.yml
@@ -9,6 +9,8 @@ status:
     chrome: "117"
     chrome_android: "117"
     edge: "117"
+    safari: "17.5"
+    safari_ios: "17.5"
 compat_features:
   - api.CSSStartingStyleRule
   - css.at-rules.starting-style

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "@js-temporal/polyfill": "^0.4.4",
+        "@mdn/browser-compat-data": "^5.5.21",
         "@types/caniuse-lite": "^1.0.4",
         "@types/node": "^18.19.31",
         "ajv": "^8.12.0",
@@ -432,11 +433,10 @@
       }
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.5.18",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.5.18.tgz",
-      "integrity": "sha512-G3Py1J3B5NgMJktE+m+COnNlzHmccyyKAueOnivX6tecFyCzRGZCzc525n2uRGNMa3F7AqKa+Re4IvzV3Z4EYw==",
-      "dev": true,
-      "peer": true
+      "version": "5.5.21",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.5.21.tgz",
+      "integrity": "sha512-M+KqctZP6J3kIHI+SwQMPbjUM510ex690NRBm0jlFwJ+TNvvuHcp3vCEzUzwtVj5RWEuTROgy5U++3XnN1Przg==",
+      "dev": true
     },
     "node_modules/@types/caniuse-lite": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@js-temporal/polyfill": "^0.4.4",
+    "@mdn/browser-compat-data": "^5.5.21",
     "@types/caniuse-lite": "^1.0.4",
     "@types/node": "^18.19.31",
     "ajv": "^8.12.0",

--- a/packages/compute-baseline/package-lock.json
+++ b/packages/compute-baseline/package-lock.json
@@ -13,6 +13,7 @@
         "compare-versions": "^6.1.0"
       },
       "devDependencies": {
+        "@mdn/browser-compat-data": "^5.5.21",
         "@types/chai": "^4.3.14",
         "@types/chai-jest-snapshot": "^1.3.8",
         "@types/mocha": "^10.0.6",
@@ -38,10 +39,10 @@
       }
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.5.19",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.5.19.tgz",
-      "integrity": "sha512-ntKBZtwWCy4XvJosdTJKqIMdmzgbxjopfoiMxgpzsml3dXqA7MIHCE/amidfQc06a6KvmMrpiVuYHIBt2feDog==",
-      "peer": true
+      "version": "5.5.21",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.5.21.tgz",
+      "integrity": "sha512-M+KqctZP6J3kIHI+SwQMPbjUM510ex690NRBm0jlFwJ+TNvvuHcp3vCEzUzwtVj5RWEuTROgy5U++3XnN1Przg==",
+      "dev": true
     },
     "node_modules/@types/chai": {
       "version": "4.3.14",

--- a/packages/compute-baseline/package.json
+++ b/packages/compute-baseline/package.json
@@ -15,6 +15,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "@mdn/browser-compat-data": "^5.5.21",
     "@types/chai": "^4.3.14",
     "@types/chai-jest-snapshot": "^1.3.8",
     "@types/mocha": "^10.0.6",


### PR DESCRIPTION
This should allow Dependabot to send dependency updates for BCD, and it
was stuck at 5.5.18 and 5.5.19 in the package-lock.json files.

compute-baseline needs it as a dependency to run tests, and
package-lock.json is needed for `npm ci` to work.

The top-level package.json needs it as a dependency since it's a peer
dependency of compute-baseline, and because `npm test:dist` needs it,
and that dependency should be pinned. starting-style.dist.yml needed
updating, and those updates should go with dependency bumps.

This is a bit convoluted and perhaps will confuse Dependabot, but it's
what would make sense if compute-baseline was in a separate repository
and we installed it from NPM.
