### PR TITLE
Refresh dist with forks

### DIFF
--- a/.github/workflows/refresh_dist.yml
+++ b/.github/workflows/refresh_dist.yml
@@ -11,6 +11,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - id: changed-package-json
         uses: tj-actions/changed-files@v44
@@ -49,13 +52,15 @@ jobs:
         with:
           commit_message: Refresh dist files
 
-      - name: Remove label
-        uses: actions/github-script@v6
+      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
+      - name: Save PR URL
+        env:
+          PR_URL: https://github.com/${{ github.repository }}/pull/${{ github.event.number }}
+        run: |
+          mkdir -p ./pr
+          echo $PR_URL > ./pr/pr_url
+
+      - uses: actions/upload-artifact@v4
         with:
-          script: |
-            github.rest.issues.removeLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: ["refresh dist"]
-            })
+          name: pr_url
+          path: pr/

--- a/.github/workflows/remove_refresh_dist_label.yml
+++ b/.github/workflows/remove_refresh_dist_label.yml
@@ -1,0 +1,37 @@
+name: Remove dist label
+
+on:
+  workflow_run:
+    workflows: [Refresh dist files]
+    types: [completed]
+
+jobs:
+  unlabel:
+    runs-on: ubuntu-latest
+
+    steps:
+      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
+      - name: Get PR URL artifact
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr_url"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_url.zip`, Buffer.from(download.data));
+
+      - run: gh pr edit "$(unzip -p pr_url.zip)" --remove-label "refresh dist"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This PR is meant to improve the behavior of the dist refresh workflow, when the contributor's PR is from a fork.

This is needed because we can't (safely) trust the branch PR to modify labels on the web-features repo or assume that the PR is coming from a branch on this repository.

It's a bit convoluted, but here's how it works:

1. The first workflow starts when you label a PR with _refresh dist_. This workflow's permissions vary, depending on the author, originating repo, and the "Allow edits and access to secrets by maintainers" checkbox. In some cases, it won't have permissions to the `web-platform-dx/web-features` repo, so we can't do anything that assumes such permission.
1. It checks out contributor's repo and branch (whether that's `web-platform-dx/web-features` or a fork).
1. It refreshes the affected dist files, commits them, and pushes the change to the contributor's repo and branch.
1. It records which PR the refresh dist workflow ran against, as an artifact.
1. The completion of the previous workflow triggers (via `workflow_run`) a workflow to modify labels. This workflow has repository permissions (like `pull_request_target` would) and runs (safely) in the context of the base branch.
1. The workflow reads the artifact (the PR URL) from the workflow that triggered it, then removes the label from that PR.

Prompted by https://github.com/web-platform-dx/web-features/pull/1242.