### PR TITLE
Add a group for CSS layout

### DIFF
--- a/feature-group-definitions/flexbox-gap.dist.yml
+++ b/feature-group-definitions/flexbox-gap.dist.yml
@@ -4,6 +4,7 @@
 name: Flexbox gap
 description: The `gap` CSS property in a flexbox layout sets the size of the space between items.
 spec: https://drafts.csswg.org/css-align-3/#gaps
+group: layout
 caniuse: flexbox-gap
 status:
   baseline: high

--- a/feature-group-definitions/flexbox-gap.yml
+++ b/feature-group-definitions/flexbox-gap.yml
@@ -1,4 +1,5 @@
 name: Flexbox gap
 description: The `gap` CSS property in a flexbox layout sets the size of the space between items.
 spec: https://drafts.csswg.org/css-align-3/#gaps
+group: layout
 caniuse: flexbox-gap

--- a/feature-group-definitions/flexbox.dist.yml
+++ b/feature-group-definitions/flexbox.dist.yml
@@ -4,6 +4,7 @@
 name: Flexbox
 description: Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
 spec: https://drafts.csswg.org/css-flexbox-1/
+group: layout
 caniuse: flexbox
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1692
 status:

--- a/feature-group-definitions/flexbox.yml
+++ b/feature-group-definitions/flexbox.yml
@@ -1,5 +1,6 @@
 name: Flexbox
 description: Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
 spec: https://drafts.csswg.org/css-flexbox-1/
+group: layout
 caniuse: flexbox
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1692

--- a/feature-group-definitions/grid.dist.yml
+++ b/feature-group-definitions/grid.dist.yml
@@ -4,6 +4,7 @@
 name: Grid
 description: CSS Grid is a two-dimensional layout system, which lays content out in rows and columns.
 spec: https://drafts.csswg.org/css-grid-3/
+group: layout
 caniuse: css-grid
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1693
 status:

--- a/feature-group-definitions/grid.yml
+++ b/feature-group-definitions/grid.yml
@@ -1,5 +1,6 @@
 name: Grid
 description: CSS Grid is a two-dimensional layout system, which lays content out in rows and columns.
 spec: https://drafts.csswg.org/css-grid-3/
+group: layout
 caniuse: css-grid
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1693

--- a/feature-group-definitions/masonry.dist.yml
+++ b/feature-group-definitions/masonry.dist.yml
@@ -4,6 +4,7 @@
 name: Masonry
 description: Masonry is a type of CSS grid layout where the items on one of the axes are tightly packed together, like brickwork, instead of leaving gaps to align across the other axis.
 spec: https://drafts.csswg.org/css-grid-3/
+group: layout
 status:
   baseline: false
   support: {}

--- a/feature-group-definitions/masonry.yml
+++ b/feature-group-definitions/masonry.yml
@@ -1,3 +1,4 @@
 name: Masonry
 description: Masonry is a type of CSS grid layout where the items on one of the axes are tightly packed together, like brickwork, instead of leaving gaps to align across the other axis.
 spec: https://drafts.csswg.org/css-grid-3/
+group: layout

--- a/feature-group-definitions/subgrid.dist.yml
+++ b/feature-group-definitions/subgrid.dist.yml
@@ -4,6 +4,7 @@
 name: Subgrid
 description: "The `subgrid` value for the `grid-template-columns` and `grid-template-rows` properties allows a grid item to inherit the grid definition of its parent grid container."
 spec: https://drafts.csswg.org/css-grid-2/#subgrids
+group: layout
 caniuse: css-subgrid
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4680
 status:

--- a/feature-group-definitions/subgrid.yml
+++ b/feature-group-definitions/subgrid.yml
@@ -1,5 +1,6 @@
 name: Subgrid
 description: "The `subgrid` value for the `grid-template-columns` and `grid-template-rows` properties allows a grid item to inherit the grid definition of its parent grid container."
 spec: https://drafts.csswg.org/css-grid-2/#subgrids
+group: layout
 caniuse: css-subgrid
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4680

--- a/groups/layout.yml
+++ b/groups/layout.yml
@@ -1,0 +1,3 @@
+# CSS layout features which give size and positions to boxes.
+name: Layout
+parent: css


### PR DESCRIPTION
Only include features that are unambiguously layout features and not
borderline. `anchor-positioning` and `aspect-ratio` are such borderline
cases, which do affect size and/or position, but aren't full layout
models like Grid is.
