### PR TITLE
Prepare v2.2.0 release

### DIFF
--- a/packages/web-features/package-lock.json
+++ b/packages/web-features/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-features",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-features",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "tsup": "^8.3.0",

--- a/packages/web-features/package.json
+++ b/packages/web-features/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-features",
   "description": "Curated list of Web platform features",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The brings us up to date with BCD v5.6.9, released yesterday. https://github.com/web-platform-dx/web-features/compare/v2.1.0...HEAD