### PR TITLE
Remove Sanitizer API

### DIFF
--- a/feature-group-definitions/sanitizer.yml
+++ b/feature-group-definitions/sanitizer.yml
@@ -1,3 +1,0 @@
-name: Sanitizer
-description: The Sanitizer API sanitizes untrusted strings of HTML, Document and DocumentFragment objects. After sanitization, unwanted elements or attributes are removed, and the returned objects can safely be inserted into a document's DOM.
-spec: https://wicg.github.io/sanitizer-api/


### PR DESCRIPTION
This was removed from Chrome:
https://chromestatus.com/feature/5115076981293056

A part of it has shipped as a separate feature:
https://github.com/web-platform-dx/web-features/pull/999
