### PR TITLE
Publishing docs: apply miscellaneous edits

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -7,7 +7,7 @@
 
 These are the steps to publish a regular release on NPM and as a GitHub release:
 
-1. Determine if it should be a major, minor, or patch release. The "[major version required](https://github.com/web-platform-dx/web-features/pulls?q=is%3Apr+is%3Amerged+label%3A%22major+version+required%22+sort%3Aupdated-desc)" and "[minor version required](https://github.com/web-platform-dx/web-features/pulls?q=is%3Apr+is%3Amerged+label%3A%22minor+version+required%22+sort%3Aupdated-desc)" labels should be used to support this decision.
+1. Determine if it should be a major, minor, or patch release. The "[major version required][major-version]" and "[minor version required][minor-version]" labels should be used to support this decision.
 1. Update `packages/web-features/package.json` and `packages/web-features/package-lock.json` in a PR and get review.
 1. Merge the PR and draft a new release at https://github.com/web-platform-dx/web-features/releases/new.
 1. Fill in the tag name `vX.Y.Z` manually as both the tag and release title.
@@ -24,6 +24,10 @@ These are the steps to publish a regular release on NPM and as a GitHub release:
 
 1. Remove all lines from Dependabot.
 1. Publish the GitHub release.
+1. Remove the "[major version required][major-version]" and "[minor version required][minor-version]" labels from any pull requests that were included in the release.
+
+[major-version]: https://github.com/web-platform-dx/web-features/pulls?q=is%3Apr+is%3Amerged+label%3A%22major+version+required%22+sort%3Aupdated-desc
+[minor-version]: https://github.com/web-platform-dx/web-features/pulls?q=is%3Apr+is%3Amerged+label%3A%22minor+version+required%22+sort%3Aupdated-desc
 
 Publishing the GitHub release creates the tag. This triggers the [Publish web-features GitHub Actions workflows](https://github.com/web-platform-dx/web-features/blob/main/.github/workflows/publish_web-features.yml), uploads GitHub release artifacts and publishes the package to NPM.
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -11,9 +11,9 @@ These are the steps to publish a regular release on NPM and as a GitHub release:
 1. Update `packages/web-features/package.json` and `packages/web-features/package-lock.json` in a PR and get review.
 1. Merge the PR and draft a new release at https://github.com/web-platform-dx/web-features/releases/new.
 1. Fill in the tag name `vX.Y.Z` manually as both the tag and release title.
-1. For major releases, add a "Breaking Changes" section up top.
-1. For minor releases, add a "What's New" section up top.
-1. Click "Generate release notes".
+1. For major releases, add a `## Breaking Changes` section up top.
+1. For minor releases, add a `## What's New` section up top.
+1. Click **Generate release notes**.
 1. Find unescaped `<` characters and make sure that HTML elements are enclosed with backticks.
 
    This regular expression can help:

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -14,7 +14,14 @@ These are the steps to publish a regular release on NPM and as a GitHub release:
 1. For major releases, add a "Breaking Changes" section up top.
 1. For minor releases, add a "What's New" section up top.
 1. Click "Generate release notes".
-1. Search for "<" and make sure all element names are quoted with backquotes.
+1. Find unescaped `<` characters and make sure that HTML elements are enclosed with backticks.
+
+   This regular expression can help:
+
+   ```regex
+   / (?<!`)<(.*?)> /
+   ```
+
 1. Remove all lines from Dependabot.
 1. Publish the GitHub release.
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -7,16 +7,16 @@
 
 These are the steps to publish a regular release on NPM and as a GitHub release:
 
-- Determine if it should be a major, minor, or patch release. The "[major version required](https://github.com/web-platform-dx/web-features/pulls?q=is%3Apr+is%3Amerged+label%3A%22major+version+required%22+sort%3Aupdated-desc)" and "[minor version required](https://github.com/web-platform-dx/web-features/pulls?q=is%3Apr+is%3Amerged+label%3A%22minor+version+required%22+sort%3Aupdated-desc)" labels should be used to support this decision.
-- Update `packages/web-features/package.json` and `packages/web-features/package-lock.json` in a PR and get review.
-- Merge the PR and draft a new release at https://github.com/web-platform-dx/web-features/releases/new
-- Fill in the tag name `vX.Y.Z` manually as both the tag and release title
-- For major releases, add a "Breaking Changes" section up top.
-- For minor releases, add a "What's New" section up top.
-- Click "Generate release notes"
-- Search for "<" and make sure all element names are quoted with backquotes
-- Remove all lines from Dependabot
-- Publish the GitHub release
+1. Determine if it should be a major, minor, or patch release. The "[major version required](https://github.com/web-platform-dx/web-features/pulls?q=is%3Apr+is%3Amerged+label%3A%22major+version+required%22+sort%3Aupdated-desc)" and "[minor version required](https://github.com/web-platform-dx/web-features/pulls?q=is%3Apr+is%3Amerged+label%3A%22minor+version+required%22+sort%3Aupdated-desc)" labels should be used to support this decision.
+1. Update `packages/web-features/package.json` and `packages/web-features/package-lock.json` in a PR and get review.
+1. Merge the PR and draft a new release at https://github.com/web-platform-dx/web-features/releases/new
+1. Fill in the tag name `vX.Y.Z` manually as both the tag and release title
+1. For major releases, add a "Breaking Changes" section up top.
+1. For minor releases, add a "What's New" section up top.
+1. Click "Generate release notes"
+1. Search for "<" and make sure all element names are quoted with backquotes
+1. Remove all lines from Dependabot
+1. Publish the GitHub release
 
 Publishing the GitHub release creates the tag. This triggers the [Publish web-features GitHub Actions workflows](https://github.com/web-platform-dx/web-features/blob/main/.github/workflows/publish_web-features.yml), uploads GitHub release artifacts and publishes the package to NPM.
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -14,7 +14,7 @@ These are the steps to publish a regular release on NPM and as a GitHub release:
 1. For major releases, add a `## Breaking Changes` section up top.
 1. For minor releases, add a `## What's New` section up top.
 1. Click **Generate release notes**.
-1. Find unescaped `<` characters and make sure that HTML elements are enclosed with backticks.
+1. In the release description, find unescaped `<` characters and make sure that HTML elements are enclosed with backticks.
 
    This regular expression can help:
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -9,14 +9,14 @@ These are the steps to publish a regular release on NPM and as a GitHub release:
 
 1. Determine if it should be a major, minor, or patch release. The "[major version required](https://github.com/web-platform-dx/web-features/pulls?q=is%3Apr+is%3Amerged+label%3A%22major+version+required%22+sort%3Aupdated-desc)" and "[minor version required](https://github.com/web-platform-dx/web-features/pulls?q=is%3Apr+is%3Amerged+label%3A%22minor+version+required%22+sort%3Aupdated-desc)" labels should be used to support this decision.
 1. Update `packages/web-features/package.json` and `packages/web-features/package-lock.json` in a PR and get review.
-1. Merge the PR and draft a new release at https://github.com/web-platform-dx/web-features/releases/new
-1. Fill in the tag name `vX.Y.Z` manually as both the tag and release title
+1. Merge the PR and draft a new release at https://github.com/web-platform-dx/web-features/releases/new.
+1. Fill in the tag name `vX.Y.Z` manually as both the tag and release title.
 1. For major releases, add a "Breaking Changes" section up top.
 1. For minor releases, add a "What's New" section up top.
-1. Click "Generate release notes"
-1. Search for "<" and make sure all element names are quoted with backquotes
-1. Remove all lines from Dependabot
-1. Publish the GitHub release
+1. Click "Generate release notes".
+1. Search for "<" and make sure all element names are quoted with backquotes.
+1. Remove all lines from Dependabot.
+1. Publish the GitHub release.
 
 Publishing the GitHub release creates the tag. This triggers the [Publish web-features GitHub Actions workflows](https://github.com/web-platform-dx/web-features/blob/main/.github/workflows/publish_web-features.yml), uploads GitHub release artifacts and publishes the package to NPM.
 


### PR DESCRIPTION
I just did a web-features release and made a few improvements to the publishing docs as I went. Hopefully this stuff will help me complete it a little faster next time:

- Explain where we're checking for unescaped HTML
- Provide Markdown literals for pasting into the release description
- Add follow up step for "version required" labels
- Add a regex hint for creating releases
- Use full stops consistently
- Number the steps