### PR TITLE
`compute-baseline`: Mark package as not private for first initial release

### DIFF
--- a/packages/compute-baseline/package.json
+++ b/packages/compute-baseline/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "compute-baseline",
   "version": "0.1.0",
   "description": "A library for computing web-features statuses from browser compatibility data",


### PR DESCRIPTION
Once I have this, I can do the first publishing to npm for `compute-baseline`. I'll start with a `next` tag, like we do for the incremental pre-releases of `web-features`.