### PR TITLE
Remove chromestatus.com usage stats

### DIFF
--- a/features/accent-color.yml
+++ b/features/accent-color.yml
@@ -1,4 +1,3 @@
 name: accent-color
 description: The `accent-color` CSS property sets a color for checkboxes, radio buttons, and other form controls.
 spec: https://drafts.csswg.org/css-ui-4/#widget-accent
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/695

--- a/features/animation-composition.yml
+++ b/features/animation-composition.yml
@@ -1,4 +1,3 @@
 name: animation-composition
 description: The `animation-composition` CSS property chooses how to combine animations that affect the same property.
 spec: https://drafts.csswg.org/css-animations-2/#animation-composition
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/743

--- a/features/appearance.yml
+++ b/features/appearance.yml
@@ -1,4 +1,3 @@
 name: appearance
 description: "The `appearance` CSS property controls the appearance of form controls. Using `appearance: none` disables any default native appearance and allows the elements to be styled with CSS."
 spec: https://drafts.csswg.org/css-ui-4/#appearance-switching
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/658

--- a/features/aspect-ratio.yml
+++ b/features/aspect-ratio.yml
@@ -1,4 +1,3 @@
 name: aspect-ratio
 description: "The `aspect-ratio` CSS property controls the width-to-height ratio of elements. For `<img>` and `<video>` elements, the `width` and `height` attributes used together with `height: auto` control the aspect ratio while the image/video is loading."
 spec: https://drafts.csswg.org/css-sizing-4/#aspect-ratio
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/657

--- a/features/avif.yml
+++ b/features/avif.yml
@@ -2,7 +2,6 @@ name: AVIF
 description: AVIF (AV1 Image File Format) is an image format based on the AV1 video format.
 spec: https://aomediacodec.github.io/av1-avif/
 caniuse: avif
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3798
 # TODO: Add notes about animated AVIF coming later in Safari (but don't mark this as partially supported)
 status:
   baseline: low

--- a/features/backdrop-filter.yml
+++ b/features/backdrop-filter.yml
@@ -2,4 +2,3 @@ name: backdrop-filter
 description: The `backdrop-filter` CSS property applies graphical effects such as blurring or color shifting to the area behind an element.
 spec: https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty
 caniuse: css-backdrop-filter
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/508

--- a/features/blocking-render.yml
+++ b/features/blocking-render.yml
@@ -8,4 +8,3 @@ description: 'The `blocking="render"` attribute for `<link>`, `<script>`, and `<
 #  - Only works for on <link rel=stylesheet> and <link rel=expect>, not other <link>s
 spec: https://html.spec.whatwg.org/multipage/urls-and-fetching.html#blocking-attributes
 group: html
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4183

--- a/features/border-image.yml
+++ b/features/border-image.yml
@@ -2,4 +2,3 @@ name: Border images
 description: The `border-image` CSS property draws an image around an element.
 spec: https://drafts.csswg.org/css-backgrounds-3/#border-images
 caniuse: border-image
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/43

--- a/features/broadcast-channel.yml
+++ b/features/broadcast-channel.yml
@@ -2,4 +2,3 @@ name: BroadcastChannel
 description: The `BroadcastChannel` API allows you to send messages between same-origin browsing contexts, such as between the same page loaded in multiple tabs.
 spec: https://html.spec.whatwg.org/multipage/web-messaging.html#broadcasting-to-other-browsing-contexts
 caniuse: broadcastchannel
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1447

--- a/features/canvas-context-lost.yml
+++ b/features/canvas-context-lost.yml
@@ -2,4 +2,3 @@ name: contextlost and contextrestored
 description: The `contextlost` event for `<canvas>` fires when the canvas backing storage is lost, while the `contextrestored` event fires when it is recreated.
 spec: https://html.spec.whatwg.org/multipage/webappapis.html#context-lost-steps
 group: canvas
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3974

--- a/features/cascade-layers.yml
+++ b/features/cascade-layers.yml
@@ -2,4 +2,3 @@ name: Cascade layers
 description: The `@layer` CSS at-rule avoids specificity conflicts by providing priority levels for different groups of CSS rules, such as low-priority styles like resets, and high-priority styles like UI components.
 spec: https://drafts.csswg.org/css-cascade-5/#layering
 caniuse: css-cascade-layers
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4007

--- a/features/color-scheme.yml
+++ b/features/color-scheme.yml
@@ -1,7 +1,6 @@
 name: color-scheme
 description: The `color-scheme` CSS property sets which color schemes (light or dark) an element uses and may prevent automatic dark mode adjustments by the browser.
 spec: https://drafts.csswg.org/css-color-adjust-1/#color-scheme-prop
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/637
 # `color-scheme: only light` and `color-scheme: only dark` can be used to opt
 # out from Chrome's Auto Dark Theme:
 # https://developer.chrome.com/blog/auto-dark-theme/#detecting-auto-dark-theme

--- a/features/compression-streams.yml
+++ b/features/compression-streams.yml
@@ -1,9 +1,6 @@
 name: Compression streams
 description: The `CompressionStream` and `DecompressionStream` interfaces compress and decompress data using the gzip or deflate formats.
 spec: https://compression.spec.whatwg.org/
-usage_stats:
-  - https://chromestatus.com/metrics/feature/timeline/popularity/3060 # CompressionStream
-  - https://chromestatus.com/metrics/feature/timeline/popularity/3061 # DecompressionStream
 compat_features:
   - api.CompressionStream
   - api.CompressionStream.CompressionStream

--- a/features/compute-pressure.yml
+++ b/features/compute-pressure.yml
@@ -1,4 +1,3 @@
 name: CPU compute pressure
 description: The `PressureObserver` API monitors CPU load, allowing you to adjust workloads in response to available computing resources. Also known as the Compute Pressure API.
 spec: https://w3c.github.io/compute-pressure/
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3899

--- a/features/constructed-stylesheets.yml
+++ b/features/constructed-stylesheets.yml
@@ -3,7 +3,6 @@ description: The `CSSStyleSheet` constructor creates a new stylesheet which can 
 spec:
   - https://drafts.csswg.org/cssom-1/#dom-cssstylesheet-cssstylesheet
   - https://drafts.csswg.org/cssom-1/#dom-documentorshadowroot-adoptedstylesheets
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2846
 compat_features:
   - api.CSSStyleSheet.CSSStyleSheet
   - api.CSSStyleSheet.replace

--- a/features/contain-intrinsic-size.yml
+++ b/features/contain-intrinsic-size.yml
@@ -2,7 +2,6 @@ name: contain-intrinsic-size
 description: The `contain-intrinsic-size` CSS property sets the intrinsic size of an element. When using size containment, the browser will layout the element as if it had a single child of this size.
 spec: https://drafts.csswg.org/css-sizing-4/#intrinsic-size-override
 # Shown as "intrinsic-size" on chromestatus.com, but 651 is contain-intrinsic-size.
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/651
 compat_features:
   # Initial support:
   - css.properties.contain-intrinsic-block-size

--- a/features/container-queries.yml
+++ b/features/container-queries.yml
@@ -2,7 +2,6 @@ name: Container queries
 description: Container size queries with the `@container` at-rule apply styles to an element based on the dimensions of its container.
 spec: https://drafts.csswg.org/css-contain-3/#container-queries
 caniuse: css-container-queries
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4165
 # The containerName and containerQuery CSSOM properties were shipped in
 # Chrome 111 and Safari 16, but aren't needed to use the feature in the typical
 # way, with `@container` in CSS.

--- a/features/container-style-queries.yml
+++ b/features/container-style-queries.yml
@@ -2,4 +2,3 @@ name: Container style queries
 description: Container style queries with the `@container` at-rule apply styles to an element based on the values of custom properties of its container.
 spec: https://drafts.csswg.org/css-contain-3/#style-container
 caniuse: css-container-queries-style
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4550

--- a/features/counter-style.yml
+++ b/features/counter-style.yml
@@ -2,7 +2,6 @@ name: "@counter-style"
 description: The `@counter-style` CSS at-rule defines custom counter styles for list items. For example, you can use a sequence of specific symbols instead of numbers for an ordered list.
 spec: https://drafts.csswg.org/css-counter-styles-3/
 caniuse: css-at-counter-style
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3809
 compat_features:
   - css.at-rules.counter-style
   - css.at-rules.counter-style.additive-symbols

--- a/features/css-modules.yml
+++ b/features/css-modules.yml
@@ -1,4 +1,3 @@
 name: CSS module scripts
 description: 'CSS module scripts allow CSS code to be organized into reusable units. Other modules use `import ... with {type: "css"}` to load CSS modules as constructable stylesheets.'
 spec: https://html.spec.whatwg.org/multipage/webappapis.html#css-module-script
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3805

--- a/features/datalist.yml
+++ b/features/datalist.yml
@@ -3,7 +3,6 @@ description: The `<datalist>` element defines a set of recommended values for an
 spec: https://html.spec.whatwg.org/multipage/form-elements.html#the-datalist-element
 group: forms
 caniuse: datalist
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/23
 # BCD and caniuse use partial support differently for <datalist>. The versions
 # below were picked as the lowest versions where both agree the feature is fully
 # supported, with the single exception of Firefox, which BCD treats as partially

--- a/features/declarative-shadow-dom.yml
+++ b/features/declarative-shadow-dom.yml
@@ -3,4 +3,3 @@ description: The `shadowrootmode` attribute on `<template>` creates a shadow roo
 spec: https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootmode
 group: html
 caniuse: declarative-shadow-dom
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4421

--- a/features/dialog.yml
+++ b/features/dialog.yml
@@ -3,4 +3,3 @@ description: The `<dialog>` HTML element represents a modal or non-modal dialog 
 spec: https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element
 group: html
 caniuse: dialog
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/481

--- a/features/dir-pseudo.yml
+++ b/features/dir-pseudo.yml
@@ -3,4 +3,3 @@ description: "The `:dir()` CSS functional pseudo-class matches elements by text 
 spec: https://drafts.csswg.org/selectors-4/#the-dir-pseudo
 group: css
 caniuse: css-dir-pseudo
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3741

--- a/features/document-picture-in-picture.yml
+++ b/features/document-picture-in-picture.yml
@@ -1,4 +1,3 @@
 name: Document picture-in-picture
 description: The document picture-in-picture API creates an always-on-top window from arbitrary HTML content.
 spec: https://wicg.github.io/document-picture-in-picture/
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4397

--- a/features/draft/speech-recognition.yml
+++ b/features/draft/speech-recognition.yml
@@ -6,4 +6,3 @@ description: The `SpeechRecognition` API converts human speech from a microphone
 spec: https://wicg.github.io/speech-api/#speechreco-section
 group: speech
 caniuse: speech-recognition
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2014

--- a/features/flexbox-gap.yml
+++ b/features/flexbox-gap.yml
@@ -3,4 +3,3 @@ description: The `gap` CSS property in a flexbox layout sets the size of the spa
 spec: https://drafts.csswg.org/css-align-3/#gaps
 group: layout
 caniuse: flexbox-gap
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3307

--- a/features/flexbox.yml
+++ b/features/flexbox.yml
@@ -3,7 +3,6 @@ description: Flexbox is a one-dimensional layout system, which places content ei
 spec: https://drafts.csswg.org/css-flexbox-1/
 group: layout
 caniuse: flexbox
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1692
 # Status is manually set to match https://caniuse.com/flexbox.
 # TODO: https://github.com/web-platform-dx/web-features/pull/1227
 status:

--- a/features/focus-visible.yml
+++ b/features/focus-visible.yml
@@ -2,4 +2,3 @@ name: ":focus-visible"
 description: The `:focus-visible` CSS pseudo-class selects elements that match the `:focus` pseudo-class and meets the browser's criteria for visually emphasizing focused elements.
 spec: https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo
 caniuse: css-focus-visible
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2388

--- a/features/font-optical-sizing.yml
+++ b/features/font-optical-sizing.yml
@@ -2,4 +2,3 @@ name: font-optical-sizing
 description: The `font-optical-sizing` CSS property sets whether text rendering is optimized for viewing at different sizes.
 spec: https://drafts.csswg.org/css-fonts-4/#font-optical-sizing-def
 group: fonts
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/647

--- a/features/font-palette-animation.yml
+++ b/features/font-palette-animation.yml
@@ -2,7 +2,6 @@ name: font-palette animation
 description: You can animate color fonts between two `font-palette` values.
 spec: https://drafts.csswg.org/css-fonts-4/#font-palette-prop
 group: fonts
-usage_stats: https://chromestatus.com/metrics/css/timeline/animated/709
 compat_features:
   - css.properties.font-palette.animation_computed
   - css.properties.font-palette.palette-mix_function

--- a/features/font-palette.yml
+++ b/features/font-palette.yml
@@ -5,4 +5,3 @@ spec:
   - https://drafts.csswg.org/css-fonts-4/#font-palette-values
 group: fonts
 caniuse: css-font-palette
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/709

--- a/features/font-synthesis-small-caps.yml
+++ b/features/font-synthesis-small-caps.yml
@@ -2,7 +2,6 @@ name: font-synthesis-small-caps
 description: "The `font-synthesis-small-caps` CSS property sets whether or not the browser should synthesize small caps typefaces when they're missing from the font."
 spec: https://drafts.csswg.org/css-fonts-4/#font-synthesis-small-caps
 group: font-synthesis
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/703
 compat_features:
   - css.properties.font-synthesis-small-caps
   - css.properties.font-synthesis-small-caps.auto

--- a/features/font-synthesis-style.yml
+++ b/features/font-synthesis-style.yml
@@ -2,7 +2,6 @@ name: font-synthesis-style
 description: The `font-synthesis-style` CSS property sets whether or not the browser should synthesize italic and oblique typefaces when they're missing from the font.
 spec: https://drafts.csswg.org/css-fonts-4/#font-synthesis-style
 group: font-synthesis
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/701
 compat_features:
   - css.properties.font-synthesis-style
   - css.properties.font-synthesis-style.auto

--- a/features/font-synthesis-weight.yml
+++ b/features/font-synthesis-weight.yml
@@ -2,7 +2,6 @@ name: font-synthesis-weight
 description: The `font-synthesis-weight` CSS property sets whether or not the browser should synthesize bold typefaces when they're missing from the font.
 spec: https://drafts.csswg.org/css-fonts-4/#font-synthesis-weight
 group: font-synthesis
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/700
 compat_features:
   - css.properties.font-synthesis-weight
   - css.properties.font-synthesis-weight.auto

--- a/features/font-synthesis.yml
+++ b/features/font-synthesis.yml
@@ -2,6 +2,5 @@ name: font-synthesis
 description: The `font-synthesis` CSS shorthand property disables all font synthesis except the given kinds. To disable a specific kind of font synthesis, instead use the longhand properties such as `font-synthesis-style` and `font-synthesis-weight`.
 spec: https://drafts.csswg.org/css-fonts-4/#font-synthesis
 group: font-synthesis
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/704
 compat_features:
   - css.properties.font-synthesis

--- a/features/font-variant-alternates.yml
+++ b/features/font-variant-alternates.yml
@@ -3,4 +3,3 @@ description: The `font-variant-alternates` CSS property, along with the `@font-f
 spec: https://drafts.csswg.org/css-fonts-4/#font-variant-alternates-prop
 group: fonts
 caniuse: font-variant-alternates
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/738

--- a/features/grid.yml
+++ b/features/grid.yml
@@ -3,4 +3,3 @@ description: CSS Grid is a two-dimensional layout system, which lays content out
 spec: https://drafts.csswg.org/css-grid-3/
 group: grid
 caniuse: css-grid
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1693

--- a/features/has.yml
+++ b/features/has.yml
@@ -2,4 +2,3 @@ name: ":has()"
 description: The `:has()` CSS functional pseudo-class matches an element if any of the selectors passed as parameters would match at least one element.
 spec: https://drafts.csswg.org/selectors-4/#relational
 caniuse: css-has
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4743

--- a/features/hidden-until-found.yml
+++ b/features/hidden-until-found.yml
@@ -2,4 +2,3 @@ name: hidden="until-found"
 description: 'The `hidden="until-found"` attribute hides an element until it is found using the browser''s find-in-page search or it is directly navigated to by following a URL fragment.'
 spec: https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found
 group: html
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4114

--- a/features/hyphens.yml
+++ b/features/hyphens.yml
@@ -2,4 +2,3 @@ name: Hyphenation
 description: The `hyphens` CSS property controls when long words are broken by line wrapping. Although called `hyphens`, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters to mark an intraword line break.
 spec: https://drafts.csswg.org/css-text-3/#hyphens-property
 caniuse: css-hyphens
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/534

--- a/features/idle-detection.yml
+++ b/features/idle-detection.yml
@@ -1,4 +1,3 @@
 name: Idle detection
 description: The `IdleDetector` API is used to notify a webpage of the user's idle, active, and locked state.
 spec: https://wicg.github.io/idle-detection/
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2834

--- a/features/import-maps.yml
+++ b/features/import-maps.yml
@@ -2,4 +2,3 @@ name: Import maps
 description: A `<script type="importmap">` HTML element provides an import map as a JSON string. An import map controls how the browser should resolve module specifiers when importing JavaScript modules.
 spec: https://html.spec.whatwg.org/multipage/webappapis.html#import-maps
 caniuse: import-maps
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2831

--- a/features/individual-transforms.yml
+++ b/features/individual-transforms.yml
@@ -2,7 +2,3 @@ name: Individual transform properties
 description: Transform elements with separate `translate`, `rotate`, and `scale` CSS properties.
 spec: https://drafts.csswg.org/css-transforms-2/#individual-transforms
 group: transforms
-usage_stats:
-  - https://chromestatus.com/metrics/css/timeline/popularity/504 # translate
-  - https://chromestatus.com/metrics/css/timeline/popularity/505 # rotate
-  - https://chromestatus.com/metrics/css/timeline/popularity/506 # scale

--- a/features/intersection-observer-v2.yml
+++ b/features/intersection-observer-v2.yml
@@ -2,7 +2,6 @@ name: Intersection observer visibility tracking
 description: The `trackVisibility` parameter for the `IntersectionObserver` constructor enables tracking the visibility of an element, to detect if it may be obscured by other content or visual effects. Also known as IntersectionObserver v2.
 spec: https://w3c.github.io/IntersectionObserver/v2/
 caniuse: intersectionobserver-v2
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3051
 # TODO: Add the API to BCD and compute this status:
 # https://github.com/mdn/browser-compat-data/issues/22862
 status:

--- a/features/intersection-observer.yml
+++ b/features/intersection-observer.yml
@@ -2,4 +2,3 @@ name: Intersection observer
 description: The Intersection Observer API asynchronously observes changes in the intersection of a target element with an ancestor element or with a top-level document's viewport.
 spec: https://w3c.github.io/IntersectionObserver/
 caniuse: intersectionobserver
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1368

--- a/features/is.yml
+++ b/features/is.yml
@@ -2,4 +2,3 @@ name: ":is()"
 description: "The `:is()` CSS functional pseudo-class takes a selector list as its argument, and matches any element that can be selected by one of the selectors in that list."
 spec: https://drafts.csswg.org/selectors-4/#matches
 caniuse: css-matches-pseudo
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2322

--- a/features/js-modules.yml
+++ b/features/js-modules.yml
@@ -6,9 +6,6 @@ spec:
   - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-modules
 snapshot: ecmascript-2015
 group: js-modules
-usage_stats:
-  - https://chromestatus.com/metrics/feature/timeline/popularity/2062
-  - https://chromestatus.com/metrics/feature/timeline/popularity/2615
 compat_features:
   # TODO: Consider notes or partial implementation for Safari 10.1 due to the
   # lack of support for nomodule. It's important for fallback behavior, but in

--- a/features/media-session.yml
+++ b/features/media-session.yml
@@ -1,4 +1,3 @@
 name: Media session
 description: The `navigator.mediaSession` API integrates with platform UI for media playback. It can be used to set metadata such as title and artwork, and to handle user actions like playing, pausing, or seeking.
 spec: https://w3c.github.io/mediasession/
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1789

--- a/features/offscreen-canvas.yml
+++ b/features/offscreen-canvas.yml
@@ -3,7 +3,6 @@ description: The `OffscreenCanvas` API provides a canvas that can be drawn to of
 spec: https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-interface
 group: canvas
 caniuse: offscreencanvas
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1624
 compat_features:
   - api.HTMLCanvasElement.transferControlToOffscreen
   - api.OffscreenCanvas

--- a/features/origin-private-file-system.yml
+++ b/features/origin-private-file-system.yml
@@ -1,4 +1,3 @@
 name: Origin private file system
 description: The `navigator.storage.getDirectory()` method returns a `FileSystemDirectoryHandle` that is restricted to a specific origin and invisible to the user's actual file system for faster file-based applications, such as SQLite databases.
 spec: https://fs.spec.whatwg.org/#origin-private-file-system
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3428

--- a/features/picture-in-picture.yml
+++ b/features/picture-in-picture.yml
@@ -2,7 +2,6 @@ name: Picture-in-picture (video)
 description: The picture-in-picture API allow websites to create a floating, always-on-top video window. Also known as PiP or pop-out video.
 spec: https://w3c.github.io/picture-in-picture/
 caniuse: picture-in-picture
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2444
 # TODO: Align the initial Chrome version these sources:
 # https://github.com/mdn/browser-compat-data/pull/7603 (Chrome 69)
 # https://caniuse.com/picture-in-picture (Chrome 70)

--- a/features/pointer-lock.yml
+++ b/features/pointer-lock.yml
@@ -2,7 +2,6 @@ name: Pointer lock
 description: Provides access to raw mouse movement by locking the target of mouse events to a single element and hiding the mouse cursor.
 spec: https://w3c.github.io/pointerlock/
 caniuse: pointerlock
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/417
 compat_features:
   - api.Document.exitPointerLock
   - api.Document.pointerlockchange_event

--- a/features/popover.yml
+++ b/features/popover.yml
@@ -2,4 +2,3 @@ name: Popover
 description: The `popover` HTML attribute creates an overlay to display content on top of other page content. Popovers can be shown declaratively using HTML, or using the `showPopover()` method.
 spec: https://html.spec.whatwg.org/multipage/popover.html
 group: html
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4191

--- a/features/relative-color.yml
+++ b/features/relative-color.yml
@@ -2,7 +2,6 @@ name: Relative colors
 description: "The `from` keyword for color functions (`color()`, `hsl()`, `oklch()`, etc.) creates a new color based on a given color by modifying the values of the input color. Also known as relative color syntax (RCS)."
 spec: https://drafts.csswg.org/css-color-5/#relative-colors
 caniuse: css-relative-colors
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4632
 # TODO: Revisit when this has shipped in Firefox if we should retroactively
 # claim partial support in Chrome and Safari for some versions. If so, also make
 # the same changes in caniuse.

--- a/features/scope.yml
+++ b/features/scope.yml
@@ -2,4 +2,3 @@ name: "@scope"
 description: The `@scope` CSS at-rule sets the scope for a group of rules.
 spec: https://drafts.csswg.org/css-cascade-6/#scope-atrule
 caniuse: css-cascade-scope
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4212

--- a/features/scroll-snap.yml
+++ b/features/scroll-snap.yml
@@ -2,7 +2,6 @@ name: Scroll snap
 description: CSS scroll snap controls the panning and scrolling behavior within a scroll container.
 spec: https://drafts.csswg.org/css-scroll-snap-1/
 caniuse: css-snappoints
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/499
 # Override the status to match caniuse.com. Even using just scroll-snap-type
 # doesn't match because of https://bugzil.la/1749352 increasing the Firefox
 # version from 68 to 99.

--- a/features/scroll-to-text-fragment.yml
+++ b/features/scroll-to-text-fragment.yml
@@ -2,7 +2,6 @@ name: Scroll to text fragment
 description: Text fragments are URL fragments on the form `#:~:text=snippet` and link to a snippet of text within a page. The browser may scroll, highlight, or otherwise bring that text to the reader's attention.
 spec: https://wicg.github.io/scroll-to-text-fragment/
 group: text-fragments
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2901
 caniuse: url-scroll-to-text-fragment
 # This feature isn't in BCD, so the status manually matches caniuse instead:
 status:

--- a/features/scrollbar-color.yml
+++ b/features/scrollbar-color.yml
@@ -1,4 +1,3 @@
 name: scrollbar-color
 description: The `scrollbar-color` CSS property sets the color of the scrollbar track and thumb.
 spec: https://drafts.csswg.org/css-scrollbars-1/#scrollbar-color
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/763

--- a/features/scrollbar-gutter.yml
+++ b/features/scrollbar-gutter.yml
@@ -1,4 +1,3 @@
 name: scrollbar-gutter
 description: The `scrollbar-gutter` CSS property reserves space for the scrollbar, preventing unwanted layout changes as the scrollbar appears and disappears.
 spec: https://drafts.csswg.org/css-overflow-3/#scrollbar-gutter-property
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/671

--- a/features/scrollbar-width.yml
+++ b/features/scrollbar-width.yml
@@ -1,4 +1,3 @@
 name: scrollbar-width
 description: The `scrollbar-width` CSS property sets the width of the scrollbar.
 spec: https://drafts.csswg.org/css-scrollbars-1/#scrollbar-width
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/680

--- a/features/scrollend.yml
+++ b/features/scrollend.yml
@@ -1,7 +1,6 @@
 name: scrollend
 description: The `scrollend` event fires when an element or document has finished scrolling.
 spec: https://drafts.csswg.org/cssom-view-1/#eventdef-document-scrollend
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4419
 compat_features:
   - api.Document.scrollend_event
   - api.Element.scrollend_event

--- a/features/show-picker-input.yml
+++ b/features/show-picker-input.yml
@@ -2,7 +2,6 @@ name: showPicker() for <input>
 description: The `showPicker()` method for `<input>` elements shows the user interface for picking a value. For example, for `<input type="date">` it shows the interface for picking a date.
 spec: https://html.spec.whatwg.org/multipage/input.html#dom-input-showpicker
 group: forms
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4097
 compat_features:
   - api.HTMLInputElement.showPicker
   - api.HTMLInputElement.showPicker.color_input

--- a/features/slot.yml
+++ b/features/slot.yml
@@ -2,7 +2,6 @@ name: <slot>
 description: The `<slot>` HTML element is a placeholder inside a web component where consumers of the component can insert their own markup.
 spec: https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element
 group: html
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1898
 compat_features:
   - api.Element.assignedSlot
   - api.Element.slot

--- a/features/speech-synthesis.yml
+++ b/features/speech-synthesis.yml
@@ -3,4 +3,3 @@ description: The `SpeechSynthesis` API converts text into audio using a syntheti
 spec: https://wicg.github.io/speech-api/#tts-section
 group: speech
 caniuse: speech-synthesis
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2483

--- a/features/storage-access.yml
+++ b/features/storage-access.yml
@@ -1,6 +1,3 @@
 name: Storage access
 description: The `document.requestStorageAccess()` method allows content in iframes to request storing and reading cookies and other site data, while the `document.hasStorageAccess()` method checks if such access is granted.
 spec: https://privacycg.github.io/storage-access/
-usage_stats:
-  - https://chromestatus.com/metrics/feature/timeline/popularity/3310 # hasStorageAccess
-  - https://chromestatus.com/metrics/feature/timeline/popularity/3311 # requestStorageAccess

--- a/features/storage-buckets.yml
+++ b/features/storage-buckets.yml
@@ -1,4 +1,3 @@
 name: Storage buckets
 description: The `navigator.storageBuckets` API allows you to organize locally stored data into groups called storage buckets. Each bucket can have different settings, allowing the browser to manage and delete buckets independently rather than applying the same treatment to all.
 spec: https://wicg.github.io/storage-buckets/
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4378

--- a/features/subgrid.yml
+++ b/features/subgrid.yml
@@ -3,4 +3,3 @@ description: "The `subgrid` value for the `grid-template-columns` and `grid-temp
 spec: https://drafts.csswg.org/css-grid-2/#subgrids
 group: grid
 caniuse: css-subgrid
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4680

--- a/features/target-text.yml
+++ b/features/target-text.yml
@@ -2,4 +2,3 @@ name: "::target-text"
 description: The `::target-text` pseudo-element allows you to style text highlighted by a URL text fragment such as `#:~:text=snippet`.
 spec: https://drafts.csswg.org/css-pseudo-4/#selectordef-target-text
 group: text-fragments
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3780

--- a/features/template.yml
+++ b/features/template.yml
@@ -3,4 +3,3 @@ description: The `<template>` HTML element holds HTML fragments which you can cl
 spec: https://html.spec.whatwg.org/multipage/scripting.html#the-template-element
 group: html
 caniuse: template
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2769

--- a/features/text-indent.yml
+++ b/features/text-indent.yml
@@ -2,4 +2,3 @@ name: text-indent
 description: The `text-indent` CSS property sets the size of the empty space (indentation) at the beginning of lines in a text.
 spec: https://drafts.csswg.org/css-text-3/#text-indent-property
 caniuse: css-text-indent
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/130

--- a/features/text-spacing-trim.yml
+++ b/features/text-spacing-trim.yml
@@ -1,4 +1,3 @@
 name: text-spacing-trim
 description: The `text-spacing-trim` CSS property controls spacing around CJK characters, avoiding excessive whitespace when using full-width punctuation characters.
 spec: https://drafts.csswg.org/css-text-4/#text-spacing-trim-property
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/771

--- a/features/text-wrap-balance.yml
+++ b/features/text-wrap-balance.yml
@@ -1,4 +1,3 @@
 name: "text-wrap: balance"
 description: "The `text-wrap: balance` CSS declaration balances the length of each line when text is broken into multiple lines. Also known as headline balancing."
 spec: https://drafts.csswg.org/css-text-4/#valdef-text-wrap-style-balance
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4673

--- a/features/text-wrap-pretty.yml
+++ b/features/text-wrap-pretty.yml
@@ -1,4 +1,3 @@
 name: "text-wrap: pretty"
 description: "The `text-wrap: pretty` CSS declaration prioritizes better layout over speed when text is broken into multiple lines."
 spec: https://drafts.csswg.org/css-text-4/#valdef-text-wrap-style-pretty
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4674

--- a/features/transition-behavior.yml
+++ b/features/transition-behavior.yml
@@ -1,4 +1,3 @@
 name: transition-behavior
 description: "The `transition-behavior: allow-discrete` CSS declaration allows transitions for properties whose animation behavior is discrete. Such properties can't be interpolated and swap from their start value to the end value at 50%."
 spec: https://drafts.csswg.org/css-transitions-2/#transition-behavior-property
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/766

--- a/features/trusted-types.yml
+++ b/features/trusted-types.yml
@@ -2,7 +2,6 @@ name: Trusted types
 description: Trusted types allow you to lock down insecure parts of the DOM API and prevent client-side cross-site scripting (XSS) attacks.
 spec: https://w3c.github.io/trusted-types/dist/spec/
 caniuse: trusted-types
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2722
 # toJSON() is excluded because they are not needed to use trusted types in the
 # idiomatic way. toJSON() shipped in Chrome 90, and the rest in Chrome 83.
 compat_features:

--- a/features/user-pseudos.yml
+++ b/features/user-pseudos.yml
@@ -1,6 +1,3 @@
 name: ":user-valid and :user-invalid"
 description: The `:user-valid` and `:user-invalid` pseudo-classes match form controls that have been marked as valid or invalid based on their validation constraints.
 spec: https://drafts.csswg.org/selectors-4/#user-pseudos
-usage_stats:
-  - https://chromestatus.com/metrics/feature/timeline/popularity/4958 # :user-valid
-  - https://chromestatus.com/metrics/feature/timeline/popularity/4959 # :user-invalid

--- a/features/view-transitions.yml
+++ b/features/view-transitions.yml
@@ -2,4 +2,3 @@ name: View transitions
 description: View transitions allow you to create animated visual transitions between different states of a document, or between different documents.
 spec: https://drafts.csswg.org/css-view-transitions-1/
 caniuse: view-transitions
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4383

--- a/features/web-locks.yml
+++ b/features/web-locks.yml
@@ -1,4 +1,3 @@
 name: Locks
 description: The `navigator.locks` API coordinates work with shared resources through mutually exclusive ownership of a resource's name. Also known as web locks.
 spec: https://w3c.github.io/web-locks/
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2375

--- a/features/webcodecs.yml
+++ b/features/webcodecs.yml
@@ -2,4 +2,3 @@ name: WebCodecs
 description: The WebCodecs API provides low-level access to individual video frames and chunks of audio samples, for full control over the way media is processed.
 spec: https://w3c.github.io/webcodecs/
 caniuse: webcodecs
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3464

--- a/features/webhid.yml
+++ b/features/webhid.yml
@@ -2,4 +2,3 @@ name: WebHID
 description: The WebHID API provides access to Human Interface Devices (HID) that are connected to the user's device.
 spec: https://wicg.github.io/webhid/
 caniuse: webhid
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2865

--- a/features/webp.yml
+++ b/features/webp.yml
@@ -2,7 +2,6 @@ name: WebP
 description: The WebP image format is a raster graphics file format that supports animation, alpha transparency, and lossy as well as lossless compression.
 spec: https://www.ietf.org/archive/id/draft-zern-webp-15.html
 caniuse: webp
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3797
 # TODO: Add notes about animated WebP coming later in Chrome (but don't mark this as partially supported)
 status:
   baseline: high

--- a/features/webtransport.yml
+++ b/features/webtransport.yml
@@ -2,7 +2,6 @@ name: WebTransport
 description: The `WebTransport` API transmits data between a client and a server, by using the HTTP/3 protocol.
 spec: https://w3c.github.io/webtransport/
 caniuse: webtransport
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/3472
 # Status override because createUnidirectionalStream() is marked as partial
 # implementation in Firefox in BCD.
 status:

--- a/features/webusb.yml
+++ b/features/webusb.yml
@@ -2,7 +2,6 @@ name: WebUSB
 description: The WebUSB API exposes USB compatible devices to web pages.
 spec: https://wicg.github.io/webusb/
 caniuse: webusb
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1519
 # TODO: Use an exclusion mechanism when available:
 # https://github.com/web-platform-dx/web-features/issues/841
 compat_features:

--- a/features/webvtt.yml
+++ b/features/webvtt.yml
@@ -2,7 +2,6 @@ name: WebVTT
 description: WebVTT is a captions and subtitles format. WebVTT files are loaded using the `<track>` element, and the `VTTCue` API can be used to create or update cues dynamically.
 spec: https://w3c.github.io/webvtt/
 caniuse: webvtt
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/409
 # The initial support for WebVTT was fairly minimal. The VTTCue API isn't the
 # main entry point to using WebVTT (<track src=captions.vtt> is) but can still
 # be used to compute the status. It matches https://caniuse.com/webvtt other

--- a/features/where.yml
+++ b/features/where.yml
@@ -1,4 +1,3 @@
 name: ":where()"
 description: The `:where()` CSS functional pseudo-class takes a selector list as its argument, and matches any element that can be selected by one of the selectors in that list. It is functionally equivalent to the selectors in the list, but doesn't affect the CSS rule specificity.
 spec: https://drafts.csswg.org/selectors-4/#zero-matches
-usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/2431

--- a/features/will-change.yml
+++ b/features/will-change.yml
@@ -2,5 +2,4 @@ name: will-change
 description: "The `will-change` CSS property gives hints to the browser about expected changes to an element's scroll position, contents, or style. These hints allow browsers to optimize for upcoming style changes."
 spec: https://drafts.csswg.org/css-will-change-1/
 group: css
-usage_stats: https://chromestatus.com/metrics/css/timeline/popularity/445
 caniuse: will-change

--- a/schemas/defs.schema.json
+++ b/schemas/defs.schema.json
@@ -133,25 +133,6 @@
             "support"
           ],
           "type": "object"
-        },
-        "usage_stats": {
-          "anyOf": [
-            {
-              "description": "Usage stats URL",
-              "format": "uri",
-              "type": "string"
-            },
-            {
-              "items": {
-                "description": "Usage stats URL",
-                "format": "uri",
-                "type": "string"
-              },
-              "minItems": 2,
-              "type": "array"
-            }
-          ],
-          "description": "Usage stats"
         }
       },
       "required": [

--- a/types.ts
+++ b/types.ts
@@ -17,8 +17,6 @@ export interface FeatureData {
     status: SupportStatus;
     /** Sources of support data for this feature */
     compat_features?: string[];
-    /** Usage stats */
-    usage_stats?: usage_stats_url | [usage_stats_url, usage_stats_url, ...usage_stats_url[]]; // A single URL or an array of two or more
 }
 
 type browserIdentifier = "chrome" | "chrome_android" | "edge" | "firefox" | "firefox_android" | "safari" | "safari_ios";
@@ -42,8 +40,3 @@ interface SupportStatus {
  * @format uri
 */
 type specification_url = string;
-
-/** Usage stats URL
- * @format uri
-*/
-type usage_stats_url = string;


### PR DESCRIPTION
Chrome usage stats for web-features is now being maintained in the
Chromium repository:
https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/use_counter/metrics/webdx_feature.mojom;drc=41e539e573351d8e57160f2de3201c28e4a3cc19

All of the 87 features touched here have an enum entry in the above
webdx_feature.mojom file, confirmed by transforming the feature
identifier to kCamelCase and looking for an exact match in the list.