### PR TITLE
`compute-baseline`: Add a couple of conveniences for spec and status data

### DIFF
--- a/packages/compute-baseline/src/browser-compat-data/feature.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.test.ts
@@ -26,6 +26,19 @@ describe("features", function () {
       });
     });
 
+    describe("standard_track", function () {
+      it("returns true only when true", function () {
+        const noStatus = feature("webextensions.manifest.storage");
+        assert.equal(noStatus.standard_track, false);
+
+        const nonStandard = feature("css.properties.-webkit-text-zoom");
+        assert.equal(nonStandard.standard_track, false);
+
+        const standard = feature("html.elements.table");
+        assert.equal(standard.standard_track, true);
+      });
+    });
+
     describe("spec_url", function () {
       it("returns an empty array if there's no spec_url", function () {
         const noSpec = feature("javascript.builtins.Date.parse.iso_8601");

--- a/packages/compute-baseline/src/browser-compat-data/feature.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.test.ts
@@ -26,6 +26,21 @@ describe("features", function () {
       });
     });
 
+    describe("spec_url", function () {
+      it("returns an empty array if there's no spec_url", function () {
+        const noSpec = feature("javascript.builtins.Date.parse.iso_8601");
+        assert(noSpec.spec_url.length === 0);
+      });
+
+      it("returns an array regardless of the number of spec_urls", function () {
+        const oneSpec = feature("css.properties.grid").spec_url;
+        assert.equal(oneSpec.length, 1);
+
+        const twoSpecs = feature("css.properties.width").spec_url;
+        assert.equal(twoSpecs.length, 2);
+      });
+    });
+
     describe("tags", function () {
       it("returns an array for features with tags", function () {
         const f = feature("css.types.length.cap");

--- a/packages/compute-baseline/src/browser-compat-data/feature.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.ts
@@ -68,6 +68,10 @@ export class Feature {
     return [];
   }
 
+  get standard_track(): boolean {
+    return this.data.__compat?.status?.standard_track ?? false;
+  }
+
   _supportedBy(
     browser: Browser,
   ): { release: Release; qualifications?: Qualifications }[] {

--- a/packages/compute-baseline/src/browser-compat-data/feature.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.ts
@@ -56,6 +56,18 @@ export class Feature {
     return this.data.__compat?.mdn_url;
   }
 
+  /**
+   * The feature's specification URLs as an array (whether there are any URLs or
+   * not).
+   */
+  get spec_url(): string[] {
+    const underlying = this.data.__compat?.spec_url;
+    if (underlying) {
+      return Array.isArray(underlying) ? underlying : [underlying];
+    }
+    return [];
+  }
+
   _supportedBy(
     browser: Browser,
   ): { release: Release; qualifications?: Qualifications }[] {

--- a/scripts/update-drafts.ts
+++ b/scripts/update-drafts.ts
@@ -61,13 +61,7 @@ async function main() {
       continue;
     }
 
-    const spec_url = feature.data.__compat.spec_url;
-    if (!spec_url) {
-      continue;
-    }
-
-    const urls = Array.isArray(spec_url) ? spec_url : [spec_url];
-    for (const url of urls) {
+    for (const url of feature.spec_url) {
       const spec = pageToSpec.get(normalize(url));
       if (!spec) {
         console.warn(`${url} not matched to any spec`);

--- a/scripts/update-drafts.ts
+++ b/scripts/update-drafts.ts
@@ -1,8 +1,8 @@
 import { Compat } from "compute-baseline/browser-compat-data";
 import fs from "node:fs/promises";
 import { fileURLToPath } from "node:url";
-import YAML from "yaml";
 import webSpecs from 'web-specs' assert { type: 'json' };
+import YAML from "yaml";
 import features from '../index.js';
 
 function* getPages(spec): Generator<string> {
@@ -56,8 +56,7 @@ async function main() {
     }
 
     // Skip deprecated and non-standard features.
-    const status = feature.data.__compat.status;
-    if (status?.deprecated || !status?.standard_track) {
+    if (feature.deprecated || !feature.standard_track) {
       continue;
     }
 


### PR DESCRIPTION
It's pretty clunky to do the `feature.data.__compat` + cleanup. I'd rather not think about the BCD schema, if I can help it. 😅 