### PR TITLE
`compute-baseline`: Add per-release support checks to `Feature`s

### DIFF
--- a/packages/compute-baseline/src/baseline/support.ts
+++ b/packages/compute-baseline/src/baseline/support.ts
@@ -19,7 +19,7 @@ export function support(feature: Feature, browsers: Browser[]): Support {
 
     // const reverseChronological = b.releases.slice().reverse();
     // let previousRelease: string | undefined;
-    // for (let index = 0; index < reverseChronological.length; index++) {
+    // for (let index = b.releases.length - 1; index >= 0; index--) {
     //   const release = reverseChronological[index] as Release;
     //   const current = feature.flatSupportedIn(release);
 

--- a/packages/compute-baseline/src/baseline/support.ts
+++ b/packages/compute-baseline/src/baseline/support.ts
@@ -13,6 +13,18 @@ export function support(feature: Feature, browsers: Browser[]): Support {
   const support: Support = new Map();
   for (const b of browsers) {
     const releases = feature.supportedBy({ only: [b] });
+    // TODO:
+    // let lastInitial: Release | undefined;
+    // let lastInitialBoundary: "" | "≤" | undefined;
+
+    // const reverseChronological = b.releases.slice().reverse();
+    // let previousRelease: string | undefined;
+    // for (let index = 0; index < reverseChronological.length; index++) {
+    //   const release = reverseChronological[index] as Release;
+    //   const current = feature.flatSupportedIn(release);
+
+    //   // Check if current has changed, etc.
+    // }
 
     const unqualifiedReleases = [];
     const qualifiedReleases = [];

--- a/packages/compute-baseline/src/browser-compat-data/feature.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.test.ts
@@ -128,7 +128,7 @@ describe("features", function () {
         assert.equal(lineClamp[0]?.qualifications?.prefix, "-webkit-");
       });
 
-      it("returns mixed results for (un)prefixedfeatures", function () {
+      it("returns mixed results for (un)prefixed features", function () {
         const fx = browser("firefox");
         const actual = feature(
           "css.types.image.gradient.repeating-linear-gradient",

--- a/packages/compute-baseline/src/browser-compat-data/feature.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.test.ts
@@ -73,18 +73,13 @@ describe("features", function () {
     describe("flatSupportedIn()", function () {
       it("returns true for unqualified support", function () {
         const cr = browser("chrome");
-        assert.equal(
-          feature("api.Attr").flatSupportedIn(cr.version("100")),
-          true,
-        );
+        assert.equal(feature("api.Attr").supportedIn(cr.version("100")), true);
       });
 
       it("returns false for qualified support", function () {
         const cr = browser("chrome");
         assert.equal(
-          feature("css.properties.line-clamp").flatSupportedIn(
-            cr.version("100"),
-          ),
+          feature("css.properties.line-clamp").supportedIn(cr.version("100")),
           false,
         ); // { version_added: "…", "prefix": "-webkit-" }
       });
@@ -92,7 +87,7 @@ describe("features", function () {
       it("returns false for wholly unsupported", function () {
         const fx = browser("firefox");
         assert.equal(
-          feature("api.Accelerometer").flatSupportedIn(fx.current()),
+          feature("api.Accelerometer").supportedIn(fx.current()),
           false,
         ); // { version_added: false }
       });
@@ -101,9 +96,9 @@ describe("features", function () {
         const edge = browser("edge");
         const f = feature("svg.elements.animate"); // { version_added: "≤79" }
 
-        assert.equal(f.flatSupportedIn(edge.version("12")), null);
-        assert.equal(f.flatSupportedIn(edge.version("79")), true);
-        assert.equal(f.flatSupportedIn(edge.version("80")), true);
+        assert.equal(f.supportedIn(edge.version("12")), null);
+        assert.equal(f.supportedIn(edge.version("79")), true);
+        assert.equal(f.supportedIn(edge.version("80")), true);
       });
     });
 
@@ -113,16 +108,16 @@ describe("features", function () {
         const cr = browser("chrome");
 
         // { version_added: "…" }
-        const bgColor = feature("css.properties.background-color").supportedIn(
-          cr.version("100"),
-        );
+        const bgColor = feature(
+          "css.properties.background-color",
+        ).supportedInDetails(cr.version("100"));
         assert.equal(bgColor.length, 1);
         assert.equal(bgColor[0]?.supported, true);
 
         // { version_added: "…", prefix: "-webkit-" }
-        const lineClamp = feature("css.properties.line-clamp").supportedIn(
-          cr.version("100"),
-        );
+        const lineClamp = feature(
+          "css.properties.line-clamp",
+        ).supportedInDetails(cr.version("100"));
         assert.equal(lineClamp.length, 1);
         assert.equal(lineClamp[0]?.supported, true);
         assert.equal(lineClamp[0]?.qualifications?.prefix, "-webkit-");
@@ -132,7 +127,7 @@ describe("features", function () {
         const fx = browser("firefox");
         const actual = feature(
           "css.types.image.gradient.repeating-linear-gradient",
-        ).supportedIn(fx.version("100"));
+        ).supportedInDetails(fx.version("100"));
         assert.equal(actual.length, 3); // unprefixed, -moz-, and -webkit-
         assert(actual.some((s) => s.supported && "qualifications" in s));
         assert(actual.some((s) => s.supported && !("qualifications" in s)));
@@ -141,11 +136,11 @@ describe("features", function () {
       it("returns unknown support before version ranges", function () {
         const edge = browser("edge");
         const f = feature("svg.elements.animate");
-        const unknown = f.supportedIn(edge.version("12"));
+        const unknown = f.supportedInDetails(edge.version("12"));
         assert.equal(unknown.length, 1);
         assert.equal(unknown[0]?.supported, null);
 
-        const known = f.supportedIn(edge.version("79"));
+        const known = f.supportedInDetails(edge.version("79"));
         assert.equal(known.length, 1);
         assert.equal(known[0]?.supported, true);
       });

--- a/packages/compute-baseline/src/browser-compat-data/feature.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.ts
@@ -1,5 +1,4 @@
-import { Identifier } from "@mdn/browser-compat-data";
-
+import { Identifier, SimpleSupportStatement } from "@mdn/browser-compat-data";
 import { Browser } from "./browser.js";
 import { Compat, defaultCompat } from "./compat.js";
 import { Release } from "./release.js";
@@ -7,6 +6,10 @@ import {
   Qualifications,
   RealSupportStatement,
   statement,
+  Supported,
+  SupportStatement,
+  UnknownSupport,
+  Unsupported,
 } from "./supportStatements.js";
 import { isFeatureData } from "./typeUtils.js";
 
@@ -72,33 +75,64 @@ export class Feature {
     return this.data.__compat?.status?.standard_track ?? false;
   }
 
-  _supportedBy(
-    browser: Browser,
-  ): { release: Release; qualifications?: Qualifications }[] {
+  rawSupportStatements(browser: Browser): SimpleSupportStatement[] {
     const support = this.data?.__compat?.support;
     if (support === undefined) {
-      throw Error("This feature contains no __compat object.");
+      throw new Error("This feature contains no __compat object.");
     }
 
     const statementOrStatements = support[browser.id];
-
     if (statementOrStatements === undefined) {
-      throw Error(`${this} contains no support data for ${browser.name}`);
+      throw new Error(`${this} contains no support data for ${browser.name}`);
     }
 
-    const rawStatements = Array.isArray(statementOrStatements)
+    return Array.isArray(statementOrStatements)
       ? statementOrStatements
       : [statementOrStatements];
+  }
 
+  supportStatements(browser: Browser): SupportStatement[] {
+    return this.rawSupportStatements(browser).map((raw) =>
+      statement(raw, browser, this),
+    );
+  }
+
+  supportedIn(release: Release): (Supported | Unsupported | UnknownSupport)[] {
     const result = [];
-    for (const raw of rawStatements) {
-      const s = statement(raw, browser, this);
+    for (const s of this.supportStatements(release.browser)) {
+      this.assertRealSupportStatement(s, release.browser);
 
-      if (!(s instanceof RealSupportStatement)) {
-        throw Error(
-          `${this.id} contains non-real values for ${browser.name}. Cannot expand support.`,
-        );
+      result.push(s.supportedIn(release));
+    }
+    return result;
+  }
+
+  flatSupportedIn(release: Release): boolean | null {
+    let unknown = false;
+    for (const s of this.supportStatements(release.browser)) {
+      this.assertRealSupportStatement(s, release.browser);
+
+      const supported = s.supportedIn(release);
+      if (supported.supported && !supported.qualifications) {
+        return true;
       }
+
+      if (supported.supported === null) {
+        unknown = true;
+      }
+    }
+    if (unknown) {
+      return null;
+    }
+    return false;
+  }
+
+  _supportedBy(
+    browser: Browser,
+  ): { release: Release; qualifications?: Qualifications }[] {
+    const result = [];
+    for (const s of this.supportStatements(browser)) {
+      this.assertRealSupportStatement(s, browser);
 
       result.push(...s.supportedBy());
     }
@@ -120,5 +154,15 @@ export class Feature {
       result.push(...this._supportedBy(b));
     }
     return result;
+  }
+
+  assertRealSupportStatement(
+    statement: SupportStatement,
+    browser: Browser,
+  ): asserts statement is RealSupportStatement {
+    if (!(statement instanceof RealSupportStatement))
+      throw new Error(
+        `${this.id} contains non-real values for ${browser.name}. Cannot expand support.`,
+      );
   }
 }

--- a/packages/compute-baseline/src/browser-compat-data/feature.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.ts
@@ -75,6 +75,9 @@ export class Feature {
     return this.data.__compat?.status?.standard_track ?? false;
   }
 
+  /**
+   * Get this feature's support statement data, for a given browser.
+   */
   rawSupportStatements(browser: Browser): SimpleSupportStatement[] {
     const support = this.data?.__compat?.support;
     if (support === undefined) {
@@ -91,12 +94,21 @@ export class Feature {
       : [statementOrStatements];
   }
 
+  /**
+   * Get this feature's `SupportStatement` or `RealSupportStatement` objects,
+   * for a given browser.
+   */
   supportStatements(browser: Browser): SupportStatement[] {
     return this.rawSupportStatements(browser).map((raw) =>
       statement(raw, browser, this),
     );
   }
 
+  /**
+   * Find out whether this feature's support data says that a given browser
+   * release is supported (with or without qualifications), unsupported, or
+   * unknown.
+   */
   supportedIn(release: Release): (Supported | Unsupported | UnknownSupport)[] {
     const result = [];
     for (const s of this.supportStatements(release.browser)) {
@@ -107,6 +119,12 @@ export class Feature {
     return result;
   }
 
+  /**
+   * Find out whether this feature's support data says that a given browser
+   * release is supported (`true`), unsupported (`false`), or unknown (`null`).
+   * Note that this ignores qualifications such as partial implementations,
+   * prefixes, alternative names, and flags.
+   */
   flatSupportedIn(release: Release): boolean | null {
     let unknown = false;
     for (const s of this.supportStatements(release.browser)) {
@@ -156,6 +174,9 @@ export class Feature {
     return result;
   }
 
+  /**
+   * Throws when a support statement contains non-real values.
+   */
   assertRealSupportStatement(
     statement: SupportStatement,
     browser: Browser,

--- a/packages/compute-baseline/src/browser-compat-data/feature.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.ts
@@ -109,12 +109,14 @@ export class Feature {
    * release is supported (with or without qualifications), unsupported, or
    * unknown.
    */
-  supportedIn(release: Release): (Supported | Unsupported | UnknownSupport)[] {
+  supportedInDetails(
+    release: Release,
+  ): (Supported | Unsupported | UnknownSupport)[] {
     const result = [];
     for (const s of this.supportStatements(release.browser)) {
       this.assertRealSupportStatement(s, release.browser);
 
-      result.push(s.supportedIn(release));
+      result.push(s.supportedInDetails(release));
     }
     return result;
   }
@@ -125,12 +127,12 @@ export class Feature {
    * Note that this ignores qualifications such as partial implementations,
    * prefixes, alternative names, and flags.
    */
-  flatSupportedIn(release: Release): boolean | null {
+  supportedIn(release: Release): boolean | null {
     let unknown = false;
     for (const s of this.supportStatements(release.browser)) {
       this.assertRealSupportStatement(s, release.browser);
 
-      const supported = s.supportedIn(release);
+      const supported = s.supportedInDetails(release);
       if (supported.supported && !supported.qualifications) {
         return true;
       }

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.test.ts
@@ -200,7 +200,7 @@ describe("statements", function () {
       it("throws when browser is undefined", function () {
         const cr = browser("chrome");
         const statement = new RealSupportStatement({ version_added: "1" });
-        assert.throws(() => statement.supportedIn(cr.current()), Error);
+        assert.throws(() => statement.supportedInDetails(cr.current()), Error);
       });
 
       it("throws when release does not correspond to the statement's browser", function () {
@@ -209,7 +209,7 @@ describe("statements", function () {
           browser("chrome"),
         );
         assert.throws(
-          () => statement.supportedIn(browser("firefox").current()),
+          () => statement.supportedInDetails(browser("firefox").current()),
           Error,
         );
       });
@@ -219,20 +219,35 @@ describe("statements", function () {
         const unranged = new RealSupportStatement({ version_added: "100" }, cr);
         const ranged = new RealSupportStatement({ version_added: "≤100" }, cr);
 
-        assert.equal(unranged.supportedIn(cr.version("100")).supported, true);
-        assert.equal(unranged.supportedIn(cr.version("101")).supported, true);
-        assert.equal(unranged.supportedIn(cr.current()).supported, true);
         assert.equal(
-          unranged.supportedIn(cr.releases.at(-1) as any).supported,
+          unranged.supportedInDetails(cr.version("100")).supported,
+          true,
+        );
+        assert.equal(
+          unranged.supportedInDetails(cr.version("101")).supported,
+          true,
+        );
+        assert.equal(unranged.supportedInDetails(cr.current()).supported, true);
+        assert.equal(
+          unranged.supportedInDetails(cr.releases.at(-1) as any).supported,
           true,
         );
 
-        assert.equal(ranged.supportedIn(cr.version("99")).supported, null);
-        assert.equal(ranged.supportedIn(cr.version("100")).supported, true);
-        assert.equal(ranged.supportedIn(cr.version("101")).supported, true);
-        assert.equal(ranged.supportedIn(cr.current()).supported, true);
         assert.equal(
-          ranged.supportedIn(cr.releases.at(-1) as any).supported,
+          ranged.supportedInDetails(cr.version("99")).supported,
+          null,
+        );
+        assert.equal(
+          ranged.supportedInDetails(cr.version("100")).supported,
+          true,
+        );
+        assert.equal(
+          ranged.supportedInDetails(cr.version("101")).supported,
+          true,
+        );
+        assert.equal(ranged.supportedInDetails(cr.current()).supported, true);
+        assert.equal(
+          ranged.supportedInDetails(cr.releases.at(-1) as any).supported,
           true,
         );
       });
@@ -248,17 +263,47 @@ describe("statements", function () {
           cr,
         );
 
-        assert.equal(unranged.supportedIn(cr.version("99")).supported, false);
-        assert.equal(unranged.supportedIn(cr.version("100")).supported, true);
-        assert.equal(unranged.supportedIn(cr.version("101")).supported, true);
-        assert.equal(unranged.supportedIn(cr.version("124")).supported, true);
-        assert.equal(unranged.supportedIn(cr.version("125")).supported, false);
+        assert.equal(
+          unranged.supportedInDetails(cr.version("99")).supported,
+          false,
+        );
+        assert.equal(
+          unranged.supportedInDetails(cr.version("100")).supported,
+          true,
+        );
+        assert.equal(
+          unranged.supportedInDetails(cr.version("101")).supported,
+          true,
+        );
+        assert.equal(
+          unranged.supportedInDetails(cr.version("124")).supported,
+          true,
+        );
+        assert.equal(
+          unranged.supportedInDetails(cr.version("125")).supported,
+          false,
+        );
 
-        assert.equal(ranged.supportedIn(cr.version("99")).supported, null);
-        assert.equal(ranged.supportedIn(cr.version("100")).supported, true);
-        assert.equal(ranged.supportedIn(cr.version("101")).supported, true);
-        assert.equal(ranged.supportedIn(cr.version("124")).supported, true);
-        assert.equal(unranged.supportedIn(cr.version("125")).supported, false);
+        assert.equal(
+          ranged.supportedInDetails(cr.version("99")).supported,
+          null,
+        );
+        assert.equal(
+          ranged.supportedInDetails(cr.version("100")).supported,
+          true,
+        );
+        assert.equal(
+          ranged.supportedInDetails(cr.version("101")).supported,
+          true,
+        );
+        assert.equal(
+          ranged.supportedInDetails(cr.version("124")).supported,
+          true,
+        );
+        assert.equal(
+          unranged.supportedInDetails(cr.version("125")).supported,
+          false,
+        );
       });
 
       it("returns unknown support when release is before ranged version_added", function () {
@@ -272,9 +317,12 @@ describe("statements", function () {
           cr,
         );
 
-        assert.equal(rangedOpen.supportedIn(cr.version("99")).supported, null);
         assert.equal(
-          rangedClosed.supportedIn(cr.version("99")).supported,
+          rangedOpen.supportedInDetails(cr.version("99")).supported,
+          null,
+        );
+        assert.equal(
+          rangedClosed.supportedInDetails(cr.version("99")).supported,
           null,
         );
       });
@@ -286,10 +334,22 @@ describe("statements", function () {
           cr,
         );
 
-        assert.equal(rangedEnd.supportedIn(cr.version("100")).supported, true);
-        assert.equal(rangedEnd.supportedIn(cr.version("101")).supported, null);
-        assert.equal(rangedEnd.supportedIn(cr.version("124")).supported, null);
-        assert.equal(rangedEnd.supportedIn(cr.version("125")).supported, false);
+        assert.equal(
+          rangedEnd.supportedInDetails(cr.version("100")).supported,
+          true,
+        );
+        assert.equal(
+          rangedEnd.supportedInDetails(cr.version("101")).supported,
+          null,
+        );
+        assert.equal(
+          rangedEnd.supportedInDetails(cr.version("124")).supported,
+          null,
+        );
+        assert.equal(
+          rangedEnd.supportedInDetails(cr.version("125")).supported,
+          false,
+        );
       });
 
       it("returns unsupported when statement is version_added false", function () {
@@ -300,14 +360,17 @@ describe("statements", function () {
         );
 
         for (const release of cr.releases) {
-          assert.equal(statement.supportedIn(release).supported, false);
+          assert.equal(statement.supportedInDetails(release).supported, false);
         }
       });
 
       it("returns unsupported when release is before fixed version_added", function () {
         const cr = browser("chrome");
         const unranged = new RealSupportStatement({ version_added: "100" }, cr);
-        assert.equal(unranged.supportedIn(cr.version("99")).supported, false);
+        assert.equal(
+          unranged.supportedInDetails(cr.version("99")).supported,
+          false,
+        );
       });
 
       it("returns unsupported when release is on or after version_removed", function () {
@@ -317,11 +380,20 @@ describe("statements", function () {
           { version_added: "1", version_removed: "10" },
           cr,
         );
-        assert.equal(unranged.supportedIn(cr.version("10")).supported, false);
-        assert.equal(unranged.supportedIn(cr.version("11")).supported, false);
-        assert.equal(unranged.supportedIn(cr.current()).supported, false);
         assert.equal(
-          unranged.supportedIn(cr.releases.at(-1) as any).supported,
+          unranged.supportedInDetails(cr.version("10")).supported,
+          false,
+        );
+        assert.equal(
+          unranged.supportedInDetails(cr.version("11")).supported,
+          false,
+        );
+        assert.equal(
+          unranged.supportedInDetails(cr.current()).supported,
+          false,
+        );
+        assert.equal(
+          unranged.supportedInDetails(cr.releases.at(-1) as any).supported,
           false,
         );
 
@@ -329,11 +401,17 @@ describe("statements", function () {
           { version_added: "≤5", version_removed: "10" },
           cr,
         );
-        assert.equal(ranged.supportedIn(cr.version("10")).supported, false);
-        assert.equal(ranged.supportedIn(cr.version("11")).supported, false);
-        assert.equal(ranged.supportedIn(cr.current()).supported, false);
         assert.equal(
-          ranged.supportedIn(cr.releases.at(-1) as any).supported,
+          ranged.supportedInDetails(cr.version("10")).supported,
+          false,
+        );
+        assert.equal(
+          ranged.supportedInDetails(cr.version("11")).supported,
+          false,
+        );
+        assert.equal(ranged.supportedInDetails(cr.current()).supported, false);
+        assert.equal(
+          ranged.supportedInDetails(cr.releases.at(-1) as any).supported,
           false,
         );
       });

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
@@ -150,7 +150,9 @@ export class RealSupportStatement extends SupportStatement {
    * Find out whether this support statement says a given browser release is
    * supported (with or without qualifications), unsupported, or unknown.
    */
-  supportedIn(release: Release): Supported | Unsupported | UnknownSupport {
+  supportedInDetails(
+    release: Release,
+  ): Supported | Unsupported | UnknownSupport {
     if (this.browser === undefined) {
       throw new Error("This support statement's browser is unknown.");
     }


### PR DESCRIPTION
The main thing this does is gives us a way to quickly and unambiguously report `true`, `null,` or `false` for _unqualified_ support relationship between a release and a feature. There's some untidiness to clean up along the way. I'll self-review with commentary.