### PR TITLE
Fix incorrect "same status" comment when status override is used

### DIFF
--- a/features/scroll-snap.yml.dist
+++ b/features/scroll-snap.yml.dist
@@ -85,7 +85,6 @@ compat_features:
   #   safari_ios: "11"
   - css.properties.scroll-snap-type
 
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: low
   # baseline_low_date: 2022-07-26
   # support:

--- a/features/web-bluetooth.yml.dist
+++ b/features/web-bluetooth.yml.dist
@@ -75,7 +75,6 @@ compat_features:
   - api.BluetoothRemoteGATTCharacteristic.writeValueWithResponse
   - api.BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse
 
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support: {}
   - api.Bluetooth.getDevices

--- a/scripts/dist.ts
+++ b/scripts/dist.ts
@@ -192,7 +192,7 @@ function toDist(sourcePath: string): YAML.Document {
   const sortedGroups = new Map<string, string[]>();
   for (const status of sortedStatus) {
     let comment = YAML.stringify(status);
-    if (isDeepStrictEqual(status, computedStatus)) {
+    if (isDeepStrictEqual(status, source.status ?? computedStatus)) {
       comment = `⬇️ Same status as overall feature ⬇️\n${comment}`;
     }
     sortedGroups.set(comment, groups.get(status));


### PR DESCRIPTION
For a few features, the comment was added incorrectly based on what the
computed status was, but the computed status is never written to dist if
the source includes an override.
