### PR TITLE
Improve weekly spec drafts updating GitHub Actions workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,3 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5
+      - if: github.actor == 'dependabot[bot]'
+        run: gh pr edit ${{ github.event.pull_request.number }} --add-label "generated"

--- a/.github/workflows/update_draft_features_weekly.yml
+++ b/.github/workflows/update_draft_features_weekly.yml
@@ -16,7 +16,7 @@ jobs:
           node-version-file: .node-version
           cache: npm
       - run: npm ci
-      - run: rm features/draft/spec/*.yml features/draft/spec/*.dist
+      - run: git rm features/draft/spec/*.yml features/draft/spec/*.dist
       - run: npm run update-drafts
       - run: npm run dist
       - name: Create Pull Request

--- a/.github/workflows/update_draft_features_weekly.yml
+++ b/.github/workflows/update_draft_features_weekly.yml
@@ -25,7 +25,10 @@ jobs:
             features/draft/spec/
           commit-message: Update draft features
           title: "Update draft features weekly"
-          body: "This is an auto-generated PR with draft features by spec updates."
+          body: |
+            This is an auto-generated PR with draft features by spec updates.
+
+            See https://github.com/web-platform-dx/web-features/blob/main/.github/workflows/update_draft_features_weekly.yml for details.
           labels: |
             generated
           branch: update-draft-features-${{ github.run_number }}

--- a/.github/workflows/update_draft_features_weekly.yml
+++ b/.github/workflows/update_draft_features_weekly.yml
@@ -24,7 +24,9 @@ jobs:
           add-paths: |
             features/draft/spec/
           commit-message: Update draft features
-          title: "[GitHub Actions] Update draft features weekly"
+          title: "Update draft features weekly"
           body: "This is an auto-generated PR with draft features by spec updates."
+          labels: |
+            generated
           branch: update-draft-features-${{ github.run_number }}
           delete-branch: true

--- a/.github/workflows/update_draft_features_weekly.yml
+++ b/.github/workflows/update_draft_features_weekly.yml
@@ -19,7 +19,7 @@ jobs:
       - run: git rm features/draft/spec/*.yml features/draft/spec/*.dist
       - run: npm run update-drafts
       - run: npm run dist
-      - name: Create Pull Request
+      - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:
           add-paths: |

--- a/.github/workflows/update_draft_features_weekly.yml
+++ b/.github/workflows/update_draft_features_weekly.yml
@@ -18,7 +18,6 @@ jobs:
       - run: npm ci
       - run: git rm features/draft/spec/*.yml features/draft/spec/*.dist
       - run: npm run update-drafts
-      - run: npm run dist
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:

--- a/.github/workflows/update_draft_features_weekly.yml
+++ b/.github/workflows/update_draft_features_weekly.yml
@@ -3,7 +3,7 @@ name: Update Draft Features
 on:
   # Runs at midnight on Mondays 05:30 UTC, or manually triggered
   schedule:
-    - cron: '30 5 * * 1'
+    - cron: "30 5 * * 1"
   workflow_dispatch:
 
 jobs:
@@ -19,16 +19,12 @@ jobs:
       - run: rm features/draft/spec/*.yml features/draft/spec/*.dist
       - run: npm run update-drafts
       - run: npm run dist
-      - name: Commit changes
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add -A
-          git commit -m "Update draft features weekly" || echo "No changes to commit"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: Update draft features weekly
+          add-paths: |
+            features/draft/spec/
+          commit-message: Update draft features
           title: "[GitHub Actions] Update draft features weekly"
           body: "This is an auto-generated PR with draft features by spec updates."
           branch: update-draft-features-${{ github.run_number }}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:specs": "tsx scripts/specs.ts",
     "test:types": "npm run --workspaces test:types && tsc",
     "test": "npm run test:caniuse -- --quiet && npm run test:schema && npm run test:specs && npm run test:format && npm run test:dist && npm run test --workspaces && npm run test:lint",
-    "update-drafts": "tsx scripts/update-drafts.ts"
+    "update-drafts": "tsx scripts/update-drafts.ts && npm run dist"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",


### PR DESCRIPTION
Working with these is a bit annoying. I can never remember the steps needed to handle merging with main. I ended up making a few changes to the workflow file to try to make this more approachable. Changes include:

- Running `dist` as part of `npm run update-drafts`. This is the single biggest headache I was having.
- Explicitly deleting and adding files, so it's clearer what files this workflow is meant to update.
- Using a label to identify generated PRs (this will make it easier for me to review these PRs alongside dependabot changes).
- Using the `peter-evans/create-pull-request` to do the commit, instead of a custom step and committer config.
- Linking to the workflow file from the pull request body.