### PR TITLE
Throw error if .yaml file is detected instead of .yml

### DIFF
--- a/scripts/dist.ts
+++ b/scripts/dist.ts
@@ -358,7 +358,7 @@ function main() {
     if (fs.statSync(fileOrDirectory).isDirectory()) {
       return new fdir()
         .withBasePath()
-        .filter((fp) => fp.endsWith(".yml") || fp.endsWith(".yml.dist"))
+        .filter((fp) => !(fp.endsWith(".md") || fp.endsWith(".DS_Store")))
         .crawl(fileOrDirectory)
         .sync();
     }
@@ -369,6 +369,11 @@ function main() {
   const sourceToDist = new Map<string, string>(
     filePaths.map((filePath: string) => {
       const ext = path.extname(filePath);
+      if (ext === ".yaml") {
+        throw new Error(
+          `YAML files must use .yml extension; ${filePath} has invalid extension`,
+        );
+      }
       if (![".dist", ".yml"].includes(ext)) {
         throw new Error(
           `Cannot generate dist for ${filePath}, only YAML input is supported`,


### PR DESCRIPTION
This PR fixes #1768 by adding linting that checks if a `.yaml` file is detected instead of a `.yml` file.

Some editors (like mine) seem to prefer the `.yaml` extension instead of `.yml`, which causes the .dist files to not be generated.  Unfortunately, there is no warning message that states there's an invalid file, so this PR adds one in.  It also searches for any files of an invalid type and throws an error.
