### PR TITLE
`compute-baseline`: Add `.js` (and organize) imports and exports

### DIFF
--- a/packages/compute-baseline/src/baseline/core-browser-set.ts
+++ b/packages/compute-baseline/src/baseline/core-browser-set.ts
@@ -1,4 +1,4 @@
-import { Compat } from "../browser-compat-data/compat";
+import { Compat } from "../browser-compat-data/compat.js";
 
 export const identifiers = [
   "chrome",

--- a/packages/compute-baseline/src/baseline/date-utils.test.ts
+++ b/packages/compute-baseline/src/baseline/date-utils.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 
-import { isFuture } from "./date-utils";
 import { Temporal } from "@js-temporal/polyfill";
+import { isFuture } from "./date-utils.js";
 
 describe("isFuture", function () {
   it("returns true for tomorrow", function () {

--- a/packages/compute-baseline/src/baseline/date-utils.ts
+++ b/packages/compute-baseline/src/baseline/date-utils.ts
@@ -1,5 +1,5 @@
 import { Temporal } from "@js-temporal/polyfill";
-import { BASELINE_LOW_TO_HIGH_DURATION } from ".";
+import { BASELINE_LOW_TO_HIGH_DURATION } from "./index.js";
 
 type LowDate = Temporal.PlainDate | string;
 

--- a/packages/compute-baseline/src/baseline/index.test.ts
+++ b/packages/compute-baseline/src/baseline/index.test.ts
@@ -4,7 +4,7 @@ import { Temporal } from "@js-temporal/polyfill";
 import * as chai from "chai";
 import chaiJestSnapshot from "chai-jest-snapshot";
 
-import { computeBaseline, keystoneDateToStatus } from ".";
+import { computeBaseline, keystoneDateToStatus } from "./index.js";
 
 chai.use(chaiJestSnapshot);
 

--- a/packages/compute-baseline/src/baseline/index.ts
+++ b/packages/compute-baseline/src/baseline/index.ts
@@ -2,13 +2,13 @@ import assert from "node:assert";
 
 import { Temporal } from "@js-temporal/polyfill";
 
-import { Browser } from "../browser-compat-data/browser";
-import { Compat, defaultCompat } from "../browser-compat-data/compat";
-import { feature } from "../browser-compat-data/feature";
-import { Release } from "../browser-compat-data/release";
-import { browsers } from "./core-browser-set";
-import { isFuture, toDateString, toHighDate } from "./date-utils";
-import { support } from "./support";
+import { Browser } from "../browser-compat-data/browser.js";
+import { Compat, defaultCompat } from "../browser-compat-data/compat.js";
+import { feature } from "../browser-compat-data/feature.js";
+import { Release } from "../browser-compat-data/release.js";
+import { browsers } from "./core-browser-set.js";
+import { isFuture, toDateString, toHighDate } from "./date-utils.js";
+import { support } from "./support.js";
 
 interface Logger {
   debug?: typeof console.debug;

--- a/packages/compute-baseline/src/baseline/support.test.ts
+++ b/packages/compute-baseline/src/baseline/support.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert/strict";
-import { Compat } from "../browser-compat-data";
-import { lastInitialRelease } from "./support";
+import { Compat } from "../browser-compat-data/index.js";
+import { lastInitialRelease } from "./support.js";
 
 describe("lastInitialRelease", function () {
   it("returns undefined for no releases", function () {

--- a/packages/compute-baseline/src/baseline/support.ts
+++ b/packages/compute-baseline/src/baseline/support.ts
@@ -1,8 +1,8 @@
-import { logger } from ".";
-import { Browser } from "../browser-compat-data/browser";
-import { Feature } from "../browser-compat-data/feature";
-import { Release } from "../browser-compat-data/release";
-import { Qualifications } from "../browser-compat-data/supportStatements";
+import { Browser } from "../browser-compat-data/browser.js";
+import { Feature } from "../browser-compat-data/feature.js";
+import { Release } from "../browser-compat-data/release.js";
+import { Qualifications } from "../browser-compat-data/supportStatements.js";
+import { logger } from "./index.js";
 
 type Support = Map<Browser, Release | undefined>;
 

--- a/packages/compute-baseline/src/browser-compat-data/browser.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/browser.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { browser } from "./browser";
+import { browser } from "./browser.js";
 
 describe("browser()", function () {
   it("throws for non-existent browsers", function () {

--- a/packages/compute-baseline/src/browser-compat-data/browser.ts
+++ b/packages/compute-baseline/src/browser-compat-data/browser.ts
@@ -5,8 +5,8 @@ import {
 } from "@mdn/browser-compat-data";
 import { compareVersions } from "compare-versions";
 
-import { defaultCompat } from "./compat";
-import { Release } from "./release";
+import { defaultCompat } from "./compat.js";
+import { Release } from "./release.js";
 
 export function browser(id: string, compat = defaultCompat): Browser {
   let b = compat.browsers.get(id);

--- a/packages/compute-baseline/src/browser-compat-data/compat.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/compat.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 
-import { Compat } from "./compat";
-import { Feature } from ".";
+import { Compat } from "./compat.js";
+import { Feature } from "./index.js";
 
 describe("Compat()", function () {
   describe("constructor", function () {

--- a/packages/compute-baseline/src/browser-compat-data/compat.ts
+++ b/packages/compute-baseline/src/browser-compat-data/compat.ts
@@ -1,5 +1,5 @@
 import bcd, { CompatData } from "@mdn/browser-compat-data";
-import { Browser, Feature, browser, feature, query, walk } from ".";
+import { Browser, Feature, browser, feature, query, walk } from "./index.js";
 
 export class Compat {
   data: unknown;

--- a/packages/compute-baseline/src/browser-compat-data/feature.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 
-import { feature } from "./feature";
-import { browser } from ".";
+import { feature } from "./feature.js";
+import { browser } from "./index.js";
 
 describe("features", function () {
   describe("feature()", function () {

--- a/packages/compute-baseline/src/browser-compat-data/feature.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.ts
@@ -1,14 +1,14 @@
 import { Identifier } from "@mdn/browser-compat-data";
 
-import { Browser } from "./browser";
-import { isFeatureData } from "./typeUtils";
-import { Release } from "./release";
+import { Browser } from "./browser.js";
+import { Compat, defaultCompat } from "./compat.js";
+import { Release } from "./release.js";
 import {
   Qualifications,
   RealSupportStatement,
   statement,
-} from "./supportStatements";
-import { Compat, defaultCompat } from "./compat";
+} from "./supportStatements.js";
+import { isFeatureData } from "./typeUtils.js";
 
 export function feature(id: string, compat: Compat = defaultCompat): Feature {
   let f = compat.features.get(id);

--- a/packages/compute-baseline/src/browser-compat-data/index.ts
+++ b/packages/compute-baseline/src/browser-compat-data/index.ts
@@ -1,14 +1,14 @@
-import { browser, Browser } from "./browser";
-import { Compat } from "./compat";
-import { feature, Feature } from "./feature";
-import { query } from "./query";
-import { Release } from "./release";
+import { browser, Browser } from "./browser.js";
+import { Compat } from "./compat.js";
+import { feature, Feature } from "./feature.js";
+import { query } from "./query.js";
+import { Release } from "./release.js";
 import {
   RealSupportStatement,
   statement,
   SupportStatement,
-} from "./supportStatements";
-import { walk } from "./walk";
+} from "./supportStatements.js";
+import { walk } from "./walk.js";
 
 export {
   browser,

--- a/packages/compute-baseline/src/browser-compat-data/query.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/query.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 
-import { query } from "./query";
 import { BrowserStatement, Identifier } from "@mdn/browser-compat-data";
-import { Compat } from "./compat";
+import { Compat } from "./compat.js";
+import { query } from "./query.js";
 
 describe("query", function () {
   it("returns arbitrary BCD data (browsers)", function () {

--- a/packages/compute-baseline/src/browser-compat-data/query.ts
+++ b/packages/compute-baseline/src/browser-compat-data/query.ts
@@ -1,4 +1,4 @@
-import { isIndexable } from "./typeUtils";
+import { isIndexable } from "./typeUtils.js";
 
 // TODO: Name this better. There's nothing so sophisticated as a "query" here.
 // It's a boring lookup!

--- a/packages/compute-baseline/src/browser-compat-data/release.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/release.test.ts
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 
 import { Temporal } from "@js-temporal/polyfill";
 
-import { browser } from "./browser";
-import { Release } from "./release";
+import { browser } from "./browser.js";
+import { Release } from "./release.js";
 
 describe("Release", function () {
   describe("toString()", function () {

--- a/packages/compute-baseline/src/browser-compat-data/release.ts
+++ b/packages/compute-baseline/src/browser-compat-data/release.ts
@@ -1,7 +1,7 @@
 import { Temporal } from "@js-temporal/polyfill";
 import { ReleaseStatement } from "@mdn/browser-compat-data";
 
-import { Browser } from "./browser";
+import { Browser } from "./browser.js";
 
 export class Release {
   browser: Browser;

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
 
+import { browser } from "./browser.js";
 import {
   RealSupportStatement,
   SupportStatement,
   statement,
-} from "./supportStatements";
-import { browser } from "./browser";
+} from "./supportStatements.js";
 
 describe("statements", function () {
   describe("statement()", function () {

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
@@ -4,9 +4,9 @@ import {
   VersionValue,
 } from "@mdn/browser-compat-data";
 
-import { Browser } from "./browser";
-import { Release } from "./release";
-import { Feature } from "./feature";
+import { Browser } from "./browser.js";
+import { Feature } from "./feature.js";
+import { Release } from "./release.js";
 
 export interface Qualifications {
   prefix?: string;

--- a/packages/compute-baseline/src/browser-compat-data/walk.ts
+++ b/packages/compute-baseline/src/browser-compat-data/walk.ts
@@ -6,9 +6,9 @@ import {
   Identifier,
   MetaBlock,
 } from "@mdn/browser-compat-data";
-import { isBrowserStatement, isFeatureData } from "./typeUtils";
-import { descendantKeys } from "./walkUtils";
-import { query } from "./query";
+import { query } from "./query.js";
+import { isBrowserStatement, isFeatureData } from "./typeUtils.js";
+import { descendantKeys } from "./walkUtils.js";
 
 type BCD =
   | CompatData

--- a/packages/compute-baseline/src/browser-compat-data/walkUtils.ts
+++ b/packages/compute-baseline/src/browser-compat-data/walkUtils.ts
@@ -4,7 +4,7 @@ import {
   isCompatStatement,
   isFeatureData,
   isMetaBlock,
-} from "./typeUtils";
+} from "./typeUtils.js";
 
 export function descendantKeys(data: unknown, path?: string): string[] {
   if (isCompatData(data)) {

--- a/packages/compute-baseline/src/index.ts
+++ b/packages/compute-baseline/src/index.ts
@@ -1,2 +1,2 @@
-export * as baseline from "./baseline";
-export * as browserCompatData from "./browser-compat-data";
+export * as baseline from "./baseline/index.js";
+export * as browserCompatData from "./browser-compat-data/index.js";

--- a/packages/compute-baseline/tsconfig.json
+++ b/packages/compute-baseline/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "outDir": "./dist",
     "declaration": true,


### PR DESCRIPTION
This adds the `.js` extension to imports in `compute-baseline`, so that consumers who don't use a bundler can still use the package.

Since I was touching almost every import, I also used VS Code's "organize imports" to impose a more consistent ordering of imports.

Fixes #967 (hopefully).