### PR TITLE
Add CLI to `build.ts`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,7 @@
 !/packages/compute-baseline/**
 !/packages/web-features/**
 
+!/scripts/build.ts
 !/scripts/dist.ts
 !/scripts/feature-init.ts
 !/scripts/find-troublesome-ancestors.ts

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">=18.19.0"
   },
   "scripts": {
-    "build": "tsx scripts/build.ts",
+    "build": "tsx scripts/build.ts package",
     "dist": "tsx scripts/dist.ts",
     "schema-defs": "ts-json-schema-generator --tsconfig ./tsconfig.json --type FeatureData --path ./types.ts --id defs",
     "schema-defs:write": "npm run schema-defs -- --out ./schemas/defs.schema.json",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,16 +1,24 @@
-import fs from "fs";
-
-import stringify from "fast-json-stable-stringify";
-
 import { execSync } from "child_process";
+import stringify from "fast-json-stable-stringify";
+import fs from "fs";
+import yargs from "yargs";
 import features from "../index.js";
 
 const rootDir = new URL("..", import.meta.url);
-const packageDir = new URL("./packages/web-features/", rootDir);
 
-const filesToCopy = ["LICENSE.txt", "types.ts"];
+yargs(process.argv.slice(2))
+  .scriptName("build")
+  .command({
+    command: "package",
+    describe: "Generate the web-features npm package",
+    handler: buildPackage,
+  })
+  .parseSync();
 
-function build() {
+function buildPackage() {
+  const packageDir = new URL("./packages/web-features/", rootDir);
+  const filesToCopy = ["LICENSE.txt", "types.ts"];
+
   const json = stringify(features);
   // TODO: Validate the resulting JSON against a schema.
   const path = new URL("index.json", packageDir);
@@ -27,5 +35,3 @@ function build() {
     encoding: "utf-8",
   });
 }
-
-build();

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,25 +1,31 @@
-import fs from 'fs';
+import fs from "fs";
 
-import stringify from 'fast-json-stable-stringify';
+import stringify from "fast-json-stable-stringify";
 
-import features from '../index.js';
-import { execSync } from 'child_process';
+import { execSync } from "child_process";
+import features from "../index.js";
 
-const rootDir = new URL('..', import.meta.url);
-const packageDir = new URL('./packages/web-features/', rootDir);
+const rootDir = new URL("..", import.meta.url);
+const packageDir = new URL("./packages/web-features/", rootDir);
 
 const filesToCopy = ["LICENSE.txt", "types.ts"];
 
 function build() {
-    const json = stringify(features);
-    // TODO: Validate the resulting JSON against a schema.
-    const path = new URL('index.json', packageDir);
-    fs.writeFileSync(path, json);
-    for (const file of filesToCopy) {
-        fs.copyFileSync(new URL(file, rootDir), new URL(file, packageDir));
-    }
-    execSync("npm install", { cwd: "./packages/web-features",  encoding: "utf-8"});
-    execSync("npm run prepare", { cwd: "./packages/web-features", encoding: "utf-8"});
+  const json = stringify(features);
+  // TODO: Validate the resulting JSON against a schema.
+  const path = new URL("index.json", packageDir);
+  fs.writeFileSync(path, json);
+  for (const file of filesToCopy) {
+    fs.copyFileSync(new URL(file, rootDir), new URL(file, packageDir));
+  }
+  execSync("npm install", {
+    cwd: "./packages/web-features",
+    encoding: "utf-8",
+  });
+  execSync("npm run prepare", {
+    cwd: "./packages/web-features",
+    encoding: "utf-8",
+  });
 }
 
 build();


### PR DESCRIPTION
This is a little bit of prep to facilitate generating bare JSONs as GitHub release artifacts. `npx tsx ./scripts/build.ts` is now `npx tsx ./scripts/build.ts package`. That's it, for now.

Also, I applied prettier to this file. That was maybe a little bit of a mistake—the diff on the 2nd commit is more readable.