### PR TITLE
Add dark, light and normal keywords to color-scheme

### DIFF
--- a/features/color-scheme.yml
+++ b/features/color-scheme.yml
@@ -9,3 +9,11 @@ spec: https://drafts.csswg.org/css-color-adjust-1/#color-scheme-prop
 # 2022-02-03 (Chrome 98). Since this is less than a month's difference and the
 # opt-out could be important for some developers, the later date is accepted.
 group: css
+compat_features:
+  - html.elements.meta.name.color-scheme
+  - css.properties.color-scheme
+  - css.properties.color-scheme.only_dark
+  - css.properties.color-scheme.only_light
+  - css.properties.color-scheme.dark
+  - css.properties.color-scheme.light
+  - css.properties.color-scheme.normal

--- a/features/color-scheme.yml.dist
+++ b/features/color-scheme.yml.dist
@@ -39,6 +39,9 @@ compat_features:
   #   safari: "13"
   #   safari_ios: "13"
   - css.properties.color-scheme
+  - css.properties.color-scheme.dark
+  - css.properties.color-scheme.light
+  - css.properties.color-scheme.normal
 
   # ⬇️ Same status as overall feature ⬇️
   # baseline: high


### PR DESCRIPTION
Doesn't impact baseline, just adds missing keys found in https://github.com/mdn/browser-compat-data/pull/24163.