### PR TITLE
Print destination path on feature init

### DIFF
--- a/scripts/feature-init.ts
+++ b/scripts/feature-init.ts
@@ -81,7 +81,7 @@ async function main() {
     process.exit(0);
   }
   await fs.writeFile(destination, formatted);
-  console.log(`Wrote ${destination}`);
+  console.log(destination);
 }
 
 async function format(featurePath: string, text: string): Promise<string> {

--- a/scripts/feature-init.ts
+++ b/scripts/feature-init.ts
@@ -81,6 +81,7 @@ async function main() {
     process.exit(0);
   }
   await fs.writeFile(destination, formatted);
+  console.log(`Wrote ${destination}`);
 }
 
 async function format(featurePath: string, text: string): Promise<string> {


### PR DESCRIPTION
Tiny QOL change- the first thing I want to do after running `feature-init` is open the newly generated file. This prints the path to the console, so I can click on it and open it.