### PR TITLE
`update-drafts`: increase frequency of updates

### DIFF
--- a/.github/workflows/update_draft_features_weekly.yml
+++ b/.github/workflows/update_draft_features_weekly.yml
@@ -1,9 +1,9 @@
 name: Update Draft Features
 
 on:
-  # Runs at midnight on Mondays 05:30 UTC, or manually triggered
+  # Runs at midnight on Mondays and Thursdays 05:30 UTC, or manually triggered
   schedule:
-    - cron: "30 5 * * 1"
+    - cron: "30 5 * * 1,4"
   workflow_dispatch:
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
           add-paths: |
             features/draft/spec/
           commit-message: Update draft features
-          title: "Update draft features weekly"
+          title: "Update draft features"
           body: |
             This is an auto-generated PR with draft features by spec updates.
 


### PR DESCRIPTION
With the lighter-weight diffs introduced in https://github.com/web-platform-dx/web-features/pull/1783 it now makes sense to run this more frequently, so contributors are less likely to see already-assigned keys.