### PR TITLE
Limit the length of names to 80 characters

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,9 @@ import { unified } from 'unified';
 
 import { BASELINE_LOW_TO_HIGH_DURATION } from 'compute-baseline';
 
+// The longest name allowed, to allow for compact display.
+const nameMaxLength = 80;
+
 // The longest description allowed, to avoid them growing into documentation.
 const descriptionMaxLength = 300;
 
@@ -127,9 +130,12 @@ for (const [key, data] of yamlEntries('feature-group-definitions')) {
         data.status.baseline_high_date = String(highDate);
     }
 
-    // Ensure description is not too long.
+    // Ensure name and description are not too long.
+    if (data.name?.length > nameMaxLength) {
+        throw new Error(`name in ${key}.yml is too long, ${data.name.length} characters. The maximum allowed length is ${nameMaxLength}.`);
+    }
     if (data.description?.length > descriptionMaxLength) {
-        throw new Error(`description in ${key}.yml is too long, ${data.description.length} characters. The maximum allowed length is ${descriptionMaxLength}.`)
+        throw new Error(`description in ${key}.yml is too long, ${data.description.length} characters. The maximum allowed length is ${descriptionMaxLength}.`);
     }
 
     // Ensure that only known group and snapshot identifiers are used.

--- a/index.ts
+++ b/index.ts
@@ -132,10 +132,10 @@ for (const [key, data] of yamlEntries('feature-group-definitions')) {
 
     // Ensure name and description are not too long.
     if (data.name?.length > nameMaxLength) {
-        throw new Error(`name in ${key}.yml is too long, ${data.name.length} characters. The maximum allowed length is ${nameMaxLength}.`);
+        throw new Error(`The name field in ${key}.yml is too long, ${data.name.length} characters. The maximum allowed length is ${nameMaxLength}.`);
     }
     if (data.description?.length > descriptionMaxLength) {
-        throw new Error(`description in ${key}.yml is too long, ${data.description.length} characters. The maximum allowed length is ${descriptionMaxLength}.`);
+        throw new Error(`The description field in ${key}.yml is too long, ${data.description.length} characters. The maximum allowed length is ${descriptionMaxLength}.`);
     }
 
     // Ensure that only known group and snapshot identifiers are used.


### PR DESCRIPTION
Shorten two CSS function features, the longest of which was 56
characters long. The remaining names that list function names consists
of 3 functions or less.

The longest remaining name is 43 characters long:
ARIA attribute reflection (initial support)
