### PR TITLE
Fix labeling tools and infrastructure PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,7 +11,7 @@
 
 "tools and infrastructure":
   - changed-files:
-      - all-globs-to-any-file:
+      - any-glob-to-any-file:
           - ".eslint.config.js"
           - ".github/**"
           - ".node-version"


### PR DESCRIPTION
The previous config required all globs to match. That is to say, all the configuration files had to change for any PR to be labeled as tools and infra.