### PR TITLE
Reinstate check for `.dist` without `.yml` companion

### DIFF
--- a/scripts/dist.ts
+++ b/scripts/dist.ts
@@ -325,7 +325,7 @@ function main() {
     if (fs.statSync(fileOrDirectory).isDirectory()) {
       return new fdir()
         .withBasePath()
-        .filter((fp) => fp.endsWith(".yml"))
+        .filter((fp) => fp.endsWith(".yml") || fp.endsWith(".yml.dist"))
         .crawl(fileOrDirectory)
         .sync();
     }


### PR DESCRIPTION
We erroneously stopped checking for this with https://github.com/web-platform-dx/web-features/pull/1343