### PR TITLE
Turn on type checking everywhere and banish the red squiggles

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:lint": "npx eslint .",
     "test:schema": "tsx scripts/schema.ts",
     "test:specs": "tsx scripts/specs.ts",
+    "test:types": "npm run --workspaces test:types && tsc",
     "test": "npm run test:caniuse -- --quiet && npm run test:schema && npm run test:specs && npm run test:format && npm run test:dist && npm run test --workspaces && npm run test:lint",
     "update-drafts": "tsx scripts/update-drafts.ts"
   },

--- a/packages/compute-baseline/package.json
+++ b/packages/compute-baseline/package.json
@@ -14,9 +14,10 @@
   "types": "./dist/index.d.ts",
   "type": "module",
   "scripts": {
-    "test": "mocha -r tsx 'src/**/*.test.ts'",
+    "prepare": "cp ../../LICENSE.txt . && tsc",
     "test:coverage": "c8 npm run test",
-    "prepare": "cp ../../LICENSE.txt . && tsc"
+    "test:types": "tsc --noEmit",
+    "test": "mocha -r tsx 'src/**/*.test.ts'"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/scripts/dist.ts
+++ b/scripts/dist.ts
@@ -1,13 +1,13 @@
 import { computeBaseline, getStatus, setLogger } from "compute-baseline";
 import { Compat, Feature } from "compute-baseline/browser-compat-data";
+import { fdir } from "fdir";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 import winston from "winston";
-import YAML, { Document, YAMLSeq, Scalar } from "yaml";
+import YAML, { Document, Scalar, YAMLSeq } from "yaml";
 import yargs from "yargs";
-import { fdir } from "fdir";
 
 const compat = new Compat();
 
@@ -101,7 +101,7 @@ function compareStatus(a: SupportStatus, b: SupportStatus) {
   const bVersions = Object.values(b.support);
   for (let i = 0; i < aVersions.length; i++) {
     if (aVersions[i] !== bVersions[i]) {
-      return aVersions[i] - bVersions[i];
+      return Number(aVersions[i]) - Number(bVersions[i]);
     }
   }
   return 0;
@@ -230,7 +230,7 @@ function insertCompatFeatures(yaml: Document, groups: Map<string, string[]>) {
     return;
   }
 
-  const list = new YAMLSeq();
+  const list = new YAMLSeq<Scalar<string>>();
   for (const [comment, keys] of groups.entries()) {
     let first = true;
     for (const key of keys) {

--- a/scripts/update-drafts.ts
+++ b/scripts/update-drafts.ts
@@ -1,10 +1,12 @@
 import { Compat } from "compute-baseline/browser-compat-data";
 import fs from "node:fs/promises";
 import { fileURLToPath } from "node:url";
-import { Document } from "yaml";
 import webSpecs from "web-specs" assert { type: "json" };
+import { Document } from "yaml";
 
 import { features } from "../index.js";
+
+type WebSpecsSpec = (typeof webSpecs)[number];
 
 function* getPages(spec): Generator<string> {
   yield spec.url;
@@ -53,7 +55,7 @@ async function main() {
   });
 
   // Build a map from URLs to spec.
-  const pageToSpec = new Map<string, object>();
+  const pageToSpec = new Map<string, WebSpecsSpec>();
   for (const spec of webSpecs) {
     for (const page of getPages(spec)) {
       pageToSpec.set(normalize(page), spec);
@@ -61,7 +63,7 @@ async function main() {
   }
 
   // Iterate BCD and group compat features by spec.
-  const specToCompatFeatures = new Map<object, Set<string>>();
+  const specToCompatFeatures = new Map<WebSpecsSpec, Set<string>>();
   for (const feature of compat.walk()) {
     // Skip deprecated and non-standard features.
     if (feature.deprecated || !feature.standard_track) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,7 @@
     "moduleResolution": "Bundler",
     "esModuleInterop": true,
     "resolveJsonModule": true,
-  }
+    "noEmit": true
+  },
+  "exclude": ["packages/"]
 }


### PR DESCRIPTION
Since we use `tsx` to run scripts, there's no explicit type checking `.ts` files outside of `compute-baseline`. Nevertheless, my editor shows type errors at editing time.

This PR makes two changes to fix this:

- Adds a `test:types` npm run command and includes it in the `test` command
- Fixes the (thankfully few) type errors reported.