### PR TITLE
`container-queries`: remove similarly-named but irrelevant compat keys

### DIFF
--- a/features/container-queries.yml
+++ b/features/container-queries.yml
@@ -10,9 +10,6 @@ compat_features:
   # - api.CSSContainerRule.containerName
   # - api.CSSContainerRule.containerQuery
   - css.at-rules.container
-  - css.properties.contain
-  - css.properties.contain.inline-size
-  - css.properties.contain.style
   - css.properties.container
   - css.properties.container-name
   - css.properties.container-name.none


### PR DESCRIPTION
Discovered thanks to https://github.com/web-platform-dx/web-features/pull/1231/ (https://github.com/web-platform-dx/web-features/pull/1231#discussion_r1660925264).