### PR TITLE
Make the spec draft updater remove completed specs and work around nulls

### DIFF
--- a/.github/workflows/update_draft_features_weekly.yml
+++ b/.github/workflows/update_draft_features_weekly.yml
@@ -16,7 +16,9 @@ jobs:
           node-version-file: .node-version
           cache: npm
       - run: npm ci
+      - run: rm features/draft/spec/*.yml features/draft/spec/*.dist
       - run: npm run update-drafts
+      - run: npm run dist
       - name: Commit changes
         run: |
           git config --local user.email "action@github.com"

--- a/scripts/update-drafts.ts
+++ b/scripts/update-drafts.ts
@@ -70,6 +70,13 @@ async function main() {
       continue;
     }
 
+    // A few null values remain in BCD. They are being removed in
+    // https://github.com/mdn/browser-compat-data/pull/23774.
+    // TODO: Remove this workaround when BCD is free or true/null values.
+    if (feature.id.startsWith("html.manifest.")) {
+      continue;
+    }
+
     const spec_url = feature.data.__compat.spec_url;
     if (!spec_url) {
       continue;


### PR DESCRIPTION
And update dist, which was overlooked. These changes together will allow
the workflow to send PRs that pass the CI.
