### PR TITLE
`compute-baseline`: add method to expand a support statement into per-release support information

### DIFF
--- a/packages/compute-baseline/src/browser-compat-data/release.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/release.test.ts
@@ -108,10 +108,19 @@ describe("Release", function () {
 
     it("handles closed ranges", function () {
       const cr = browser("chrome");
+
+      // Start of range is inclusive
       assert.equal(
         cr.version("1").inRange(cr.version("1"), cr.version("125")),
         true,
       );
+
+      // End of range is exclusive
+      assert.equal(
+        cr.version("20").inRange(cr.version("1"), cr.version("20")),
+        false,
+      );
+
       assert.equal(
         cr.version("1").inRange(cr.version("10"), cr.version("15")),
         false,

--- a/packages/compute-baseline/src/browser-compat-data/release.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/release.test.ts
@@ -87,4 +87,30 @@ describe("Release", function () {
       assert.equal(safariPreview.isPrerelease(), true);
     });
   });
+
+  describe("inRange()", function () {
+    it("handles closed ranges", function () {
+      const cr = browser("chrome");
+      assert.equal(
+        cr.version("1").inRange(cr.version("1"), cr.version("125")),
+        true,
+      );
+      assert.equal(
+        cr.version("1").inRange(cr.version("10"), cr.version("15")),
+        false,
+      );
+      assert.equal(
+        cr.version("100").inRange(cr.version("10"), cr.version("15")),
+        false,
+      );
+    });
+
+    it("handles open ranges", function () {
+      const cr = browser("chrome");
+      assert.equal(cr.version("1").inRange(cr.version("1")), true);
+      assert.equal(cr.version("1").inRange(cr.version("10")), false);
+      assert.equal(cr.version("100").inRange(cr.version("10")), true);
+      assert.equal(cr.version("preview").inRange(cr.version("10")), true);
+    });
+  });
 });

--- a/packages/compute-baseline/src/browser-compat-data/release.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/release.test.ts
@@ -40,6 +40,16 @@ describe("Release", function () {
   });
 
   describe("compare()", function () {
+    it("throws when comparing between two browsers", function () {
+      const cr = browser("chrome");
+      const ed = browser("edge");
+
+      assert.throws(
+        () => cr.version("100").inRange(ed.version("79"), cr.version("125")),
+        Error,
+      );
+    });
+
     it("returns 0 for equivalent releases", function () {
       const chrome100 = browser("chrome").version("100");
       assert.equal(chrome100.compare(chrome100), 0);
@@ -89,6 +99,13 @@ describe("Release", function () {
   });
 
   describe("inRange()", function () {
+    it("throws when comparing between two browsers", function () {
+      const cr = browser("chrome");
+      const fx = browser("firefox");
+
+      assert.throws(() => cr.version("50").inRange(fx.version("50")), Error);
+    });
+
     it("handles closed ranges", function () {
       const cr = browser("chrome");
       assert.equal(

--- a/packages/compute-baseline/src/browser-compat-data/release.ts
+++ b/packages/compute-baseline/src/browser-compat-data/release.ts
@@ -44,6 +44,19 @@ export class Release {
     return this.releaseIndex - otherRelease.releaseIndex;
   }
 
+  /**
+   * Check if this release is the same as or after a starting release and,
+   * optionally, before an ending release.
+   */
+  inRange(start: Release, end?: Release): boolean {
+    const onOrAfterStart = this.compare(start) >= 0;
+    if (end) {
+      const beforeEnd = this.compare(end) < 0;
+      return onOrAfterStart && beforeEnd;
+    }
+    return onOrAfterStart;
+  }
+
   isPrerelease(): boolean {
     if (["beta", "nightly", "planned"].includes(this.data.status)) {
       return true;

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.test.ts
@@ -96,9 +96,17 @@ describe("statements", function () {
         assert.equal(s.version_removed, "2");
       });
 
-      it("returns false for undefined", function () {
-        const s = new SupportStatement({ version_added: "1" });
+      it("returns false", function () {
+        const s = new SupportStatement({
+          version_added: "1",
+          version_removed: false,
+        });
         assert.equal(s.version_removed, false);
+      });
+
+      it("returns undefined", function () {
+        const s = new SupportStatement({ version_added: "1" });
+        assert.equal(s.version_removed, undefined);
       });
     });
 

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.test.ts
@@ -258,6 +258,7 @@ describe("statements", function () {
         assert.equal(ranged.supportedIn(cr.version("100")).supported, true);
         assert.equal(ranged.supportedIn(cr.version("101")).supported, true);
         assert.equal(ranged.supportedIn(cr.version("124")).supported, true);
+        assert.equal(unranged.supportedIn(cr.version("125")).supported, false);
       });
 
       it("returns unknown support when release is before ranged version_added", function () {
@@ -286,6 +287,7 @@ describe("statements", function () {
         );
 
         assert.equal(rangedEnd.supportedIn(cr.version("100")).supported, true);
+        assert.equal(rangedEnd.supportedIn(cr.version("101")).supported, null);
         assert.equal(rangedEnd.supportedIn(cr.version("124")).supported, null);
         assert.equal(rangedEnd.supportedIn(cr.version("125")).supported, false);
       });

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.test.ts
@@ -297,9 +297,8 @@ describe("statements", function () {
           cr,
         );
 
-        const allReleases = cr.releases.map((r) => statement.supportedIn(r));
-        for (const { supported } of allReleases) {
-          assert.equal(supported, false);
+        for (const release of cr.releases) {
+          assert.equal(statement.supportedIn(release).supported, false);
         }
       });
 

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
@@ -71,26 +71,6 @@ export class SupportStatement {
     this.feature = feature;
   }
 
-  _isRanged(key: "version_added" | "version_removed" | undefined): boolean {
-    if (key === undefined) {
-      return (
-        this._isRanged("version_added") || this._isRanged("version_removed")
-      );
-    }
-
-    const version = this.data?.[key];
-
-    if (
-      typeof version === "boolean" ||
-      version === undefined ||
-      version === null
-    ) {
-      return false;
-    }
-
-    return version.includes("≤");
-  }
-
   get flags(): FlagStatement[] {
     return this.data?.flags ?? [];
   }

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
@@ -90,9 +90,29 @@ export class SupportStatement {
     return this.data?.version_added;
   }
 
-  get version_removed(): VersionValue {
-    // Strictness guarantee: unset version_removed returns false
-    return this.data?.version_removed || false;
+  get version_removed(): string | boolean | undefined {
+    const value = this.data?.version_removed;
+
+    // TODO: Report and fix upstream bug in BCD, then uncomment or drop the code
+    // below
+
+    // According to @mdn/browser-compat-data's schema, `version_removed` values
+    // should only be `true` or strings. In practice (and according to the
+    // exported types), this is not the case, because mirroring inserts `false`
+    // values.
+
+    // if (value === null || value === false) {
+    //   throw new Error(
+    //     "`version_added` should never be `null` or `false`. This is a bug, so please file an issue!",
+    //   );
+    // }
+    if (value === null) {
+      throw new Error(
+        "`version_added` should never be `null`. This is a bug, so please file an issue!",
+      );
+    }
+
+    return value;
   }
 
   /**
@@ -194,12 +214,12 @@ export class RealSupportStatement extends SupportStatement {
     }
   }
 
-  get version_added() {
+  get version_added(): string | false {
     return super.version_added as string | false;
   }
 
-  get version_removed() {
-    return super.version_removed as string | false;
+  get version_removed(): string | false | undefined {
+    return super.version_removed as string | false | undefined;
   }
 
   supportedBy(): { release: Release; qualifications?: Qualifications }[] {
@@ -219,7 +239,7 @@ export class RealSupportStatement extends SupportStatement {
     }
 
     let releases;
-    if (this.version_removed === undefined) {
+    if (this.version_removed === undefined || this.version_removed === false) {
       releases = this.browser.releases.filter((rel) => rel.inRange(start));
     } else {
       const end: Release = this.browser.version(this.version_removed);

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
@@ -168,13 +168,11 @@ export class RealSupportStatement extends SupportStatement {
     }
 
     let releases;
-    if (this.version_removed === false) {
-      releases = this.browser.releases.filter((rel) => rel.compare(start) >= 0); // Release is on or after start
+    if (this.version_removed === undefined) {
+      releases = this.browser.releases.filter((rel) => rel.inRange(start));
     } else {
       const end: Release = this.browser.version(this.version_removed);
-      releases = this.browser.releases.filter(
-        (rel) => rel.compare(start) >= 0 && rel.compare(end) < 0,
-      ); // Release is on or after start and before the end
+      releases = this.browser.releases.filter((rel) => rel.inRange(start, end));
     }
 
     let qualifications: Qualifications = statementToQualifications(this);

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
@@ -136,23 +136,14 @@ export class SupportStatement {
       );
     }
 
-    if (this.version_added === true) {
-      const result = new Map();
-      for (const r of this.browser.releases) {
-        if (r.inRange(this.browser.current())) {
-          result.set(r, { supported: true });
-        } else {
-          result.set(r, { supported: false });
-        }
-      }
-      return result;
-    }
-
     const result = new Map();
 
     let start: Release;
     let startRanged = false;
-    if (this.version_added.startsWith("≤")) {
+    if (this.version_added === true) {
+      startRanged = true;
+      start = this.browser.current();
+    } else if (this.version_added.startsWith("≤")) {
       startRanged = true;
       start = this.browser.version(this.version_added.slice(1));
     } else {

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
@@ -177,19 +177,7 @@ export class RealSupportStatement extends SupportStatement {
       ); // Release is on or after start and before the end
     }
 
-    let qualifications: Qualifications = {};
-    if (this.data.prefix) {
-      qualifications.prefix = this.data.prefix;
-    }
-    if (this.data.alternative_name) {
-      qualifications.alternative_name = this.data.alternative_name;
-    }
-    if (this.flags.length) {
-      qualifications.flags = this.flags;
-    }
-    if (this.partial_implementation) {
-      qualifications.partial_implementation = this.partial_implementation;
-    }
+    let qualifications: Qualifications = statementToQualifications(this);
     if (Object.keys(qualifications).length) {
       return releases.map((release) => ({ release, qualifications }));
     }
@@ -197,4 +185,23 @@ export class RealSupportStatement extends SupportStatement {
       release,
     }));
   }
+}
+
+function statementToQualifications(
+  statement: SupportStatement,
+): Qualifications {
+  let qualifications: Qualifications = {};
+  if (statement.data.prefix) {
+    qualifications.prefix = statement.data.prefix;
+  }
+  if (statement.data.alternative_name) {
+    qualifications.alternative_name = statement.data.alternative_name;
+  }
+  if (statement.flags.length) {
+    qualifications.flags = statement.flags;
+  }
+  if (statement.partial_implementation) {
+    qualifications.partial_implementation = statement.partial_implementation;
+  }
+  return qualifications;
 }


### PR DESCRIPTION
This is another incremental step toward handling version ranges more completely, by taking a support statement and mapping it to _every_ release that a browser has.

More specifically, this PR:

- Adds `toReleaseSupportMap()` method to `SupportStatement`s. It's very much like `supportedBy()`, except it has something to say about every version, not just the supporting versions. I've made some of `supportedBy()` reusable. Eventually, but not today, we'll rip out `supportedBy()` entirely.

- Adds an `inRange(start, end?)` method to `Releases`s. This is a not-infrequent thing to check and remembering what `>= 0` means is hard.

- Remove some never-used code relating to ranges.

- Handle bugged `version_removed` values in BCD. Basically, some values should never happen according to the schema, but are happening anyway. This won't be completely fixed until it gets fixed upstream.

The next step after this will be to reconcile multiple support statements at the feature level (i.e., filtering out "unsupported" entries when there's a competing "supported" entry) and do it across browsers (e.g., to create something like `Map<Browser, Map<Release, Supported | Unsupported | UnknownSupport>>`).