### PR TITLE
Turn off drafts updater on forks

### DIFF
--- a/.github/workflows/update_draft_features_weekly.yml
+++ b/.github/workflows/update_draft_features_weekly.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   update-drafts:
+    if: github.repository == 'web-platform-dx/web-features'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I assume this is not very helpful for forks and it produces a lot of needless branches. I think we should make this opt-in for forks.