### PR TITLE
Add more keys to Intersection observer

### DIFF
--- a/features/intersection-observer.yml
+++ b/features/intersection-observer.yml
@@ -1,4 +1,30 @@
 name: Intersection observer
 description: The Intersection Observer API asynchronously observes changes in the intersection of a target element with an ancestor element or with a top-level document's viewport.
 spec: https://w3c.github.io/IntersectionObserver/
+status:
+  compute_from: api.IntersectionObserverEntry.isIntersecting
 caniuse: intersectionobserver
+compat_features:
+  - api.IntersectionObserver
+  - api.IntersectionObserver.IntersectionObserver
+  - api.IntersectionObserver.IntersectionObserver.options_root_parameter_Document
+  - api.IntersectionObserver.delay
+  - api.IntersectionObserver.disconnect
+  - api.IntersectionObserver.observe
+  - api.IntersectionObserver.root
+  - api.IntersectionObserver.rootMargin
+  - api.IntersectionObserver.scrollMargin
+  - api.IntersectionObserver.takeRecords
+  - api.IntersectionObserver.thresholds
+  - api.IntersectionObserver.trackVisibility
+  - api.IntersectionObserver.unobserve
+  - api.IntersectionObserverEntry
+  - api.IntersectionObserverEntry.IntersectionObserverEntry
+  - api.IntersectionObserverEntry.boundingClientRect
+  - api.IntersectionObserverEntry.intersectionRatio
+  - api.IntersectionObserverEntry.intersectionRect
+  - api.IntersectionObserverEntry.isIntersecting
+  - api.IntersectionObserverEntry.isVisible
+  - api.IntersectionObserverEntry.rootBounds
+  - api.IntersectionObserverEntry.target
+  - api.IntersectionObserverEntry.time

--- a/features/intersection-observer.yml.dist
+++ b/features/intersection-observer.yml.dist
@@ -67,3 +67,38 @@ compat_features:
   #   safari: "12.1"
   #   safari_ios: "12.2"
   - api.IntersectionObserverEntry.isIntersecting
+
+  # baseline: high
+  # baseline_low_date: 2020-09-16
+  # baseline_high_date: 2023-03-16
+  # support:
+  #   chrome: "81"
+  #   chrome_android: "81"
+  #   edge: "81"
+  #   firefox: "76"
+  #   firefox_android: "79"
+  #   safari: "14"
+  #   safari_ios: "14"
+  - api.IntersectionObserver.IntersectionObserver.options_root_parameter_Document
+
+  # baseline: false
+  # support:
+  #   chrome: "74"
+  #   chrome_android: "74"
+  #   edge: "79"
+  - api.IntersectionObserver.delay
+  - api.IntersectionObserver.trackVisibility
+  - api.IntersectionObserverEntry.isVisible
+
+  # baseline: false
+  # support:
+  #   chrome: "120"
+  #   chrome_android: "120"
+  #   edge: "120"
+  - api.IntersectionObserver.scrollMargin
+
+  # baseline: false
+  # support:
+  #   safari: "12.1"
+  #   safari_ios: "12.2"
+  - api.IntersectionObserverEntry.IntersectionObserverEntry


### PR DESCRIPTION
Compare with the latest draft file: https://github.com/web-platform-dx/web-features/blob/main/features/draft/spec/intersection-observer.yml

Also use `compute_from`. I used `isIntersecting` so that the current status remains the same.