### PR TITLE
Allow use of ranges (≤) before the Baseline low date

### DIFF
--- a/features/search-input-type.yml
+++ b/features/search-input-type.yml
@@ -5,3 +5,4 @@ group: forms
 caniuse: input-search
 # TODO: investigate minor differences in the early support of the feature
 # between https://caniuse.com/input-search and our generated status.
+use_ranges_before_baseline_low_date: true

--- a/features/search-input-type.yml.dist
+++ b/features/search-input-type.yml.dist
@@ -6,12 +6,12 @@ status:
   baseline_low_date: 2015-07-29
   baseline_high_date: 2018-01-29
   support:
-    chrome: "5"
+    chrome: ≤5
     chrome_android: "18"
     edge: "12"
-    firefox: "4"
+    firefox: ≤4
     firefox_android: "4"
-    safari: "5"
-    safari_ios: "4.2"
+    safari: ≤5
+    safari_ios: ≤4.2
 compat_features:
   - html.elements.input.type_search

--- a/schemas/defs.schema.json
+++ b/schemas/defs.schema.json
@@ -101,7 +101,7 @@
             },
             "support": {
               "additionalProperties": false,
-              "description": "Browser versions that most-recently introduced the feature",
+              "description": "Browser versions that most-recently introduced the feature. A \"≤\" prefix indicates that support before this point is uncertain and the feature may have been supported earlier.",
               "properties": {
                 "chrome": {
                   "type": "string"

--- a/scripts/dist.ts
+++ b/scripts/dist.ts
@@ -1,5 +1,6 @@
 import { computeBaseline, setLogger } from "compute-baseline";
 import { Compat, Feature } from "compute-baseline/browser-compat-data";
+import { Temporal } from "@js-temporal/polyfill";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
@@ -94,7 +95,7 @@ function toDist(sourcePath: string): YAML.Document {
 
   // Compute the status. A `status` block in the source takes precedence, but
   // can be removed if it matches the computed status.
-  let computedStatus = computeBaseline({
+  const computedStatus = computeBaseline({
     compatKeys: source.compat_features ?? taggedCompatFeatures,
     checkAncestors: false,
   });
@@ -105,10 +106,27 @@ function toDist(sourcePath: string): YAML.Document {
     );
   }
 
-  computedStatus = JSON.parse(computedStatus.toJSON());
+  const distStatus = JSON.parse(computedStatus.toJSON());
+
+  // Add ranges to releases before the Baseline low date. It's not possible
+  // to use ranges more selectively than this.
+  if (source.use_ranges_before_baseline_low_date) {
+    const lowDate = Temporal.PlainDate.from(computedStatus.baseline_low_date);
+    const distSupport = distStatus.support;
+    for (const [browser, release] of computedStatus.support.entries()) {
+      if (release.releaseIndex === 0) {
+        // Don't add a range for the first release of a browser.
+        continue;
+      }
+      const date = Temporal.PlainDate.from(release.date);
+      if (Temporal.PlainDate.compare(date, lowDate) === -1) {
+        distSupport[browser.id] = `≤${release.version}`;
+      }
+    }
+  }
 
   if (source.status) {
-    if (isDeepStrictEqual(source.status, computedStatus)) {
+    if (isDeepStrictEqual(source.status, distStatus)) {
       logger.warn(
         `${id}: status override matches computed status. Consider deleting this override.`,
       );
@@ -126,7 +144,7 @@ function toDist(sourcePath: string): YAML.Document {
     .join("\n");
 
   if (!source.status) {
-    dist.set("status", computedStatus);
+    dist.set("status", distStatus);
   }
 
   if (!source.compat_features) {

--- a/types.ts
+++ b/types.ts
@@ -32,7 +32,7 @@ interface SupportStatus {
     baseline_low_date?: string;
     /** Date the feature achieved Baseline high status */
     baseline_high_date?: string;
-    /** Browser versions that most-recently introduced the feature */
+    /** Browser versions that most-recently introduced the feature. A "≤" prefix indicates that support before this point is uncertain and the feature may have been supported earlier. */
     support: {
         [K in browserIdentifier]?: string;
     };


### PR DESCRIPTION
The `use_ranges_before_baseline_low_date` field controls when generating
the status, but it could also be done in overrides.

Closes https://github.com/web-platform-dx/web-features/issues/1018.
