### PR TITLE
Add AggregateError to promise-any feature

### DIFF
--- a/features/promise-any.yml
+++ b/features/promise-any.yml
@@ -3,3 +3,8 @@ description: The `Promise.any()` static method returns a promise that fulfills a
 snapshot: ecmascript-2021
 spec: https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.any
 group: promises
+compat_features:
+  - javascript.builtins.Promise.any
+  - javascript.builtins.AggregateError
+  - javascript.builtins.AggregateError.AggregateError
+  - javascript.builtins.AggregateError.errors

--- a/features/promise-any.yml.dist
+++ b/features/promise-any.yml.dist
@@ -14,4 +14,7 @@ status:
     safari: "14"
     safari_ios: "14"
 compat_features:
+  - javascript.builtins.AggregateError
+  - javascript.builtins.AggregateError.AggregateError
+  - javascript.builtins.AggregateError.errors
   - javascript.builtins.Promise.any


### PR DESCRIPTION
I think AggregateError should belong to the promise-any feature. 

This PR is also a bit of a process question: If we think that certain features should contain additional BCD keys, do we open a PR here in web-features to alter the feature's definition? (and sync the decision back to BCD later on?) or should things be synced in two ways (a PR updating tags in BCD would have been fine, too). I'm leaning towards just syncing from web-features to BCD for the moment, but curious to hear what others think.