### PR TITLE
Invert .prettierignore (use opt-out, not opt-in)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,24 +1,19 @@
-# Exclude all files (but not directories)
-/**/*.*
+# Exclude any generated files/folders
+/**/*.dist
+/**/dist
 
-# Opt-ins
-!GOVERNANCE.md
-!eslint.config.js
-
+# Files/folders that have not yet been formatted
+# XXX Format all these files
+README.md
+index.ts
+types.ts
+2022-backgrounder.md
+towards-features.md
+/.github/**
+/docs
 !/docs/publishing.md
-
-!/features/*.yml
-/features/*.yml.dist
-!/groups/*.yml
-!/snapshots/*.yml
-
-!/packages/compute-baseline/**
-!/packages/web-features/**
-
-!/scripts/build.ts
-!/scripts/dist.ts
-!/scripts/feature-init.ts
-!/scripts/find-troublesome-ancestors.ts
-!/scripts/release.ts
-!/scripts/update-drafts.ts
-!/scripts/validate.ts
+/features/draft
+/schemas
+/scripts/caniuse.ts
+/scripts/schema.ts
+/scripts/specs.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,7 +3,7 @@
 /**/dist
 
 # Files/folders that have not yet been formatted
-# XXX Format all these files
+# TODO: Format all these files
 README.md
 index.ts
 types.ts


### PR DESCRIPTION
This PR inverts the direction of the `.prettierignore` file, so that it lists the files and folders to ignore (as the file name implies), rather than all the files and folders to _only_ format.

## Motivation

In another PR (my first), the [first review comment](https://github.com/web-platform-dx/web-features/pull/1622#discussion_r1723110227) had requested that the new script was added to the `.prettierignore` file as an opt-in.  However, it is not standard to use a `.ignore` file for opting into formatting, so this was very confusing to me.  Additionally, since I'm assuming the plan is to eventually format all files using Prettier, having the `.prettierignore` file use an opt-out (or using proper terminology, _ignore_) structure, it serves as a to-do list for what still needs to be formatted.
