### PR TITLE
Add missing keys to contain-intrinsic-size

### DIFF
--- a/features/contain-intrinsic-size.yml
+++ b/features/contain-intrinsic-size.yml
@@ -4,3 +4,15 @@ spec: https://drafts.csswg.org/css-sizing-4/#intrinsic-size-override
 group: containment
 status:
   compute_from: css.properties.contain-intrinsic-size
+compat_features:
+  - css.properties.contain-intrinsic-size
+  - css.properties.contain-intrinsic-block-size
+  - css.properties.contain-intrinsic-height
+  - css.properties.contain-intrinsic-inline-size
+  - css.properties.contain-intrinsic-width
+  - css.properties.contain-intrinsic-size.auto_none
+  - css.properties.contain-intrinsic-block-size.none
+  - css.properties.contain-intrinsic-height.none
+  - css.properties.contain-intrinsic-inline-size.none
+  - css.properties.contain-intrinsic-size.none
+  - css.properties.contain-intrinsic-width.none

--- a/features/contain-intrinsic-size.yml.dist
+++ b/features/contain-intrinsic-size.yml.dist
@@ -44,6 +44,22 @@ compat_features:
   # baseline: low
   # baseline_low_date: 2023-09-18
   # support:
+  #   chrome: "98"
+  #   chrome_android: "98"
+  #   edge: "98"
+  #   firefox: "107"
+  #   firefox_android: "107"
+  #   safari: "17"
+  #   safari_ios: "17"
+  - css.properties.contain-intrinsic-block-size.none
+  - css.properties.contain-intrinsic-height.none
+  - css.properties.contain-intrinsic-inline-size.none
+  - css.properties.contain-intrinsic-size.none
+  - css.properties.contain-intrinsic-width.none
+
+  # baseline: low
+  # baseline_low_date: 2023-09-18
+  # support:
   #   chrome: "117"
   #   chrome_android: "117"
   #   edge: "117"


### PR DESCRIPTION
Adds `.none` suffix to each key.