### PR TITLE
Add keys to Background sync

### DIFF
--- a/features/background-sync.yml
+++ b/features/background-sync.yml
@@ -1,6 +1,8 @@
 name: Background sync
 description: The background synchronization API registers a service worker callback to run only when the device is no longer offline. You can use this to let users continue using your app while offline and synchronize with a server after reconnecting.
 spec: https://wicg.github.io/background-sync/spec/
+status:
+  compute_from: api.SyncManager
 compat_features:
   - api.ServiceWorkerGlobalScope.sync_event
   - api.ServiceWorkerRegistration.sync
@@ -11,3 +13,4 @@ compat_features:
   - api.SyncManager
   - api.SyncManager.getTags
   - api.SyncManager.register
+  - api.SyncManager.worker_support

--- a/features/background-sync.yml.dist
+++ b/features/background-sync.yml.dist
@@ -8,6 +8,12 @@ status:
     chrome_android: "49"
     edge: "79"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: false
+  # support:
+  #   chrome: "49"
+  #   chrome_android: "49"
+  #   edge: "79"
   - api.ServiceWorkerGlobalScope.sync_event
   - api.ServiceWorkerRegistration.sync
   - api.SyncEvent
@@ -17,3 +23,10 @@ compat_features:
   - api.SyncManager
   - api.SyncManager.getTags
   - api.SyncManager.register
+
+  # baseline: false
+  # support:
+  #   chrome: "61"
+  #   chrome_android: "61"
+  #   edge: "79"
+  - api.SyncManager.worker_support


### PR DESCRIPTION
Compare with the latest draft file: https://github.com/web-platform-dx/web-features/blob/main/features/draft/spec/background-sync.yml

I also introduced `compute_from` here so that the status remains the same.