### PR TITLE
Make the dist script crawl all features by default

### DIFF
--- a/features/draft/html-elements/README.md
+++ b/features/draft/html-elements/README.md
@@ -9,9 +9,7 @@ To help out, pick a feature and do the following:
   its own feature or if it should be grouped with other features.
 - Review `baseline_low_date`, does it look plausible? If not, remove features
   from `compat_features` until the date and browser versions seem plausible. Run
-  `npm run dist features/draft/html-elements/tag.yml` to regenerate dist. If
-  this throws an error, most likely BCD needs to be updated first to provide
-  better data.
+  `npm run dist features/draft/html-elements` to regenerate dist.
 - Write a description for the feature.
 - Move the file into the main features/ directory and submit a PR with your
   changes.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "schema-defs:write": "npm run schema-defs -- --out ./schemas/defs.schema.json",
     "test": "npm run test:caniuse -- --quiet && npm run test:schema && npm run test:specs && npm run test:format && npm run test:dist && npm run test --workspaces",
     "test:caniuse": "tsx scripts/caniuse.ts",
-    "test:dist": "tsx scripts/dist.ts --check features/**/*.yml.dist",
+    "test:dist": "tsx scripts/dist.ts --check",
     "test:schema": "tsx scripts/schema.ts",
     "test:specs": "tsx scripts/specs.ts",
     "test:format": "prettier --check .",


### PR DESCRIPTION
The "**" path pattern in package.json doesn't work on at least macOS,
and contributed to an orphaned dist file:
https://github.com/web-platform-dx/web-features/pull/1205.

To avoid such issues, let the command expand directory names to any dist
files within, and make the dist script crawl all features by default.

This also allows simplifiying instructions in a README.