### PR TITLE
Update contain-intrinsic-size to cover the `auto none` value

### DIFF
--- a/features/contain-intrinsic-size.yml
+++ b/features/contain-intrinsic-size.yml
@@ -1,13 +1,5 @@
 name: contain-intrinsic-size
 description: The `contain-intrinsic-size` CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.
 spec: https://drafts.csswg.org/css-sizing-4/#intrinsic-size-override
-# Shown as "intrinsic-size" on chromestatus.com, but 651 is contain-intrinsic-size.
-compat_features:
-  # Initial support:
-  - css.properties.contain-intrinsic-block-size
-  - css.properties.contain-intrinsic-height
-  - css.properties.contain-intrinsic-inline-size
-  - css.properties.contain-intrinsic-size
-  - css.properties.contain-intrinsic-width
-  # Later support:
-  # - css.properties.contain-intrinsic-size.auto_none
+status:
+  compute_from: css.properties.contain-intrinsic-size

--- a/features/contain-intrinsic-size.yml.dist
+++ b/features/contain-intrinsic-size.yml.dist
@@ -5,14 +5,15 @@ status:
   baseline: low
   baseline_low_date: 2023-09-18
   support:
-    chrome: "95"
-    chrome_android: "95"
-    edge: "95"
+    chrome: "83"
+    chrome_android: "83"
+    edge: "83"
     firefox: "107"
     firefox_android: "107"
     safari: "17"
     safari_ios: "17"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: low
   # baseline_low_date: 2023-09-18
   # support:
@@ -25,7 +26,6 @@ compat_features:
   #   safari_ios: "17"
   - css.properties.contain-intrinsic-size
 
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: low
   # baseline_low_date: 2023-09-18
   # support:
@@ -40,3 +40,15 @@ compat_features:
   - css.properties.contain-intrinsic-height
   - css.properties.contain-intrinsic-inline-size
   - css.properties.contain-intrinsic-width
+
+  # baseline: low
+  # baseline_low_date: 2023-09-18
+  # support:
+  #   chrome: "117"
+  #   chrome_android: "117"
+  #   edge: "117"
+  #   firefox: "117"
+  #   firefox_android: "117"
+  #   safari: "17"
+  #   safari_ios: "17"
+  - css.properties.contain-intrinsic-size.auto_none


### PR DESCRIPTION
This was already tagged in BCD, so use the tags.

Pin the feature status to the contain-intrinsic-size shorthand, since
the feature is usable with just that. This changes the Chrome and Edge
versions, but not the Baseline low date.
