### PR TITLE
Remove backticks from ranges describing valid identifiers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,7 @@ Feature authors should (in descending order of priority):
 
 ### Identifiers
 
-Feature identifiers must contain only lowercase alphanumeric characters (`a`-`z` and `0-9`) plus the `-` character (hyphen or minus sign) as a word separator.
+Feature identifiers must contain only lowercase alphanumeric characters (a-z and 0-9) plus the `-` character (hyphen or minus sign) as a word separator.
 
 The identifier should match the name, with these additional guidelines:
 


### PR DESCRIPTION
This is really to fix the inconsistency that was there.