### PR TITLE
Retitle "input event" feature to "input (event)"

### DIFF
--- a/features/input-event.yml
+++ b/features/input-event.yml
@@ -1,4 +1,4 @@
-name: input event
+name: input (event)
 description: The `input` event fires when a form control changes or an element with the `contenteditable` attribute changes.
 spec: https://w3c.github.io/uievents/#event-type-input
 caniuse: input-event


### PR DESCRIPTION
This is a special case. We use only the name of a lone event elsewhere (e.g., "scrollend"), but this event shares a name with the element ("\<input\>"). This moves the disambiguation text to parentheses to distinguish the name of the thing ("input").

Extracted from https://github.com/web-platform-dx/web-features/pull/1026.