### PR TITLE
Remove long-animation-frames.yaml

### DIFF
--- a/features/long-animation-frames.yaml
+++ b/features/long-animation-frames.yaml
@@ -1,2 +1,0 @@
-name: Long animation frame timing
-spec: https://w3c.github.io/long-animation-frames/


### PR DESCRIPTION
I came across this file and believe it is there by accident. Renaming it to `.yml` and running dist does not add any keys, so the tag doesn't appear to exist in BCD. Because it is a .yaml file, it is not included in data.json.

It was originally added in https://github.com/web-platform-dx/web-features/pull/645. @Elchi3 is there a reason this file should be kept?