### PR TITLE
Write "represents" guideline for HTML elements

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -162,6 +162,11 @@ Don't use it as a coordinating conjunction; start a new sentence instead.
 For example, this is an example.
 ([#738](https://github.com/web-platform-dx/web-features/pull/738#discussion_r1537762579), [#742](https://github.com/web-platform-dx/web-features/pull/742))
 
+##### indicates
+
+Avoid when you mean sets or represents.
+See [sets](#sets) and [represents](#represents).
+
 ##### is used to
 
 Omit "is used" where there's no loss in meaning.
@@ -180,9 +185,13 @@ Avoid, especially with gerunds.
 For example, prefer the "The feature writes to…" over "The feature provides writing to…."
 ([#727](https://github.com/web-platform-dx/web-features/pull/727#discussion_r1537635491))
 
+##### represents
+
+If an HTML element or other type doesn't obviously do anything, then it probably _represents_ something.
+
 ##### sets
 
-Prefer this over multisyllabic alternatives, such as "defines", "determines", or "specifies".
+Prefer this over multisyllabic alternatives, such as "defines", "determines", "indicates", or "specifies".
 Use "The property sets…" but never "The property defines…."
 ([#727](https://github.com/web-platform-dx/web-features/pull/727#discussion_r1537635491))
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -183,6 +183,11 @@ For example, prefer the "The feature writes to…" over "The feature provides wr
 ##### represents
 
 If an HTML element or other type doesn't obviously do anything, then it probably _represents_ something.
+Use _represents_ as a default for describing the behavior of HTML elements when no more specific verb makes sense.
+
+  - 👍 Recommended: The `<html>` element represents the top level of an HTML document…
+  - 👍 Recommended: The `<br>` element breaks lines in text.
+  - 👎 Not recommended: The `<br>` element represents a line break in text.
 
 ##### sets
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -162,11 +162,6 @@ Don't use it as a coordinating conjunction; start a new sentence instead.
 For example, this is an example.
 ([#738](https://github.com/web-platform-dx/web-features/pull/738#discussion_r1537762579), [#742](https://github.com/web-platform-dx/web-features/pull/742))
 
-##### indicates
-
-Avoid when you mean sets or represents.
-See [sets](#sets) and [represents](#represents).
-
 ##### is used to
 
 Omit "is used" where there's no loss in meaning.
@@ -191,7 +186,7 @@ If an HTML element or other type doesn't obviously do anything, then it probably
 
 ##### sets
 
-Prefer this over multisyllabic alternatives, such as "defines", "determines", "indicates", or "specifies".
+Prefer this over multisyllabic alternatives, such as "defines", "determines", or "specifies".
 Use "The property sets…" but never "The property defines…."
 ([#727](https://github.com/web-platform-dx/web-features/pull/727#discussion_r1537635491))
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -185,7 +185,6 @@ For example, prefer the "The feature writes to…" over "The feature provides wr
 If an HTML element or other type doesn't obviously do anything, then it probably _represents_ something.
 Use _represents_ as a default for describing the behavior of HTML elements when no more specific verb makes sense.
 
-  - 👍 Recommended: The `<html>` element represents the top level of an HTML document…
   - 👍 Recommended: The `<br>` element breaks lines in text.
   - 👎 Not recommended: The `<br>` element represents a line break in text.
 

--- a/features/br.yml
+++ b/features/br.yml
@@ -1,5 +1,5 @@
 name: <br>
-description: The `<br>` element produces line breaks in text.
+description: The `<br>` element breaks lines in text.
 spec: https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-br-element
 group: html-elements
 compat_features:

--- a/features/html.yml
+++ b/features/html.yml
@@ -1,5 +1,5 @@
 name: <html>
-description: The `<html>` element represents the top-level of an HTML document and is referred to as the root element.
+description: The `<html>` element represents the top level of an HTML document and is referred to as the root element.
 spec: https://html.spec.whatwg.org/multipage/semantics.html#the-html-element
 group: html-elements
 compat_features:


### PR DESCRIPTION
Also, discourage "indicates" to describe things that are not indicators.

This is inspired by several reviews of HTML elements. Sometimes an element does something (the `<br>` element _breaks_ lines), but sometimes they're abstract containers "represents" is a reasonable default.