### PR TITLE
Bump tsx from 4.13.1 to 4.13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.0",
         "ts-json-schema-generator": "^2.3.0",
-        "tsx": "^4.13.1",
+        "tsx": "^4.13.2",
         "typescript": "^5.4.5",
         "unified": "^11.0.4",
         "web-specs": "^3.9.1",
@@ -3053,9 +3053,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.13.1.tgz",
-      "integrity": "sha512-MU1IshdvSdIvf0U9ofr5ZWCWjLAPvf5gIvRZygGisoA/fq/FmSxjAfLIxF8ZoZtvHffY1NRkmxIR5/RW1Qc84g==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.13.2.tgz",
+      "integrity": "sha512-s+WGqChkA77uU8xij1IdO9jQnwJAiWJto0bF5yJLbAZpLtNs82Qa5CwMBxWjJ7QOYU9MzBf4MCNt6lZduwkQ+g==",
       "dev": true,
       "dependencies": {
         "esbuild": "~0.20.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.0",
     "ts-json-schema-generator": "^2.3.0",
-    "tsx": "^4.13.1",
+    "tsx": "^4.13.2",
     "typescript": "^5.4.5",
     "unified": "^11.0.4",
     "web-specs": "^3.9.1",


### PR DESCRIPTION
This fixes an issue seen locally when importing compare-versions.

It seems related to https://github.com/privatenumber/tsx/issues/577 as
my version of Node.js is 20.12.1.
