### PR TITLE
Remove obsolete comment about caniuse mismatch

### DIFF
--- a/feature-group-definitions/declarative-shadow-dom.dist.yml
+++ b/feature-group-definitions/declarative-shadow-dom.dist.yml
@@ -5,7 +5,6 @@ name: Declarative shadow DOM
 description: The `shadowrootmode` attribute on `<template>` creates a shadow root without the use of JavaScript. It is a declarative alternative to the `attachShadow()` method.
 spec: https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootmode
 group: html
-# Caniuse doesn't match our data because of https://github.com/Fyrd/caniuse/issues/7025.
 caniuse: declarative-shadow-dom
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4421
 status:

--- a/feature-group-definitions/declarative-shadow-dom.yml
+++ b/feature-group-definitions/declarative-shadow-dom.yml
@@ -2,7 +2,6 @@ name: Declarative shadow DOM
 description: The `shadowrootmode` attribute on `<template>` creates a shadow root without the use of JavaScript. It is a declarative alternative to the `attachShadow()` method.
 spec: https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootmode
 group: html
-# Caniuse doesn't match our data because of https://github.com/Fyrd/caniuse/issues/7025.
 caniuse: declarative-shadow-dom
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4421
 compat_features:


### PR DESCRIPTION
https://caniuse.com/declarative-shadow-dom nows shows partial support in
Chrome 90-110.
