### PR TITLE
`namespace`: remove Markdown from the feature name

### DIFF
--- a/features/namespace.yml
+++ b/features/namespace.yml
@@ -1,4 +1,4 @@
-name: "`@namespace`"
+name: "@namespace"
 description: The `@namespace` CSS rule sets a default namespace or namespace prefix. Namespace prefixes allow CSS selectors to distinguish elements with the same name but different document types, such as the HTML `<a>` element and the SVG `<a>` element.
 spec: https://drafts.csswg.org/css-namespaces-3/#declaration
 caniuse: css-namespaces


### PR DESCRIPTION
The `name` field is non-Markdown plain text, unlike `description`.