### PR TITLE
Add Uint32Array to typed arrays feature

### DIFF
--- a/features/typed-arrays.yml
+++ b/features/typed-arrays.yml
@@ -72,6 +72,10 @@ compat_features:
   - javascript.builtins.Uint16Array.Uint16Array
   - javascript.builtins.Uint16Array.Uint16Array.constructor_without_parameters
   - javascript.builtins.Uint16Array.Uint16Array.iterable_allowed
+  - javascript.builtins.Uint32Array
+  - javascript.builtins.Uint32Array.Uint32Array
+  - javascript.builtins.Uint32Array.Uint32Array.constructor_without_parameters
+  - javascript.builtins.Uint32Array.Uint32Array.iterable_allowed
   - javascript.builtins.Uint8Array
   - javascript.builtins.Uint8Array.Uint8Array
   - javascript.builtins.Uint8Array.Uint8Array.constructor_without_parameters


### PR DESCRIPTION
This seems like a simple omission. BCD data is the same as for
Uint16Array so this won't affect any later computed status.
