### PR TITLE
Add text-wrap-style.pretty key

### DIFF
--- a/features/text-wrap-style.yml
+++ b/features/text-wrap-style.yml
@@ -6,4 +6,5 @@ compat_features:
   - css.properties.text-wrap-style
   - css.properties.text-wrap-style.auto
   - css.properties.text-wrap-style.balance
+  - css.properties.text-wrap-style.pretty
   - css.properties.text-wrap-style.stable

--- a/features/text-wrap-style.yml.dist
+++ b/features/text-wrap-style.yml.dist
@@ -3,13 +3,20 @@
 
 status:
   baseline: false
-  support:
-    firefox: "124"
-    firefox_android: "124"
-    safari: "17.5"
-    safari_ios: "17.5"
+  support: {}
 compat_features:
+  # baseline: false
+  # support:
+  #   firefox: "124"
+  #   firefox_android: "124"
+  #   safari: "17.5"
+  #   safari_ios: "17.5"
   - css.properties.text-wrap-style
   - css.properties.text-wrap-style.auto
   - css.properties.text-wrap-style.balance
   - css.properties.text-wrap-style.stable
+
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: false
+  # support: {}
+  - css.properties.text-wrap-style.pretty


### PR DESCRIPTION
Key was added in latest BCD, supported by Safari 18 TP.
