### PR TITLE
`compute-baseline`: Fix support statement `version_added` getter return type

### DIFF
--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.test.ts
@@ -80,6 +80,11 @@ describe("statements", function () {
         const s = new SupportStatement({});
         assert.equal(s.version_added, false);
       });
+
+      it("returns null for null", function () {
+        const s = new SupportStatement({ version_added: null });
+        assert.equal(s.version_added, null);
+      });
     });
 
     describe("#version_removed", function () {

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
@@ -97,9 +97,14 @@ export class SupportStatement {
     return this.data?.partial_implementation ?? false;
   }
 
+  /**
+   * Get the `version_added` value, or false if unset.
+   */
   get version_added(): VersionValue {
-    // Strictness guarantee: unset version_added returns false
-    return this.data?.version_added || false;
+    if (this.data?.version_added === undefined) {
+      return false;
+    }
+    return this.data?.version_added;
   }
 
   get version_removed(): VersionValue {


### PR DESCRIPTION
A very tiny step on the way toward "exploding" support statements into per-version y/n/unknown support information.

(Putting this PR in now, in the spirit of smaller PRs faster.)