### PR TITLE
Merge gravity-sensor.yaml into accelerometer.yml

### DIFF
--- a/features/accelerometer.yml
+++ b/features/accelerometer.yml
@@ -1,6 +1,6 @@
 name: Accelerometer
-description: The `Accelerometer` and `LinearAccelerationSensor` APIs read the acceleration applied to a device in three dimensions, either including the effect of gravity or not, respectively.
-spec: https://w3c.github.io/accelerometer/#accelerometer-interface
+description: The `Accelerometer`, `LinearAccelerationSensor` and `GravitySensor` APIs read the acceleration applied to a device in three dimensions, either including the effect of gravity, without its effect, or only its effect, respectively.
+spec: https://w3c.github.io/accelerometer/
 group: sensors
 status:
   compute_from: api.Accelerometer.Accelerometer
@@ -10,6 +10,8 @@ compat_features:
   - api.Accelerometer.x
   - api.Accelerometer.y
   - api.Accelerometer.z
+  - api.GravitySensor
+  - api.GravitySensor.GravitySensor
   - api.LinearAccelerationSensor
   - api.LinearAccelerationSensor.LinearAccelerationSensor
   - api.Permissions.permission_accelerometer

--- a/features/gravity-sensor.yml
+++ b/features/gravity-sensor.yml
@@ -1,7 +1,0 @@
-name: Gravity sensor
-description: The `GravitySensor` API reads the gravity applied to a device in three dimensions.
-spec: https://w3c.github.io/accelerometer/#gravity-sensor-model
-group: sensors
-compat_features:
-  - api.GravitySensor
-  - api.GravitySensor.GravitySensor


### PR DESCRIPTION
The `GravitySensor` interface is part of the Accelerometer specification and is another view over the accelerometer data, just like `LinearAccelerationSensor`.