### PR TITLE
Reinstate speech recognition draft feature

### DIFF
--- a/features/draft/speech-recognition.yml
+++ b/features/draft/speech-recognition.yml
@@ -1,0 +1,9 @@
+# Speech recognition is prefixed in all implementations and would appear as
+# unsupported, so don't publish it. Revisit if it's unprefixed.
+draft_date: 2024-04-30
+name: Speech recognition
+description: The `SpeechRecognition` API converts human speech from a microphone to text.
+spec: https://wicg.github.io/speech-api/#speechreco-section
+group: speech
+caniuse: speech-recognition
+usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2014


### PR DESCRIPTION
This was accidentally removed in https://github.com/web-platform-dx/web-features/pull/1162.

It's not clear how the accident happened, but this is the only source
*.yml file removed, all other file removals were *.dist.yml, confirmed
through `git show --stat c25032062c3211d7ffa6dcbc86bfb631eb648ba3 --diff-filter=D`.
