### PR TITLE
Fix import syntax to work with Deno

### DIFF
--- a/packages/web-features/README.md
+++ b/packages/web-features/README.md
@@ -15,11 +15,8 @@ import { features, groups, snapshots } from "web-features";
 Or, without Node.js:
 
 ```js
-import {
-  features,
-  groups,
-  snapshots,
-} from "web-features/data.json" with { type: "json" };
+import data from "web-features/data.json" with { type: "json" };
+const { features, groups, snapshots } = data;
 ```
 
 ## Rendering Baseline statuses with `web-features`


### PR DESCRIPTION
This was tested with the 0.10.0 version of the package from NPM, but with index.json instead of data.json.

The previous syntax didn't work because these aren't named exports.