### PR TITLE
Dist refresh: run `npm install` in any case with changes

### DIFF
--- a/.github/workflows/refresh_dist.yml
+++ b/.github/workflows/refresh_dist.yml
@@ -27,10 +27,10 @@ jobs:
             features/**/*.yml.dist
 
       - uses: actions/setup-node@v4
-        if: steps.changed-features.outputs.any_changed == 'true'
+        if: steps.changed-package-json.outputs.any_changed == 'true' || steps.changed-features.outputs.any_changed == 'true'
 
       - run: npm install
-        if: steps.changed-features.outputs.any_changed == 'true'
+        if: steps.changed-package-json.outputs.any_changed == 'true' || steps.changed-features.outputs.any_changed == 'true'
 
       - name: Refresh dist files for feature changes
         if: steps.changed-package-json.outputs.any_changed == 'false' && steps.changed-features.outputs.any_changed == 'true'


### PR DESCRIPTION
This fixes a failure like https://github.com/web-platform-dx/web-features/actions/runs/9513999419/job/26225227552?pr=1250 where the dependencies weren't installed because the conditional didn't take into account package.json changes.