### PR TITLE
Add catch for invalid spec URLs

### DIFF
--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -77,7 +77,8 @@ function suggestSpecs(bad: URL): void {
     }
 }
 
-let checked = 0;
+let checkedFeatures = 0;
+let checkedSpecs = 0;
 let errors = 0;
 
 // Ensure every exception in defaultAllowlist is needed
@@ -96,20 +97,21 @@ for (const [id, data] of Object.entries(features)) {
             var url = new URL(spec);
         } catch (error) {
             console.error(`Invalid URL "${spec}" found in spec for "${data.name}"`);
-            errors++
+            errors++;
         }
         if (url && !isOK(url)) {
             console.error(`URL for ${id} not in web-specs: ${url.toString()}`);
             suggestSpecs(url);
             errors++;
         }
-        checked++;
+        checkedSpecs++;
     }
+    checkedFeatures++;
 }
 
 if (errors) {
-    console.log(`\n${checked} features checked, found ${errors} error(s)`);
+    console.log(`\nChecked ${checkedSpecs} specs in ${checkedFeatures} features, found ${errors} error(s)`);
     process.exit(1);
 } else {
-    console.log(`${checked} features checked, no errors`);
+    console.log(`\nChecked ${checkedSpecs} specs in ${checkedFeatures} features, no errors`);
 }

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -93,8 +93,9 @@ for (const [allowedUrl, message] of defaultAllowlist) {
 for (const [id, data] of Object.entries(features)) {
     const specs = Array.isArray(data.spec) ? data.spec : [data.spec];
     for (const spec of specs) {
+        let url: URL;
         try {
-            var url = new URL(spec);
+            url = new URL(spec);
         } catch (error) {
             console.error(`Invalid URL "${spec}" found in spec for "${data.name}"`);
             errors++;

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -92,8 +92,13 @@ for (const [allowedUrl, message] of defaultAllowlist) {
 for (const [id, data] of Object.entries(features)) {
     const specs = Array.isArray(data.spec) ? data.spec : [data.spec];
     for (const spec of specs) {
-        const url = new URL(spec);
-        if (!isOK(url)) {
+        try {
+            var url = new URL(spec);
+        } catch (error) {
+            console.error(`Invalid URL "${spec}" found in spec for "${data.name}"`);
+            errors++
+        }
+        if (url && !isOK(url)) {
             console.error(`URL for ${id} not in web-specs: ${url.toString()}`);
             suggestSpecs(url);
             errors++;


### PR DESCRIPTION
Previously, a missing or invalid spec URL would throw an error without a message. This change surfaces that error when running `npm run test:specs`.

In addition, the test was reporting the number of specs as the number of features, so now it reports both.