### PR TITLE
Set Baseline to `false` for deprecated features

### DIFF
--- a/packages/compute-baseline/src/baseline/index.test.ts
+++ b/packages/compute-baseline/src/baseline/index.test.ts
@@ -111,12 +111,21 @@ describe("computeBaseline", function () {
     chai.expect(result).to.matchSnapshot();
     assert.notEqual(Boolean(result.baseline), true);
   });
+
+  it("rejects deprecated", function () {
+    const actual = computeBaseline({
+      compatKeys: ["javascript.statements.with"],
+      checkAncestors: false,
+    });
+    assert.equal(actual.baseline, false);
+  });
 });
 
 describe("keystoneDateToStatus()", function () {
   it('returns "low" for recent dates', function () {
     const status = keystoneDateToStatus(
       Temporal.Now.plainDateISO().subtract({ days: 7 }),
+      false,
     );
     assert.equal(status.baseline, "low");
     assert.equal(typeof status.baseline_low_date, "string");
@@ -124,7 +133,10 @@ describe("keystoneDateToStatus()", function () {
   });
 
   it('returns "high" for long past dates', function () {
-    const status = keystoneDateToStatus(Temporal.PlainDate.from("2020-01-01"));
+    const status = keystoneDateToStatus(
+      Temporal.PlainDate.from("2020-01-01"),
+      false,
+    );
     assert.equal(status.baseline, "high");
     assert.equal(typeof status.baseline_low_date, "string");
     assert.equal(typeof status.baseline_high_date, "string");
@@ -133,6 +145,7 @@ describe("keystoneDateToStatus()", function () {
   it("returns false for future dates", function () {
     const status = keystoneDateToStatus(
       Temporal.Now.plainDateISO().add({ days: 90 }),
+      false,
     );
     assert.equal(status.baseline, false);
     assert.equal(status.baseline_low_date, null);
@@ -140,7 +153,17 @@ describe("keystoneDateToStatus()", function () {
   });
 
   it("returns false for null dates", function () {
-    const status = keystoneDateToStatus(null);
+    const status = keystoneDateToStatus(null, false);
+    assert.equal(status.baseline, false);
+    assert.equal(status.baseline_low_date, null);
+    assert.equal(status.baseline_high_date, null);
+  });
+
+  it("returns false for discouraged (deprecated, obsolete, etc.) features", function () {
+    const status = keystoneDateToStatus(
+      Temporal.PlainDate.from("2020-01-01"),
+      true,
+    );
     assert.equal(status.baseline, false);
     assert.equal(status.baseline_low_date, null);
     assert.equal(status.baseline_high_date, null);

--- a/packages/compute-baseline/src/browser-compat-data/feature.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.ts
@@ -39,7 +39,14 @@ export class Feature {
   }
 
   /**
-   * Return the feature's tags as an array (whether there are any tags or not).
+   * The deprecation status of this feature, if known.
+   */
+  get deprecated(): boolean | undefined {
+    return this.data.__compat?.status?.deprecated;
+  }
+
+  /**
+   * The feature's tags as an array (whether there are any tags or not).
    */
   get tags(): string[] {
     return this.data.__compat?.tags ?? [];

--- a/scripts/dist.ts
+++ b/scripts/dist.ts
@@ -97,20 +97,16 @@ function toDist(sourcePath: string): YAML.Document {
       ? taggedCompatFeatures
       : undefined,
     status: taggedCompatFeatures.length
-      ? JSON.parse(
-          computeBaseline({
-            compatKeys: taggedCompatFeatures as [string, ...string[]],
-            checkAncestors: false,
-          }).toJSON(),
-        )
+      ? computeBaseline({
+          compatKeys: taggedCompatFeatures as [string, ...string[]],
+          checkAncestors: false,
+        })
       : undefined,
     statusByCompatFeaturesOverride: Array.isArray(overridden.compatFeatures)
-      ? JSON.parse(
-          computeBaseline({
-            compatKeys: overridden.compatFeatures as [string, ...string[]],
-            checkAncestors: false,
-          }).toJSON(),
-        )
+      ? computeBaseline({
+          compatKeys: overridden.compatFeatures as [string, ...string[]],
+          checkAncestors: false,
+        })
       : undefined,
   };
 
@@ -127,7 +123,12 @@ function toDist(sourcePath: string): YAML.Document {
   if (!overridden.status) {
     const status = generated.statusByCompatFeaturesOverride ?? generated.status;
     if (status) {
-      insertStatus(yaml, status);
+      if (status.discouraged) {
+        logger.warn(
+          `${id}: contains at least one deprecated compat feature and can never be Baseline. Was this intentional?`,
+        );
+      }
+      insertStatus(yaml, JSON.parse(status.toJSON()));
     }
   }
 


### PR DESCRIPTION
This PR changes compute-baseline to always set Baseline to false for features marked as deprecated, obsolete, legacy, or otherwise discouraged from use.

Fixes https://github.com/web-platform-dx/web-features/issues/864