### PR TITLE
Remove redundant compat_features lists

### DIFF
--- a/features/conic-gradients.yml
+++ b/features/conic-gradients.yml
@@ -3,15 +3,13 @@ description: The `conic-gradient()` and `repeating-conic-gradient()` CSS functio
 spec: https://drafts.csswg.org/css-images-4/#conic-gradients
 group: gradients
 caniuse: css-conic-gradients
-# https://caniuse.com/css-conic-gradients has a note about multi-position color
-# stops in Chrome 69-70, while BCD has it as a subfeature supported since Chrome
-# 72. TODO: investigate support in Chrome 71 and align BCD and caniuse.
+status:
+  compute_from: css.types.image.gradient.conic-gradient
 compat_features:
   - css.types.image.gradient.conic-gradient
   - css.types.image.gradient.conic-gradient.doubleposition
   - css.types.image.gradient.repeating-conic-gradient
-  # Later additions for parity with CSS Color Level 4:
-  # - css.types.image.gradient.conic-gradient.hue_interpolation_method
-  # - css.types.image.gradient.conic-gradient.interpolation_color_space
-  # - css.types.image.gradient.repeating-conic-gradient.hue_interpolation_method
-  # - css.types.image.gradient.repeating-conic-gradient.interpolation_color_space
+  - css.types.image.gradient.conic-gradient.hue_interpolation_method
+  - css.types.image.gradient.conic-gradient.interpolation_color_space
+  - css.types.image.gradient.repeating-conic-gradient.hue_interpolation_method
+  - css.types.image.gradient.repeating-conic-gradient.interpolation_color_space

--- a/features/conic-gradients.yml.dist
+++ b/features/conic-gradients.yml.dist
@@ -6,14 +6,15 @@ status:
   baseline_low_date: 2020-11-17
   baseline_high_date: 2023-05-17
   support:
-    chrome: "72"
-    chrome_android: "72"
+    chrome: "69"
+    chrome_android: "69"
     edge: "79"
     firefox: "83"
     firefox_android: "83"
     safari: "12.1"
     safari_ios: "12.2"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: high
   # baseline_low_date: 2020-11-17
   # baseline_high_date: 2023-05-17
@@ -28,7 +29,6 @@ compat_features:
   - css.types.image.gradient.conic-gradient
   - css.types.image.gradient.repeating-conic-gradient
 
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: high
   # baseline_low_date: 2020-11-17
   # baseline_high_date: 2023-05-17
@@ -41,3 +41,18 @@ compat_features:
   #   safari: "12.1"
   #   safari_ios: "12.2"
   - css.types.image.gradient.conic-gradient.doubleposition
+
+  # baseline: low
+  # baseline_low_date: 2024-06-11
+  # support:
+  #   chrome: "111"
+  #   chrome_android: "111"
+  #   edge: "111"
+  #   firefox: "127"
+  #   firefox_android: "127"
+  #   safari: "16.2"
+  #   safari_ios: "16.2"
+  - css.types.image.gradient.conic-gradient.hue_interpolation_method
+  - css.types.image.gradient.conic-gradient.interpolation_color_space
+  - css.types.image.gradient.repeating-conic-gradient.hue_interpolation_method
+  - css.types.image.gradient.repeating-conic-gradient.interpolation_color_space

--- a/features/font-palette-animation.yml
+++ b/features/font-palette-animation.yml
@@ -2,6 +2,3 @@ name: font-palette animation
 description: You can animate color fonts between two `font-palette` values.
 spec: https://drafts.csswg.org/css-fonts-4/#font-palette-prop
 group: fonts
-compat_features:
-  - css.properties.font-palette.animation_computed
-  - css.properties.font-palette.palette-mix_function

--- a/features/font-size-adjust.yml
+++ b/features/font-size-adjust.yml
@@ -3,9 +3,13 @@ description: The `font-size-adjust` CSS property preserves apparent text size, r
 spec: https://drafts.csswg.org/css-fonts-5/#font-size-adjust-prop
 group: fonts
 caniuse: font-size-adjust
+status:
+  compute_from:
+    - css.properties.font-size-adjust
+    # Included in order to match https://caniuse.com/font-size-adjust
+    - css.properties.font-size-adjust.from-font
 compat_features:
   - css.properties.font-size-adjust
-  # TODO: include after https://github.com/mdn/browser-compat-data/pull/22936
-  # - css.properties.font-size-adjust.from-font
-  # - css.properties.font-size-adjust.none
-  # - css.properties.font-size-adjust.two-values
+  - css.properties.font-size-adjust.from-font
+  - css.properties.font-size-adjust.none
+  - css.properties.font-size-adjust.two-values

--- a/features/font-size-adjust.yml.dist
+++ b/features/font-size-adjust.yml.dist
@@ -4,9 +4,33 @@
 status:
   baseline: false
   support:
-    firefox: "3"
-    firefox_android: "4"
-    safari: "16.4"
-    safari_ios: "16.4"
+    firefox: "118"
+    firefox_android: "118"
+    safari: "17"
+    safari_ios: "17"
 compat_features:
+  # baseline: false
+  # support:
+  #   firefox: "3"
+  #   firefox_android: "4"
+  #   safari: "16.4"
+  #   safari_ios: "16.4"
   - css.properties.font-size-adjust
+  - css.properties.font-size-adjust.none
+
+  # baseline: false
+  # support:
+  #   firefox: "92"
+  #   firefox_android: "92"
+  #   safari: "17"
+  #   safari_ios: "17"
+  - css.properties.font-size-adjust.two-values
+
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: false
+  # support:
+  #   firefox: "118"
+  #   firefox_android: "118"
+  #   safari: "17"
+  #   safari_ios: "17"
+  - css.properties.font-size-adjust.from-font

--- a/features/font-synthesis-position.yml
+++ b/features/font-synthesis-position.yml
@@ -2,12 +2,7 @@ name: font-synthesis-position
 description: "The `font-synthesis-position` CSS property sets whether or not the browser should synthesize subscript and superscript typefaces when they're missing from the font."
 spec: https://drafts.csswg.org/css-fonts-4/#font-synthesis-position
 group: font-synthesis
-compat_features:
-  - css.properties.font-synthesis-position
-  - css.properties.font-synthesis-position.auto
-  - css.properties.font-synthesis-position.none
-  # The font-synthesis shorthand also allows disabling all synthesis and opting
-  # in to specific kinds of synthesis. As such, `font-synthesis: position`
-  # affects everything except position, and doesn't fit the description of this
-  # feature. See https://github.com/w3c/csswg-drafts/issues/1641.
-  # - css.properties.font-synthesis.position
+# The font-synthesis shorthand also allows disabling all synthesis and opting
+# in to specific kinds of synthesis. As such, `font-synthesis: position`
+# affects everything except position, and doesn't fit the description of this
+# feature. See https://github.com/w3c/csswg-drafts/issues/1641.

--- a/features/font-synthesis-small-caps.yml
+++ b/features/font-synthesis-small-caps.yml
@@ -2,12 +2,7 @@ name: font-synthesis-small-caps
 description: "The `font-synthesis-small-caps` CSS property sets whether or not the browser should synthesize small caps typefaces when they're missing from the font."
 spec: https://drafts.csswg.org/css-fonts-4/#font-synthesis-small-caps
 group: font-synthesis
-compat_features:
-  - css.properties.font-synthesis-small-caps
-  - css.properties.font-synthesis-small-caps.auto
-  - css.properties.font-synthesis-small-caps.none
-  # The font-synthesis shorthand also allows disabling all synthesis and opting
-  # in to specific kinds of synthesis. As such, `font-synthesis: small-caps`
-  # affects everything except small caps, and doesn't fit the description of
-  # this feature. See https://github.com/w3c/csswg-drafts/issues/1641.
-  # - css.properties.font-synthesis.small-caps
+# The font-synthesis shorthand also allows disabling all synthesis and opting
+# in to specific kinds of synthesis. As such, `font-synthesis: small-caps`
+# affects everything except small caps, and doesn't fit the description of
+# this feature. See https://github.com/w3c/csswg-drafts/issues/1641.

--- a/features/font-synthesis-style.yml
+++ b/features/font-synthesis-style.yml
@@ -2,12 +2,7 @@ name: font-synthesis-style
 description: The `font-synthesis-style` CSS property sets whether or not the browser should synthesize italic and oblique typefaces when they're missing from the font.
 spec: https://drafts.csswg.org/css-fonts-4/#font-synthesis-style
 group: font-synthesis
-compat_features:
-  - css.properties.font-synthesis-style
-  - css.properties.font-synthesis-style.auto
-  - css.properties.font-synthesis-style.none
-  # The font-synthesis shorthand also allows disabling all synthesis and opting
-  # in to specific kinds of synthesis. As such, `font-synthesis: style` affects
-  # everything except style, and doesn't fit the description of this feature.
-  # See https://github.com/w3c/csswg-drafts/issues/1641.
-  # - css.properties.font-synthesis.style
+# The font-synthesis shorthand also allows disabling all synthesis and opting
+# in to specific kinds of synthesis. As such, `font-synthesis: style` affects
+# everything except style, and doesn't fit the description of this feature.
+# See https://github.com/w3c/csswg-drafts/issues/1641.

--- a/features/font-synthesis-weight.yml
+++ b/features/font-synthesis-weight.yml
@@ -2,12 +2,7 @@ name: font-synthesis-weight
 description: The `font-synthesis-weight` CSS property sets whether or not the browser should synthesize bold typefaces when they're missing from the font.
 spec: https://drafts.csswg.org/css-fonts-4/#font-synthesis-weight
 group: font-synthesis
-compat_features:
-  - css.properties.font-synthesis-weight
-  - css.properties.font-synthesis-weight.auto
-  - css.properties.font-synthesis-weight.none
-  # The font-synthesis shorthand also allows disabling all synthesis and opting
-  # in to specific kinds of synthesis. As such, `font-synthesis: weight` affects
-  # everything except weight, and doesn't fit the description of this feature.
-  # See https://github.com/w3c/csswg-drafts/issues/1641.
-  # - css.properties.font-synthesis.weight
+# The font-synthesis shorthand also allows disabling all synthesis and opting
+# in to specific kinds of synthesis. As such, `font-synthesis: weight` affects
+# everything except weight, and doesn't fit the description of this feature.
+# See https://github.com/w3c/csswg-drafts/issues/1641.

--- a/features/font-synthesis.yml
+++ b/features/font-synthesis.yml
@@ -2,5 +2,3 @@ name: font-synthesis
 description: The `font-synthesis` CSS shorthand property disables all font synthesis except the given kinds. To disable a specific kind of font synthesis, instead use the longhand properties such as `font-synthesis-style` and `font-synthesis-weight`.
 spec: https://drafts.csswg.org/css-fonts-4/#font-synthesis
 group: font-synthesis
-compat_features:
-  - css.properties.font-synthesis


### PR DESCRIPTION
This resolves all warnings from `npm run dist` about this. For conic
gradients and font-size-adjust, the change in overall feature status
aligns with caniuse.com.
