### PR TITLE
Add a key to WebNFC

### DIFF
--- a/features/web-nfc.yml
+++ b/features/web-nfc.yml
@@ -2,3 +2,31 @@ name: Web NFC
 description: The `NDEFReader` API reads and writes messages to near-field communication (NFC) tags.
 spec: https://w3c.github.io/web-nfc/
 caniuse: webnfc
+compat_features:
+  - api.NDEFMessage
+  - api.NDEFMessage.NDEFMessage
+  - api.NDEFMessage.records
+  - api.NDEFMessage.secure_context_required
+  - api.NDEFReader
+  - api.NDEFReader.NDEFReader
+  - api.NDEFReader.makeReadOnly
+  - api.NDEFReader.reading_event
+  - api.NDEFReader.readingerror_event
+  - api.NDEFReader.scan
+  - api.NDEFReader.secure_context_required
+  - api.NDEFReader.write
+  - api.NDEFReadingEvent
+  - api.NDEFReadingEvent.NDEFReadingEvent
+  - api.NDEFReadingEvent.message
+  - api.NDEFReadingEvent.secure_context_required
+  - api.NDEFReadingEvent.serialNumber
+  - api.NDEFRecord
+  - api.NDEFRecord.NDEFRecord
+  - api.NDEFRecord.data
+  - api.NDEFRecord.encoding
+  - api.NDEFRecord.id
+  - api.NDEFRecord.lang
+  - api.NDEFRecord.mediaType
+  - api.NDEFRecord.recordType
+  - api.NDEFRecord.secure_context_required
+  - api.NDEFRecord.toRecords

--- a/features/web-nfc.yml.dist
+++ b/features/web-nfc.yml.dist
@@ -4,8 +4,11 @@
 status:
   baseline: false
   support:
-    chrome_android: "89"
+    chrome_android: "100"
 compat_features:
+  # baseline: false
+  # support:
+  #   chrome_android: "89"
   - api.NDEFMessage
   - api.NDEFMessage.NDEFMessage
   - api.NDEFMessage.records
@@ -32,3 +35,9 @@ compat_features:
   - api.NDEFRecord.recordType
   - api.NDEFRecord.secure_context_required
   - api.NDEFRecord.toRecords
+
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: false
+  # support:
+  #   chrome_android: "100"
+  - api.NDEFReader.makeReadOnly


### PR DESCRIPTION
Compare with the latest draft file: https://github.com/web-platform-dx/web-features/blob/main/features/draft/spec/web-nfc.yml

See also https://github.com/web-platform-dx/web-features/pull/1087 in which we didn't have `compute_from` yet, I assume. 
Not sure if we want to use `compute_from` here. The effect on the baseline status is basically none, I think.