### PR TITLE
Fix decodedBodySize and encodedBodySize property names in resource-size description

### DIFF
--- a/features/resource-size.yml
+++ b/features/resource-size.yml
@@ -1,5 +1,5 @@
 name: Resource size
-description: The `decodedSize`, `encodedSize`, and `transferSize` properties of the `PerformanceResourceTiming` API reports the size of resources loaded.
+description: The `decodedBodySize`, `encodedBodySize`, and `transferSize` properties of the `PerformanceResourceTiming` API reports the size of resources loaded.
 spec:
   - https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-decodedbodysize
   - https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-encodedbodysize


### PR DESCRIPTION
**Before:**

> The decodedSize, encodedSize, and transferSize properties of the PerformanceResourceTiming API reports the size of resources loaded

**After:**

> The decodedBodySize, encodedBodySize, and transferSize properties of the PerformanceResourceTiming API reports the size of resources loaded

I know nothing about this feature, but this is what's documented at MDN.