### PR TITLE
Put some things in the Transferable group

### DIFF
--- a/features/offscreen-canvas.yml
+++ b/features/offscreen-canvas.yml
@@ -1,7 +1,9 @@
 name: Offscreen canvas
 description: The `OffscreenCanvas` API provides a canvas that can be drawn to off screen, with no dependencies on the DOM, which can be used to run heavy rendering operations inside a worker context.
 spec: https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-interface
-group: canvas
+group:
+  - canvas
+  - transferable
 caniuse: offscreencanvas
 compat_features:
   - api.HTMLCanvasElement.transferControlToOffscreen

--- a/features/streams.yml
+++ b/features/streams.yml
@@ -2,7 +2,9 @@ name: Streams
 description: The streams API creates, composes, and consumes continuously generated data.
 spec: https://streams.spec.whatwg.org/
 caniuse: streams
-group: streams
+group:
+  - streams
+  - transferable
 # TODO: Later support
 # - api.ReadableStreamDefaultController
 # - api.ReadableStreamDefaultController.close

--- a/features/webcodecs.yml
+++ b/features/webcodecs.yml
@@ -2,6 +2,8 @@ name: WebCodecs
 description: The WebCodecs API provides low-level access to individual video frames and chunks of audio samples, for full control over the way media is processed.
 spec: https://w3c.github.io/webcodecs/
 caniuse: webcodecs
+group:
+  - transferable
 status:
   compute_from:
     - api.AudioDecoder.AudioDecoder


### PR DESCRIPTION
Originally suggested in https://github.com/web-platform-dx/web-features/pull/987#discussion_r1583180916. I grouped any non-draft that _contained_ a transferable object, to see how things looked.

@foolip originally wrote:

> My hunch is that not all of these things will be in features by themselves, and the features they are part have some other primary location in a feature group hierarchy, like `MediaSourceHandle` being a part of Media Source Extensions or some media group.

My feeling is that canvas is probably rightly grouped here, but the other two are much more uncertain.

(I've been on a tab-closing spree today, so apologies if this seems out of the blue.)

Closes https://github.com/web-platform-dx/web-features/pull/1512