### PR TITLE
Add comments for features that regressed Baseline status

### DIFF
--- a/features/font-variant-position.yml
+++ b/features/font-variant-position.yml
@@ -2,6 +2,12 @@ name: font-variant-position
 description: The `font-variant-position` CSS property sets whether to use alternate glyphs for subscript and superscript text.
 spec: https://drafts.csswg.org/css-fonts-4/#font-variant-position-prop
 group: font-features
+# TODO: https://github.com/web-platform-dx/web-features/issues/1971
+# Status changed: https://github.com/web-platform-dx/web-features/pull/1958
+# 2024-10-15 — low → false — Chrome, Edge, and Safari do not implement font synthesis for missing superscript or subscript glpyhs.
+# References:
+# - https://issues.chromium.org/issues/352218916
+# - https://bugs.webkit.org/show_bug.cgi?id=151471
 compat_features:
   - css.properties.font-variant-position
   - css.properties.font-variant-position.normal

--- a/features/popover.yml
+++ b/features/popover.yml
@@ -2,3 +2,9 @@ name: Popover
 description: The `popover` HTML attribute creates an overlay to display content on top of other page content. Popovers can be shown declaratively using HTML, or using the `showPopover()` method.
 spec: https://html.spec.whatwg.org/multipage/popover.html
 group: html
+# TODO: https://github.com/web-platform-dx/web-features/issues/1971
+# Status changed: https://github.com/web-platform-dx/web-features/pull/1797
+# 2024-09-18 — low → false — Safari on iOS has a bug that prevents dismissing popovers by touch.
+# References:
+# - https://github.com/mdn/browser-compat-data/issues/22927
+# - https://bugs.webkit.org/show_bug.cgi?id=267688


### PR DESCRIPTION
Eventually these should become some object representing a note. See https://github.com/web-platform-dx/web-features/issues/1971.

But until then a comment will do nicely.