### PR TITLE
Update Safari version for (typed) array of()

### DIFF
--- a/features/array-of.yml
+++ b/features/array-of.yml
@@ -9,15 +9,15 @@ group:
   - typed-arrays
 status:
   baseline: high
-  baseline_low_date: 2015-09-30
+  baseline_low_date: 2016-09-20
   support:
     chrome: "45"
     chrome_android: "39"
     edge: "12"
     firefox: "25"
     firefox_android: "25"
-    safari: "9"
-    safari_ios: "9"
+    safari: "10"
+    safari_ios: "10"
 compat_features:
   - javascript.builtins.Array.of
   - javascript.builtins.TypedArray.of


### PR DESCRIPTION
The correct version for typed arrays was carefully researched here:
https://github.com/mdn/browser-compat-data/pull/23319

This changes the Baseline low date by 1 year.
