### PR TITLE
Add Trusted Types to security group

### DIFF
--- a/features/trusted-types.yml
+++ b/features/trusted-types.yml
@@ -2,5 +2,6 @@ name: Trusted types
 description: Trusted types allow you to lock down insecure parts of the DOM API and prevent client-side cross-site scripting (XSS) attacks.
 spec: https://w3c.github.io/trusted-types/dist/spec/
 caniuse: trusted-types
+group: security
 status:
   compute_from: api.trustedTypes


### PR DESCRIPTION
Wondering which existing features should belong into the newly created security group for https://github.com/w3c-cg/swag/issues/2. So far we have:

- CSP
- Trusted Types (this PR)

Maybe there is more? @wbamberg, do you want to look through https://web-platform-dx.github.io/web-features-explorer/groups/ to see if anything should be added to the group as well?