### PR TITLE
Add missing text-wrap-mode keys

### DIFF
--- a/features/text-wrap-mode.yml
+++ b/features/text-wrap-mode.yml
@@ -4,3 +4,5 @@ spec: https://drafts.csswg.org/css-text-4/#text-wrap-mode
 group: white-space
 compat_features:
   - css.properties.text-wrap-mode
+  - css.properties.text-wrap-mode.nowrap
+  - css.properties.text-wrap-mode.wrap

--- a/features/text-wrap-mode.yml.dist
+++ b/features/text-wrap-mode.yml.dist
@@ -10,3 +10,5 @@ status:
     safari_ios: "17.4"
 compat_features:
   - css.properties.text-wrap-mode
+  - css.properties.text-wrap-mode.nowrap
+  - css.properties.text-wrap-mode.wrap


### PR DESCRIPTION
Just adds `wrap` and `nowrap` keys, which were missed in #1698.