### PR TITLE
Create a continuous prerelease for GitHub

### DIFF
--- a/.github/workflows/publish_next_web-features.yml
+++ b/.github/workflows/publish_next_web-features.yml
@@ -12,6 +12,9 @@ on:
       - index.ts
       - scripts/build.ts
 
+permissions:
+  contents: write
+
 env:
   package: "web-features"
   package_dir: "packages/web-features"
@@ -33,32 +36,52 @@ jobs:
     runs-on: ubuntu-latest
     needs: "test"
     steps:
-      - name: Get timestamp
-        id: timestamp
-        run: echo "TIMESTAMP=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
+      - name: Get timestamp and short hash
+        id: timestamp_and_hash
+        run: |
+          echo "TIMESTAMP=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
+          echo "SHORT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
       - uses: actions/setup-node@v4
         with:
           node-version-file: .node-version
           cache: npm
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
+
       - run: npm run build
+      - run: npm run build:extended
+
       - name: Get package.json version
         id: version
         run: echo "VERSION=$(npm version --json | jq --raw-output '.["${{ env.package }}"]')" >> $GITHUB_OUTPUT
         working-directory: ${{ env.package_dir }}
       - run: npm install
         working-directory: ${{ env.package_dir }}
-      - run: npm version --no-git-tag-version "$VERSION-dev-$TIMESTAMP-$(git rev-parse --short HEAD)"
+      - run: npm version --no-git-tag-version "$VERSION-dev-$TIMESTAMP-$SHORT_HASH"
         # The version string template is: <package.json version>-dev-<timestamp>-<commit-hash>
         # Why not use SemVer build metadata with a plus sign for some of this?
         # Because npm completely ignores it. 😒
         working-directory: ${{ env.package_dir }}
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
-          TIMESTAMP: ${{ steps.timestamp.outputs.TIMESTAMP }}
+          TIMESTAMP: ${{ steps.timestamp_and_hash.outputs.TIMESTAMP }}
+          SHORT_HASH: ${{ steps.timestamp_and_hash.outputs.SHORT_HASH }}
       - run: npm publish --tag ${{ env.dist_tag }}
         working-directory: ${{ env.package_dir }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish pre-release on GitHub
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 #v2.0.8
+        with:
+          files: |
+            schemas/data.schema.json
+            ${{ env.package_dir }}/data.json
+            data.extended.json
+          prerelease: true
+          name: web-features@next
+          body: This is a continuously-updated prerelease generated from `main` (currently at ${{ steps.timestamp_and_hash.outputs.SHORT_HASH }}).
+          tag_name: ${{ env.dist_tag }}
+          fail_on_unmatched_files: true


### PR DESCRIPTION
This is like the `web-features@next` release on npm, but on GitHub and extended to the bare JSON artifacts.

This is setup for https://github.com/web-platform-dx/web-features/issues/1860.