### PR TITLE
GitHub Actions: Automatically publish compute-baseline (next) on changes

### DIFF
--- a/.github/workflows/publish_next_compute-baseline.yml
+++ b/.github/workflows/publish_next_compute-baseline.yml
@@ -1,13 +1,15 @@
-name: Publish web-features@next
+name: Publish compute-baseline@next
 
 on:
   push:
     branches:
       - "main"
+    paths:
+      - packages/compute-baseline/**
 
 env:
-  package: "web-features"
-  package_dir: "packages/web-features"
+  package: "compute-baseline"
+  package_dir: "packages/compute-baseline"
   dist_tag: "next"
 
 jobs:
@@ -36,22 +38,16 @@ jobs:
           cache: npm
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
-      - run: npm run build
       - name: Get package.json version
         id: version
-        run: echo "VERSION=$(npm version --json | jq --raw-output '.["${{ env.package }}"]')" >> $GITHUB_OUTPUT
-        working-directory: ${{ env.package_dir }}
-      - run: npm install
-        working-directory: ${{ env.package_dir }}
-      - run: npm version --no-git-tag-version "$VERSION-dev-$TIMESTAMP-$(git rev-parse --short HEAD)"
+        run: echo "VERSION=$(npm version --json --workspace=${{ env.package }} | jq --raw-output '.["${{ env.package }}"]')" >> $GITHUB_OUTPUT
+      - run: npm version --workspace=${{ env.package }} --no-git-tag-version "$VERSION-dev-$TIMESTAMP-$(git rev-parse --short HEAD)"
         # The version string template is: <package.json version>-dev-<timestamp>-<commit-hash>
         # Why not use SemVer build metadata with a plus sign for some of this?
         # Because npm completely ignores it. 😒
-        working-directory: ${{ env.package_dir }}
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
           TIMESTAMP: ${{ steps.timestamp.outputs.TIMESTAMP }}
-      - run: npm publish --tag ${{ env.dist_tag }}
-        working-directory: ${{ env.package_dir }}
+      - run: npm publish --workspace=${{ env.package }} --tag ${{ env.dist_tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_next_web-features.yml
+++ b/.github/workflows/publish_next_web-features.yml
@@ -1,0 +1,64 @@
+name: Publish web-features@next
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - feature-group-definitions/**
+      - groups/**
+      - packages/web-features/**
+      - snapshots/**
+      - index.ts
+      - scripts/build.ts
+
+env:
+  package: "web-features"
+  package_dir: "packages/web-features"
+  dist_tag: "next"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .node-version
+          cache: npm
+      - run: npm ci
+      - run: npm test
+  publish:
+    if: github.repository == 'web-platform-dx/web-features'
+    runs-on: ubuntu-latest
+    needs: "test"
+    steps:
+      - name: Get timestamp
+        id: timestamp
+        run: echo "TIMESTAMP=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .node-version
+          cache: npm
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm run build
+      - name: Get package.json version
+        id: version
+        run: echo "VERSION=$(npm version --json | jq --raw-output '.["${{ env.package }}"]')" >> $GITHUB_OUTPUT
+        working-directory: ${{ env.package_dir }}
+      - run: npm install
+        working-directory: ${{ env.package_dir }}
+      - run: npm version --no-git-tag-version "$VERSION-dev-$TIMESTAMP-$(git rev-parse --short HEAD)"
+        # The version string template is: <package.json version>-dev-<timestamp>-<commit-hash>
+        # Why not use SemVer build metadata with a plus sign for some of this?
+        # Because npm completely ignores it. 😒
+        working-directory: ${{ env.package_dir }}
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          TIMESTAMP: ${{ steps.timestamp.outputs.TIMESTAMP }}
+      - run: npm publish --tag ${{ env.dist_tag }}
+        working-directory: ${{ env.package_dir }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR does two things:

- Automatically publishes `compute-baseline` as a `next`-tagged release to npm, when changes take place on files that might plausibly impact the package
- Filters publishing `web-features` only to files that migh plausibly impact _that_ package (i.e., we're not constantly publishing new releases when unrelated changes happen)

(I've already updated the npm token to allow publishing `compute-baseline`, so this should start working on the first merge after this PR merges.)