### PR TITLE
more functional contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ By creating a common nomenclature for web platform features, `web-features` inte
 To get feature identifiers, Baseline support data, or cross-references to other resources (such as specifications and caniuse), use [the `web-features` npm package](https://www.npmjs.com/package/web-features).
 [Read the package README](./packages/web-features/README.md) for more information.
 
-To contribute to feature identification, definition, Baseline support statuses, or to update the status on MDN, jump to [Contribute](#contribute).
+To contribute to feature identification, definition, Baseline support statuses, or to update the status on MDN, read [`CONTRIBUTING.md`](./docs/CONTRIBUTING.md).
 
 ## Background
 


### PR DESCRIPTION
the internal link approach means that if you've scrolled to the bottom of the page, you click on it and seemingly nothing happens.

so you click it a bunch of times wondering what the heck is going on.

until you realize that it's just linking to a section a few lines below and nothing happens because you're already there.

this has happened to me a few times now, so proposing to link to the contribution guide directly instead.