### PR TITLE
Revise `individual-transforms` description

### DIFF
--- a/features/individual-transforms.yml
+++ b/features/individual-transforms.yml
@@ -1,5 +1,5 @@
 name: Individual transform properties
-description: The `translate`, `rotate`, and `scale` CSS properties apply simple transformations independently, as opposed to applying multiple transformations with the `transform` CSS property.
+description: The `translate`, `rotate`, and `scale` CSS properties apply single transformations independently, as opposed to applying multiple transformations with the `transform` CSS property.
 spec: https://drafts.csswg.org/css-transforms-2/#individual-transforms
 group: transforms
 compat_features:


### PR DESCRIPTION
This creates a stronger link to the "as opposed to" clause.

That said, another way to do this would be:

> The `translate`, `rotate`, and `scale` CSS properties apply simple transformations independently, as opposed to applying compound transformations with the `transform` CSS property.