### PR TITLE
Check for stale BCD before updating dist files

### DIFF
--- a/packages/compute-baseline/src/browser-compat-data/compat.ts
+++ b/packages/compute-baseline/src/browser-compat-data/compat.ts
@@ -2,6 +2,7 @@ import bcd, {
   CompatData,
 } from "@mdn/browser-compat-data" with { type: "json" };
 import { Browser, Feature, browser, feature, query, walk } from "./index.js";
+import { isIndexable, isMetaBlock } from "./typeUtils.js";
 
 export class Compat {
   data: unknown;
@@ -12,6 +13,17 @@ export class Compat {
     this.data = data;
     this.browsers = new Map();
     this.features = new Map();
+  }
+
+  /**
+   * Get the version string from @mdn/browser-compat-data's `__meta` object (or
+   * `"unknown"` if unset).
+   */
+  get version(): string {
+    if (isIndexable(this.data) && isMetaBlock(this.data.__meta)) {
+      return this.data.__meta.version;
+    }
+    return "unknown";
   }
 
   query(path: string) {

--- a/scripts/dist.ts
+++ b/scripts/dist.ts
@@ -52,6 +52,39 @@ let exitStatus = 0;
 setLogger(logger);
 
 /**
+ * Check that the installed @mdn/browser-compat-data (BCD) package matches the
+ * one pinned in `package.json`. BCD updates frequently, leading to surprising
+ * error messages if you haven't run `npm install` recently.
+ */
+function checkForStaleCompat(): void {
+  const packageBCDVersionSpecifier: string = (() => {
+    const packageJSON: unknown = JSON.parse(
+      fs.readFileSync(process.env.npm_package_json, {
+        encoding: "utf-8",
+      }),
+    );
+    if (typeof packageJSON === "object" && "devDependencies" in packageJSON) {
+      const bcd = packageJSON.devDependencies["@mdn/browser-compat-data"];
+      if (typeof bcd === "string") {
+        return bcd;
+      }
+      throw new Error(
+        "@mdn/browser-compat-data version not found in package.json",
+      );
+    }
+  })();
+  const installedBCDVersion = compat.version;
+
+  if (!packageBCDVersionSpecifier.includes(installedBCDVersion)) {
+    logger.error(
+      `Installed @mdn/browser-compat-data (${installedBCDVersion}) does not match package.json version (${packageBCDVersionSpecifier})`,
+    );
+    logger.error("Run `npm install` and try again.");
+    process.exit(1);
+  }
+}
+
+/**
  * Update (or create) a dist YAML file from a feature definition YAML file.
  *
  * @param {string} sourcePath The path to the human-authored YAML file.
@@ -379,6 +412,7 @@ function main() {
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  checkForStaleCompat();
   main();
   process.exit(exitStatus);
 }


### PR DESCRIPTION
If a contributor has not run `npm install` recently, then it's easy to get (surprising) messages from `dist.ts` about stale YAML files. This adds a preflight check to the dist script, to prevent this from happening.

This also adds a `version` getter to compute-baseline, which might affect the version number of the next compute-baseline release.