### PR TITLE
export all types in web-features package

### DIFF
--- a/packages/web-features/index.ts
+++ b/packages/web-features/index.ts
@@ -8,4 +8,5 @@ const { features, groups, snapshots } = JSON.parse(
   readFileSync(jsonPath, { encoding: "utf-8" }),
 ) as WebFeaturesData;
 
+export * from "./types";
 export { features, groups, snapshots };

--- a/schemas/data.schema.json
+++ b/schemas/data.schema.json
@@ -2,6 +2,13 @@
   "$ref": "#/definitions/WebFeaturesData",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "BaselineHighLow": {
+      "enum": [
+        "high",
+        "low"
+      ],
+      "type": "string"
+    },
     "FeatureData": {
       "additionalProperties": false,
       "properties": {
@@ -72,15 +79,11 @@
         "spec": {
           "anyOf": [
             {
-              "description": "Specification URL",
-              "format": "uri",
-              "type": "string"
+              "$ref": "#/definitions/specification_url"
             },
             {
               "items": {
-                "description": "Specification URL",
-                "format": "uri",
-                "type": "string"
+                "$ref": "#/definitions/specification_url"
               },
               "minItems": 2,
               "type": "array"
@@ -89,125 +92,8 @@
           "description": "Specification"
         },
         "status": {
-          "additionalProperties": false,
-          "description": "Whether a feature is considered a \"baseline\" web platform feature and when it achieved that status",
-          "properties": {
-            "baseline": {
-              "description": "Whether the feature is Baseline (low substatus), Baseline (high substatus), or not (false)",
-              "enum": [
-                "high",
-                "low",
-                false
-              ],
-              "type": [
-                "string",
-                "boolean"
-              ]
-            },
-            "baseline_high_date": {
-              "description": "Date the feature achieved Baseline high status",
-              "type": "string"
-            },
-            "baseline_low_date": {
-              "description": "Date the feature achieved Baseline low status",
-              "type": "string"
-            },
-            "by_compat_key": {
-              "additionalProperties": {
-                "additionalProperties": false,
-                "properties": {
-                  "baseline": {
-                    "description": "Whether the feature is Baseline (low substatus), Baseline (high substatus), or not (false)",
-                    "enum": [
-                      "high",
-                      "low",
-                      false
-                    ],
-                    "type": [
-                      "string",
-                      "boolean"
-                    ]
-                  },
-                  "baseline_high_date": {
-                    "description": "Date the feature achieved Baseline high status",
-                    "type": "string"
-                  },
-                  "baseline_low_date": {
-                    "description": "Date the feature achieved Baseline low status",
-                    "type": "string"
-                  },
-                  "support": {
-                    "additionalProperties": false,
-                    "description": "Browser versions that most-recently introduced the feature",
-                    "properties": {
-                      "chrome": {
-                        "type": "string"
-                      },
-                      "chrome_android": {
-                        "type": "string"
-                      },
-                      "edge": {
-                        "type": "string"
-                      },
-                      "firefox": {
-                        "type": "string"
-                      },
-                      "firefox_android": {
-                        "type": "string"
-                      },
-                      "safari": {
-                        "type": "string"
-                      },
-                      "safari_ios": {
-                        "type": "string"
-                      }
-                    },
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "baseline",
-                  "support"
-                ],
-                "type": "object"
-              },
-              "description": "Statuses for each key in the feature's compat_features list, if applicable. Not available to the npm release of web-features.",
-              "type": "object"
-            },
-            "support": {
-              "additionalProperties": false,
-              "description": "Browser versions that most-recently introduced the feature",
-              "properties": {
-                "chrome": {
-                  "type": "string"
-                },
-                "chrome_android": {
-                  "type": "string"
-                },
-                "edge": {
-                  "type": "string"
-                },
-                "firefox": {
-                  "type": "string"
-                },
-                "firefox_android": {
-                  "type": "string"
-                },
-                "safari": {
-                  "type": "string"
-                },
-                "safari_ios": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            }
-          },
-          "required": [
-            "baseline",
-            "support"
-          ],
-          "type": "object"
+          "$ref": "#/definitions/SupportStatus",
+          "description": "Whether a feature is considered a \"baseline\" web platform feature and when it achieved that status"
         }
       },
       "required": [
@@ -244,14 +130,136 @@
           "type": "string"
         },
         "spec": {
-          "description": "Specification",
-          "format": "uri",
-          "type": "string"
+          "$ref": "#/definitions/specification_url",
+          "description": "Specification"
         }
       },
       "required": [
         "name",
         "spec"
+      ],
+      "type": "object"
+    },
+    "Status": {
+      "additionalProperties": false,
+      "properties": {
+        "baseline": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BaselineHighLow"
+            },
+            {
+              "const": false,
+              "type": "boolean"
+            }
+          ],
+          "description": "Whether the feature is Baseline (low substatus), Baseline (high substatus), or not (false)"
+        },
+        "baseline_high_date": {
+          "description": "Date the feature achieved Baseline high status",
+          "type": "string"
+        },
+        "baseline_low_date": {
+          "description": "Date the feature achieved Baseline low status",
+          "type": "string"
+        },
+        "support": {
+          "additionalProperties": false,
+          "description": "Browser versions that most-recently introduced the feature",
+          "properties": {
+            "chrome": {
+              "type": "string"
+            },
+            "chrome_android": {
+              "type": "string"
+            },
+            "edge": {
+              "type": "string"
+            },
+            "firefox": {
+              "type": "string"
+            },
+            "firefox_android": {
+              "type": "string"
+            },
+            "safari": {
+              "type": "string"
+            },
+            "safari_ios": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "baseline",
+        "support"
+      ],
+      "type": "object"
+    },
+    "SupportStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "baseline": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BaselineHighLow"
+            },
+            {
+              "const": false,
+              "type": "boolean"
+            }
+          ],
+          "description": "Whether the feature is Baseline (low substatus), Baseline (high substatus), or not (false)"
+        },
+        "baseline_high_date": {
+          "description": "Date the feature achieved Baseline high status",
+          "type": "string"
+        },
+        "baseline_low_date": {
+          "description": "Date the feature achieved Baseline low status",
+          "type": "string"
+        },
+        "by_compat_key": {
+          "additionalProperties": {
+            "$ref": "#/definitions/Status"
+          },
+          "description": "Statuses for each key in the feature's compat_features list, if applicable. Not available to the npm release of web-features.",
+          "type": "object"
+        },
+        "support": {
+          "additionalProperties": false,
+          "description": "Browser versions that most-recently introduced the feature",
+          "properties": {
+            "chrome": {
+              "type": "string"
+            },
+            "chrome_android": {
+              "type": "string"
+            },
+            "edge": {
+              "type": "string"
+            },
+            "firefox": {
+              "type": "string"
+            },
+            "firefox_android": {
+              "type": "string"
+            },
+            "safari": {
+              "type": "string"
+            },
+            "safari_ios": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "baseline",
+        "support"
       ],
       "type": "object"
     },
@@ -286,6 +294,11 @@
         "snapshots"
       ],
       "type": "object"
+    },
+    "specification_url": {
+      "description": "Specification URL",
+      "format": "uri",
+      "type": "string"
     }
   }
 }

--- a/types.ts
+++ b/types.ts
@@ -28,11 +28,11 @@ export interface FeatureData {
     compat_features?: string[];
 }
 
-type browserIdentifier = "chrome" | "chrome_android" | "edge" | "firefox" | "firefox_android" | "safari" | "safari_ios";
+export type BrowserIdentifier = "chrome" | "chrome_android" | "edge" | "firefox" | "firefox_android" | "safari" | "safari_ios";
 
-type BaselineHighLow = "high" | "low";
+export type BaselineHighLow = "high" | "low";
 
-interface Status {
+export interface Status {
     /** Whether the feature is Baseline (low substatus), Baseline (high substatus), or not (false) */
     baseline: BaselineHighLow | false;
     /** Date the feature achieved Baseline low status */
@@ -41,11 +41,11 @@ interface Status {
     baseline_high_date?: string;
     /** Browser versions that most-recently introduced the feature */
     support: {
-        [K in browserIdentifier]?: string;
+        [K in BrowserIdentifier]?: string;
     };
 }
 
-interface SupportStatus extends Status {
+export interface SupportStatus extends Status {
     /** Statuses for each key in the feature's compat_features list, if applicable. Not available to the npm release of web-features. */
     by_compat_key?: Record<string, Status>
 }
@@ -53,7 +53,7 @@ interface SupportStatus extends Status {
 /** Specification URL
  * @format uri
 */
-type specification_url = string;
+export type specification_url = string;
 
 export interface GroupData {
     /** Short name */


### PR DESCRIPTION
We currently have to do some typescript shenanigans to get access to certain types from `web-features` for use [in our code](https://github.com/mdn/yari/blob/d930863abcb20d52170ab95b670a2676e26f7451/client/src/document/baseline-indicator.tsx#L10-L14):

```ts
// web-features doesn't export these types directly so we need to do a little typescript magic:
import type { features } from "web-features";
type SupportStatus = (typeof features)[keyof typeof features]["status"];
type BrowserIdentifier =
  keyof (typeof features)[keyof typeof features]["status"]["support"];
```

It would be far nicer if we could simply import the types directly:

```ts
import type { SupportStatus, BrowserIdentifier } from "web-features";
```

This PR enables that, by exporting all the types, and renaming `browserIdentifier` to the more type-like `BrowserIdentifier`