### PR TITLE
Mark scroll snap as Baseline high

### DIFF
--- a/features/scroll-snap.dist.yml
+++ b/features/scroll-snap.dist.yml
@@ -13,8 +13,9 @@ usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/499
 # TODO: Decide if https://bugzil.la/1749352 warrants the partial implementation
 # status and align BCD and caniuse.
 status:
-  baseline: low
+  baseline: high
   baseline_low_date: 2019-07-09
+  baseline_high_date: 2022-01-09
   support:
     chrome: "69"
     chrome_android: "69"

--- a/features/scroll-snap.yml
+++ b/features/scroll-snap.yml
@@ -10,7 +10,7 @@ usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/499
 # TODO: Decide if https://bugzil.la/1749352 warrants the partial implementation
 # status and align BCD and caniuse.
 status:
-  baseline: low
+  baseline: high
   baseline_low_date: 2019-07-09
   support:
     chrome: "69"


### PR DESCRIPTION
This was a mistake in https://github.com/web-platform-dx/web-features/pull/1004.
