### PR TITLE
Disallow `compute_from` when it has no impact on the status

### DIFF
--- a/features/abbr.yml
+++ b/features/abbr.yml
@@ -2,7 +2,5 @@ name: <abbr>
 description: The `<abbr>` HTML element represents an abbreviation or acronym.
 spec: https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-abbr-element
 group: html-elements
-status:
-  compute_from: html.elements.abbr
 compat_features:
   - html.elements.abbr

--- a/features/abbr.yml
+++ b/features/abbr.yml
@@ -2,5 +2,7 @@ name: <abbr>
 description: The `<abbr>` HTML element represents an abbreviation or acronym.
 spec: https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-abbr-element
 group: html-elements
+status:
+  compute_from: html.elements.abbr
 compat_features:
   - html.elements.abbr

--- a/scripts/dist.ts
+++ b/scripts/dist.ts
@@ -177,7 +177,7 @@ function toDist(sourcePath: string): YAML.Document {
   const compatFeatures = source.compat_features ?? taggedCompatFeatures;
   let computeFrom = compatFeatures;
 
-  const computeFromWasExplicitlySet = Boolean(source.status?.compute_from);
+  const computeFromWasExplicitlySet = source.status?.compute_from !== undefined;
   if (computeFromWasExplicitlySet) {
     const compute_from = source.status.compute_from;
     const keys = Array.isArray(compute_from) ? compute_from : [compute_from];

--- a/scripts/dist.ts
+++ b/scripts/dist.ts
@@ -236,7 +236,7 @@ function toDist(sourcePath: string): YAML.Document {
   if (computeFromWasExplicitlySet) {
     if (groups.size === 1) {
       logger.error(
-        `${id}: uses compute_from overall but it does not differ from per-key statuses. Delete this override.`,
+        `${id}: uses compute_from which must not be used when the overall status does not differ from the per-key statuses. Delete this override.`,
       );
       exitStatus = 1;
     }


### PR DESCRIPTION
This was suggested by @Elchi3 as an initial step toward automatically checking good and bad uses of `compute_from`. Thank you, Florian!