### PR TITLE
Add dist refresh workflow

### DIFF
--- a/.github/workflows/refresh_dist.yml
+++ b/.github/workflows/refresh_dist.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           CHANGED_FEATURES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          npx tsx scripts/dist.ts ${CHANGED_FEATURES}
+          npm run dist -- ${CHANGED_FEATURES}
 
       - uses: stefanzweifel/git-auto-commit-action@v5
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/refresh_dist.yml
+++ b/.github/workflows/refresh_dist.yml
@@ -1,0 +1,49 @@
+name: Refresh dist files
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  refresh:
+    if: contains(github.event.pull_request.labels.*.name, 'refresh dist')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            features/**/*.yml
+            features/**/*.yml.dist
+
+      - uses: actions/setup-node@v4
+        if: steps.changed-files.outputs.any_changed == 'true'
+
+      - run: npm install
+        if: steps.changed-files.outputs.any_changed == 'true'
+
+      - name: Refresh dist files
+        if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          CHANGED_FEATURES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          npx tsx scripts/dist.ts ${CHANGED_FEATURES}
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        if: steps.changed-files.outputs.any_changed == 'true'
+        with:
+          commit_message: Refresh dist files
+
+      - name: Remove label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: ["refresh dist"]
+            })


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that lets reviewers request a dist file refresh by adding a `refresh dist` label to the pull request. It only refreshes dists where the dist or authored YAML has changed on the PR, relative to the target branch.

A known limitation: this will only work for owners/peers on the repo, who can set labels on a PR.