### PR TITLE
Mark dist files as read-only in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "files.readonlyInclude": {
-    "features/*.yml.dist": true
+    "features/**/*.yml.dist": true
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.readonlyInclude": {
+    "features/*.yml.dist": true
+  }
+}


### PR DESCRIPTION
For contributors using VS Code, this configuration change marks `.dist` files as read-only, so it's harder to accidentally edit a dist file. Less likely now with the compact dists, but a convenience nonetheless.