### PR TITLE
Let Dependabot upgrade web-features dev dependencies more strictly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     directory: packages/web-features
     schedule:
       interval: daily
+    versioning-strategy: increase
   - package-ecosystem: npm
     directory: packages/compute-baseline
     schedule:


### PR DESCRIPTION
Upgrades to `packages/web-features` are a little weird, since it only changes the lockfile. This ought to upgrade them more in line with the top-level `package.json`.