### PR TITLE
Revise `<label>` description

### DIFF
--- a/features/label.yml
+++ b/features/label.yml
@@ -1,5 +1,5 @@
 name: <label>
-description: The `<label>` HTML element represents a caption for a form element.
+description: The `<label>` HTML element represents a caption for a form field.
 spec: https://html.spec.whatwg.org/multipage/forms.html#the-label-element
 group:
   - forms


### PR DESCRIPTION
This is meant to avoid the ambiguity of "form element" implying "`<form>` element" and not "[an element of a] form element."