### PR TITLE
Unbreak the dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,13 +16,3 @@ updates:
     directory: packages/compute-baseline
     schedule:
       interval: daily
-    versioning-strategy: widen
-    allow:
-      - dependency-type: production
-  - package-ecosystem: npm
-    directory: packages/compute-baseline
-    schedule:
-      interval: daily
-    versioning-strategy: increase
-    allow:
-      - dependency-type: development


### PR DESCRIPTION
In https://github.com/web-platform-dx/web-features/pull/891, I made a change to `dependabot.yml` that was invalid. The combination of `package-ecosystem` and `directory` must be unique, so I can't selectively widen and increase certain dependencies in one `package.json`. Here's hoping the defaults do something reasonable.