### PR TITLE
Add missing keys to overlay

### DIFF
--- a/features/overlay.yml
+++ b/features/overlay.yml
@@ -3,3 +3,6 @@ description: The `overlay` CSS property, used as an `allow-discrete` CSS transit
 spec: https://drafts.csswg.org/css-position-4/#overlay
 compat_features:
   - css.properties.overlay
+  - css.properties.overlay.auto
+  - css.properties.overlay.none
+  

--- a/features/overlay.yml
+++ b/features/overlay.yml
@@ -6,4 +6,3 @@ compat_features:
   - css.properties.overlay
   - css.properties.overlay.auto
   - css.properties.overlay.none
-  

--- a/features/overlay.yml.dist
+++ b/features/overlay.yml.dist
@@ -9,3 +9,5 @@ status:
     edge: "117"
 compat_features:
   - css.properties.overlay
+  - css.properties.overlay.auto
+  - css.properties.overlay.none


### PR DESCRIPTION
`auto` and `none` were missing, no changes to baseline. 
