### PR TITLE
Revert "Allow use of ranges (≤) before the Baseline low date"

### DIFF
--- a/features/search-input-type.yml
+++ b/features/search-input-type.yml
@@ -5,4 +5,3 @@ group: forms
 caniuse: input-search
 # TODO: investigate minor differences in the early support of the feature
 # between https://caniuse.com/input-search and our generated status.
-use_ranges_before_baseline_low_date: true

--- a/features/search-input-type.yml.dist
+++ b/features/search-input-type.yml.dist
@@ -6,12 +6,12 @@ status:
   baseline_low_date: 2015-07-29
   baseline_high_date: 2018-01-29
   support:
-    chrome: ≤5
+    chrome: "5"
     chrome_android: "18"
     edge: "12"
-    firefox: ≤4
+    firefox: "4"
     firefox_android: "4"
-    safari: ≤5
-    safari_ios: ≤4.2
+    safari: "5"
+    safari_ios: "4.2"
 compat_features:
   - html.elements.input.type_search

--- a/index.ts
+++ b/index.ts
@@ -20,9 +20,6 @@ const nameMaxLength = 80;
 // The longest description allowed, to avoid them growing into documentation.
 const descriptionMaxLength = 300;
 
-// The cutoff point for when ranges (≤) are allowed.
-const allowRangesBeforeDate = Temporal.PlainDate.from('2016-01-01');
-
 // Internal symbol to mark draft entries, so that using the draft field outside
 // of a draft directory doesn't work.
 const draft = Symbol('draft');
@@ -30,10 +27,9 @@ const draft = Symbol('draft');
 // Some FeatureData keys aren't (and may never) be ready for publishing.
 // They're not part of the public schema (yet).
 const omittables = [
-    "group",
     "snapshot",
-    "use_ranges_before_baseline_low_date",
-];
+    "group"
+]
 
 function scrub(data: any) {
     for (const key of omittables) {
@@ -169,17 +165,6 @@ for (const [key, data] of yamlEntries('features')) {
     for (const snapshot of identifiers(data.snapshot)) {
         if (!snapshots.has(snapshot)) {
             throw new Error(`snapshot ${snapshot} used in ${key}.yml is not a valid snapshot. Add it to snapshots/ if needed.`);
-        }
-    }
-
-    // Ensure that version ranges are only used for prehistoric features.
-    if (data.status?.support) {
-        const versions: string[] = Object.values(data.status.support);
-        if (versions.some((v) => v.startsWith('≤'))) {
-            const lowDate = Temporal.PlainDate.from(data.status.baseline_low_date);
-            if (Temporal.PlainDate.compare(lowDate, allowRangesBeforeDate) >= 0) {
-                throw new Error(`Ranges (≤) used in ${key}.yml(.dist) but can only be used when the baseline_low_date is before ${allowRangesBeforeDate}.`);
-            }
         }
     }
 

--- a/schemas/defs.schema.json
+++ b/schemas/defs.schema.json
@@ -101,7 +101,7 @@
             },
             "support": {
               "additionalProperties": false,
-              "description": "Browser versions that most-recently introduced the feature. A \"≤\" prefix indicates that support before this point is uncertain and the feature may have been supported earlier.",
+              "description": "Browser versions that most-recently introduced the feature",
               "properties": {
                 "chrome": {
                   "type": "string"

--- a/types.ts
+++ b/types.ts
@@ -30,7 +30,7 @@ interface SupportStatus {
     baseline_low_date?: string;
     /** Date the feature achieved Baseline high status */
     baseline_high_date?: string;
-    /** Browser versions that most-recently introduced the feature. A "≤" prefix indicates that support before this point is uncertain and the feature may have been supported earlier. */
+    /** Browser versions that most-recently introduced the feature */
     support: {
         [K in browserIdentifier]?: string;
     };


### PR DESCRIPTION
This complicates https://github.com/web-platform-dx/web-features/pull/1231 which is much more important for the velocity of the project, so back this out for now.

Reverts https://github.com/web-platform-dx/web-features/pull/1208.