### PR TITLE
Fix labeler failure due to missing repo environment variable

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,3 +14,4 @@ jobs:
         run: gh pr edit ${{ github.event.pull_request.number }} --add-label "generated"
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
It's failing right now because the labeler doesn't use a checkout, so the repository must be explicitly set.