### PR TITLE
`dist` script: be more permissive with file extensions

### DIFF
--- a/scripts/dist.ts
+++ b/scripts/dist.ts
@@ -379,9 +379,7 @@ function main() {
         .crawl(fileOrDirectory)
         .sync();
     }
-    if (isDistOrDistable(fileOrDirectory)) {
-      return fileOrDirectory;
-    }
+    return isDistOrDistable(fileOrDirectory) ? fileOrDirectory : [];
   });
 
   // Map from .yml to .yml.dist to filter out duplicates.


### PR DESCRIPTION
This lets more files remain in the `features` directory—such as editor `.swp` files—without throwing an exception. 

Fixes https://github.com/web-platform-dx/web-features/issues/1789.