### PR TITLE
Update Baseline date and TODO of CSS masks

### DIFF
--- a/features/masks.dist.yml
+++ b/features/masks.dist.yml
@@ -5,10 +5,10 @@ name: Masks
 description: The `mask` CSS property (and several longhand properties) partially or completely hides an element according to the shape and depth of an image.
 spec: https://drafts.fxtf.org/css-masking-1/#positioned-masks
 caniuse: css-masks
-# TODO: remove this override when https://github.com/mdn/browser-compat-data/pull/23000 lands
+# TODO: remove this override when https://github.com/mdn/browser-compat-data/pull/23103 lands
 status:
   baseline: low
-  baseline_low_date: 2023-12-05
+  baseline_low_date: 2023-12-07
   support:
     chrome: "120"
     chrome_android: "120"

--- a/features/masks.yml
+++ b/features/masks.yml
@@ -2,10 +2,10 @@ name: Masks
 description: The `mask` CSS property (and several longhand properties) partially or completely hides an element according to the shape and depth of an image.
 spec: https://drafts.fxtf.org/css-masking-1/#positioned-masks
 caniuse: css-masks
-# TODO: remove this override when https://github.com/mdn/browser-compat-data/pull/23000 lands
+# TODO: remove this override when https://github.com/mdn/browser-compat-data/pull/23103 lands
 status:
   baseline: low
-  baseline_low_date: 2023-12-05
+  baseline_low_date: 2023-12-07
   support:
     chrome: "120"
     chrome_android: "120"


### PR DESCRIPTION
2023-12-05 appears to be a simple mistake in https://github.com/web-platform-dx/web-features/pull/1037.

More issues in BCD were found, so update the PR link.
