### PR TITLE
`compute-baseline`: Use JSON import attribute when importing BCD

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3415,7 +3415,7 @@
       }
     },
     "packages/compute-baseline": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@js-temporal/polyfill": "^0.4.4",

--- a/packages/compute-baseline/package.json
+++ b/packages/compute-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compute-baseline",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A library for computing web-features statuses from browser compatibility data",
   "exports": {
     ".": "./dist/baseline/index.js",

--- a/packages/compute-baseline/src/browser-compat-data/compat.ts
+++ b/packages/compute-baseline/src/browser-compat-data/compat.ts
@@ -1,4 +1,6 @@
-import bcd, { CompatData } from "@mdn/browser-compat-data";
+import bcd, {
+  CompatData,
+} from "@mdn/browser-compat-data" with { type: "json" };
 import { Browser, Feature, browser, feature, query, walk } from "./index.js";
 
 export class Compat {


### PR DESCRIPTION
I think this will fix the issue reported by @tidoust in https://github.com/web-platform-dx/web-features/issues/967#issuecomment-2096339885.

This change will require one of Node.js ~~v16.14.0+~~ (see https://github.com/web-platform-dx/web-features/pull/1051#issuecomment-2100565931), v18.20.0+, or v20.10.0+.

If you want to test this immediately, do the following:

1. Check out this PR's branch.
2. Run `npm pack --workspace compute-baseline`. A `.tgz` file for the package is built.
3. In your project, install the `.tgz` file. For example, run `npm install ../path/to/compute-baseline-0.1.0.tgz`.