### PR TITLE
`compute-baseline`: make it `npm pack`-able

### DIFF
--- a/packages/compute-baseline/package.json
+++ b/packages/compute-baseline/package.json
@@ -7,6 +7,9 @@
     ".": "./dist/baseline/index.js",
     "./browser-compat-data": "./dist/browser-compat-data/index.js"
   },
+  "files": [
+    "dist"
+  ],
   "types": "./dist/index.d.ts",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
This is a prerequisite to publishing the package.

To see how this works out, you can do something like `npm pack --workspace=compute-baseline` to get a `.tgz` that's installable elsewhere. Right now, the (complex) logic of `.gitignore` in workspaces means some essential files don't make it into the tarball. After this change, it's sufficiently complete to install. (I used this in the burndown generation yesterday.)

Later, when we have a README, we'll need to add it to the list of files.