### PR TITLE
Remove alias from the schema and all features

### DIFF
--- a/features/draft/text-box-trim.yml
+++ b/features/draft/text-box-trim.yml
@@ -3,4 +3,3 @@ draft_date: 2024-04-30
 name: text-box-trim
 description: The `text-box-trim` CSS property removes the additional space above and below text which is normally reserved for ascenders and descenders.
 spec: https://drafts.csswg.org/css-inline-3/#leading-trim
-alias: leading-trim

--- a/features/font-face.yml
+++ b/features/font-face.yml
@@ -3,4 +3,3 @@ description: The `@font-face` CSS at-rule creates a custom `font-family` value. 
 spec: https://drafts.csswg.org/css-fonts-5/
 group: fonts
 caniuse: fontface
-alias: fonts

--- a/features/long-animation-frames.yaml
+++ b/features/long-animation-frames.yaml
@@ -1,3 +1,2 @@
 name: Long animation frame timing
-alias: long-animation-frame-timing
 spec: https://w3c.github.io/long-animation-frames/

--- a/features/promise.yml
+++ b/features/promise.yml
@@ -1,6 +1,5 @@
 name: Promise (initial support)
 description: A promise represents an asynchronous operation which eventually succeeds or fails.
-alias: promises
 caniuse: promises
 snapshot: ecmascript-2015
 spec:

--- a/features/read-write-pseudos.yml
+++ b/features/read-write-pseudos.yml
@@ -4,5 +4,4 @@ spec:
   - https://html.spec.whatwg.org/multipage/semantics-other.html#selector-read-only
   - https://drafts.csswg.org/selectors-4/#rw-pseudos
 group: forms
-alias: read-write-pseudo-classes
 caniuse: css-read-only-write

--- a/features/scroll-into-view.yml
+++ b/features/scroll-into-view.yml
@@ -1,6 +1,5 @@
 name: scrollIntoView()
 description: The `scrollIntoView()` method scrolls an element's ancestor containers such that the element is visible to the user.
 spec: https://drafts.csswg.org/cssom-view-1/#dom-element-scrollintoview
-alias: scrollintoview
 caniuse: scrollintoview
 group: scrolling

--- a/features/viewport-unit-variants.yml
+++ b/features/viewport-unit-variants.yml
@@ -3,5 +3,4 @@ description: The `sv*`, `lv*`, and `dv*` CSS viewport units are relative to the 
 spec:
   - https://drafts.csswg.org/css-values-4/#viewport-variants
   - https://drafts.csswg.org/css-values-4/#viewport-relative-lengths
-alias: viewport-relative-unit-variants
 caniuse: viewport-unit-variants

--- a/features/viewport-units.yml
+++ b/features/viewport-units.yml
@@ -2,5 +2,4 @@ name: Viewport units
 description: The `vw`, `vh`, `vmin`, and `vmax` CSS viewport units are relative to the size of the viewport, and are used to size elements in relation to the viewport's dimensions.
 # This feature excludes `vb` and `vi` because they were introduced later (see `viewport-relative-unit-variants`)
 spec: https://drafts.csswg.org/css-values-4/#viewport-relative-lengths
-alias: viewport-relative-units
 caniuse: viewport-units

--- a/schemas/defs.schema.json
+++ b/schemas/defs.schema.json
@@ -6,21 +6,6 @@
     "FeatureData": {
       "additionalProperties": false,
       "properties": {
-        "alias": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "items": {
-                "type": "string"
-              },
-              "minItems": 2,
-              "type": "array"
-            }
-          ],
-          "description": "Alias identifier"
-        },
         "caniuse": {
           "anyOf": [
             {

--- a/types.ts
+++ b/types.ts
@@ -14,8 +14,6 @@ export interface FeatureData {
     description: string;
     /** Short description of the feature, as an HTML string */
     description_html: string;
-    /** Alias identifier */
-    alias?: string | [string, string, ...string[]];
     /** Specification */
     spec: specification_url | [specification_url, specification_url, ...specification_url[]];
     /** Group identifier */


### PR DESCRIPTION
This mechanism for renames hasn't been used by any consumers that we
know of.

A mechanism like this may not be needed at all, and if it is we may want
to design it a bit different to allow consumers to detect both deleted
and renamed identifiers.

Removing this now does not prevent us from reintroducing this as a "new"
feature if the need arises. If so, we may want to design it a bit
different to handle both deleted and renamed identifiers.
