### PR TITLE
Extend migrate-to-bcd CLI

### DIFF
--- a/scripts/migrate-to-bcd.ts
+++ b/scripts/migrate-to-bcd.ts
@@ -1,7 +1,5 @@
-import assert from "node:assert";
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { fdir } from "fdir";
 import winston from "winston";

--- a/scripts/migrate-to-bcd.ts
+++ b/scripts/migrate-to-bcd.ts
@@ -26,7 +26,7 @@ const argv = yargs(process.argv.slice(2))
   .middleware((argv) => {
     // Read `--bcd-path` option from BCD_PATH if set, for compatibility with BCD
     // Collector's config style
-    if (process.env.BCD_PATH) {
+    if (!argv.bcdPath && process.env.BCD_PATH) {
       argv.bcdPath = process.env.BCD_PATH;
     }
   })

--- a/scripts/migrate-to-bcd.ts
+++ b/scripts/migrate-to-bcd.ts
@@ -34,7 +34,6 @@ const argv = yargs(process.argv.slice(2))
     if (argv.bcdPath) {
       return true;
     } else {
-      console.log(argv);
       throw new Error(
         "The path to BCD must be set, as a positional, BCD_PATH environment variable, or MIGRATE_TO_BCD_BCD_PATH environment variable.",
       );


### PR DESCRIPTION
This adds environment variables for setting the path to BCD and a verbosity option.

Follow up from the discussion at https://github.com/web-platform-dx/web-features/pull/1622#discussion_r1724863422.

cc: @queengooborg Hopefully this accommodates everyone's config preferences (implicit, explicit, and environment variables).