### PR TITLE
Add missing cjk-ideographic key

### DIFF
--- a/features/list-style.yml
+++ b/features/list-style.yml
@@ -20,6 +20,7 @@ compat_features:
   - css.properties.list-style-type.cjk-decimal
   - css.properties.list-style-type.cjk-earthly-branch
   - css.properties.list-style-type.cjk-heavenly-stem
+  - css.properties.list-style-type.cjk-ideographic
   - css.properties.list-style-type.decimal
   - css.properties.list-style-type.decimal-leading-zero
   - css.properties.list-style-type.devanagari

--- a/features/list-style.yml.dist
+++ b/features/list-style.yml.dist
@@ -57,6 +57,19 @@ compat_features:
   # baseline_low_date: 2020-01-15
   # baseline_high_date: 2022-07-15
   # support:
+  #   chrome: "1"
+  #   chrome_android: "18"
+  #   edge: "79"
+  #   firefox: "1"
+  #   firefox_android: "4"
+  #   safari: "5"
+  #   safari_ios: "4.2"
+  - css.properties.list-style-type.cjk-ideographic
+
+  # baseline: high
+  # baseline_low_date: 2020-01-15
+  # baseline_high_date: 2022-07-15
+  # support:
   #   chrome: "6"
   #   chrome_android: "18"
   #   edge: "79"


### PR DESCRIPTION
This was accidentally removed in https://github.com/web-platform-dx/web-features/pull/1764, but it should be included, as it is part of the spec.