### PR TITLE
Make description required without publishing them

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -100,6 +100,12 @@ for (const [key, data] of yamlEntries('feature-group-definitions')) {
         data.status.baseline_high_date = String(highDate);
     }
 
+    // TODO: remove this when description is required by schema.
+    // Part of https://github.com/web-platform-dx/web-features/pull/761.
+    if (!data.description) {
+        throw new Error(`description is missing from ${key}.yml`);
+    }
+
     // Ensure description is not too long.
     if (data.description?.length > descriptionMaxLength) {
         throw new Error(`description in ${key}.yml is too long, ${data.description.length} characters. The maximum allowed length is ${descriptionMaxLength}.`)


### PR DESCRIPTION
This is to ensure all new features have a description as we're working
out the Markdown/HTML details for publishing.
