### PR TITLE
Fix a typo in indexeddb

### DIFF
--- a/features/draft/indexeddb.yml
+++ b/features/draft/indexeddb.yml
@@ -8,7 +8,7 @@
 # https://github.com/web-platform-dx/web-features/issues/557
 #
 # Unknown hard parts are that there may be other parts of IndexedDB with such
-# issues. Someone who's knowlegeable about IndexedDB ought to author or review
+# issues. Someone who's knowledgeable about IndexedDB ought to author or review
 # this feature.
 draft_date: 2024-07-11
 name: IndexedDB


### PR DESCRIPTION
Just a missing letter.

https://github.com/crate-ci/typos