### PR TITLE
Add keywords to font optical sizing

### DIFF
--- a/features/font-optical-sizing.yml
+++ b/features/font-optical-sizing.yml
@@ -2,3 +2,9 @@ name: font-optical-sizing
 description: The `font-optical-sizing` CSS property sets whether text rendering is optimized for viewing at different sizes.
 spec: https://drafts.csswg.org/css-fonts-4/#font-optical-sizing-def
 group: fonts
+status:
+  compute_from: css.properties.font-optical-sizing
+compat_features:
+  - css.properties.font-optical-sizing
+  - css.properties.font-optical-sizing.auto
+  - css.properties.font-optical-sizing.none

--- a/features/font-optical-sizing.yml
+++ b/features/font-optical-sizing.yml
@@ -2,8 +2,6 @@ name: font-optical-sizing
 description: The `font-optical-sizing` CSS property sets whether text rendering is optimized for viewing at different sizes.
 spec: https://drafts.csswg.org/css-fonts-4/#font-optical-sizing-def
 group: fonts
-status:
-  compute_from: css.properties.font-optical-sizing
 compat_features:
   - css.properties.font-optical-sizing
   - css.properties.font-optical-sizing.auto

--- a/features/font-optical-sizing.yml.dist
+++ b/features/font-optical-sizing.yml.dist
@@ -14,4 +14,30 @@ status:
     safari: "11"
     safari_ios: "11"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: high
+  # baseline_low_date: 2019-12-17
+  # baseline_high_date: 2022-06-17
+  # support:
+  #   chrome: "79"
+  #   chrome_android: "79"
+  #   edge: "17"
+  #   firefox: "62"
+  #   firefox_android: "62"
+  #   safari: "11"
+  #   safari_ios: "11"
   - css.properties.font-optical-sizing
+
+  # baseline: high
+  # baseline_low_date: 2020-07-28
+  # baseline_high_date: 2023-01-28
+  # support:
+  #   chrome: "79"
+  #   chrome_android: "79"
+  #   edge: "79"
+  #   firefox: ≤72
+  #   firefox_android: "79"
+  #   safari: ≤13.1
+  #   safari_ios: ≤13.4
+  - css.properties.font-optical-sizing.auto
+  - css.properties.font-optical-sizing.none

--- a/features/font-optical-sizing.yml.dist
+++ b/features/font-optical-sizing.yml.dist
@@ -3,18 +3,17 @@
 
 status:
   baseline: high
-  baseline_low_date: 2019-12-17
-  baseline_high_date: 2022-06-17
+  baseline_low_date: 2020-07-28
+  baseline_high_date: 2023-01-28
   support:
     chrome: "79"
     chrome_android: "79"
-    edge: "17"
-    firefox: "62"
-    firefox_android: "62"
-    safari: "11"
-    safari_ios: "11"
+    edge: "79"
+    firefox: ≤72
+    firefox_android: "79"
+    safari: ≤13.1
+    safari_ios: ≤13.4
 compat_features:
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: high
   # baseline_low_date: 2019-12-17
   # baseline_high_date: 2022-06-17
@@ -28,6 +27,7 @@ compat_features:
   #   safari_ios: "11"
   - css.properties.font-optical-sizing
 
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: high
   # baseline_low_date: 2020-07-28
   # baseline_high_date: 2023-01-28


### PR DESCRIPTION
The keywords were very likely added simultaneously to the property, so I suspect the `<=` values for the keywords could be adjusted in BCD. 