### PR TITLE
Update WebVTT to match caniuse.com better

### DIFF
--- a/features/webvtt.dist.yml
+++ b/features/webvtt.dist.yml
@@ -8,24 +8,32 @@ caniuse: webvtt
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/409
 status:
   baseline: high
-  baseline_low_date: 2020-01-15
-  baseline_high_date: 2022-07-15
+  baseline_low_date: 2015-07-29
+  baseline_high_date: 2018-01-29
   support:
-    chrome: "33"
-    chrome_android: "33"
-    edge: "79"
+    chrome: "23"
+    chrome_android: "25"
+    edge: "12"
     firefox: "31"
     firefox_android: "31"
-    safari: "8"
+    safari: "6"
     safari_ios: "8"
+# The initial support for WebVTT was fairly minimal. The VTTCue API isn't the
+# main entry point to using WebVTT (<track src=captions.vtt> is) but can still
+# be used to compute the status. It matches https://caniuse.com/webvtt other
+# than the Safari iOS version. TODO: Research whether WebVTT was shipped in
+# iOS 6, 7, or 8, and align all sources on the right answer.
 compat_features:
   - api.VTTCue
-  - api.VTTCue.VTTCue
-  - api.VTTCue.align
   - api.VTTCue.getCueAsHTML
-  - api.VTTCue.line
-  - api.VTTCue.position
-  - api.VTTCue.size
-  - api.VTTCue.snapToLines
   - api.VTTCue.text
-  - api.VTTCue.vertical
+  # The VTTCue constructor came a bit later as it was originally the
+  # TextTrackCue constructor.
+  # - api.VTTCue.VTTCue
+  # Cue settings should be a separate feature
+  # - api.VTTCue.align
+  # - api.VTTCue.line
+  # - api.VTTCue.position
+  # - api.VTTCue.size
+  # - api.VTTCue.snapToLines
+  # - api.VTTCue.vertical

--- a/features/webvtt.yml
+++ b/features/webvtt.yml
@@ -3,3 +3,22 @@ description: WebVTT is a captions and subtitles format. WebVTT files are loaded 
 spec: https://w3c.github.io/webvtt/
 caniuse: webvtt
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/409
+# The initial support for WebVTT was fairly minimal. The VTTCue API isn't the
+# main entry point to using WebVTT (<track src=captions.vtt> is) but can still
+# be used to compute the status. It matches https://caniuse.com/webvtt other
+# than the Safari iOS version. TODO: Research whether WebVTT was shipped in
+# iOS 6, 7, or 8, and align all sources on the right answer.
+compat_features:
+  - api.VTTCue
+  - api.VTTCue.getCueAsHTML
+  - api.VTTCue.text
+  # The VTTCue constructor came a bit later as it was originally the
+  # TextTrackCue constructor.
+  # - api.VTTCue.VTTCue
+  # Cue settings should be a separate feature
+  # - api.VTTCue.align
+  # - api.VTTCue.line
+  # - api.VTTCue.position
+  # - api.VTTCue.size
+  # - api.VTTCue.snapToLines
+  # - api.VTTCue.vertical


### PR DESCRIPTION
This changes the Baseline date from 2020 to 2015.

Chrome 23 is correct and caniuse is being updated here:
https://github.com/Fyrd/caniuse/pull/7062

The only remaining difference is the iOS version, which is a TODO.
