### PR TITLE
Fix checklist for BCD upgrades workflow

### DIFF
--- a/.github/workflows/bcd_upgrade_checklist.yml
+++ b/.github/workflows/bcd_upgrade_checklist.yml
@@ -3,19 +3,21 @@ name: BCD upgrade
 on:
   pull_request:
     types: [opened]
+permissions:
+  pull-requests: write
 jobs:
   post-comment:
     name: "Post checklist"
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
-      - id: dependency
-        run: |
-          if ! git diff --exit-code -G '@mdn/browser-compat-data' "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}"; then
-            echo "is_bcd=true" >> $GITHUB_OUTPUT
-          fi
-          exit 0
-      - if: ${{ steps.dependency.outputs.is_bcd == 'true' }}
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        continue-on-error: true
+        uses: dependabot/fetch-metadata@dbb049abf0d677abbd7f7eee0375145b417fdd34 #v2.2.0
+
+      - if: ${{ contains(steps.dependabot-metadata.outputs.dependency-names, "@mdn/browser-compat-data" }}
+        continue-on-error: true
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 #v4.0.0
         with:
           issue-number: ${{ github.event.number }}


### PR DESCRIPTION
A follow up to https://github.com/web-platform-dx/web-features/pull/2043.

This workflow on the first attempt: https://github.com/web-platform-dx/web-features/actions/runs/11496579249/job/31998472971?pr=2071#logs

Problems:

- No write permissions for the PR
- No checkout to run the diff against (I tested this bit and I have no idea why this worked on my own repo but not here, even though it obviously SHOULD have failed 🙄)

To fix this, I did these things:

- Switched to using https://github.com/dependabot/fetch-metadata instead (to avoid a slow checkout)

  Unfortunately, this makes the PR basically untestable—you can't force Dependabot to do anything. We'll find out if it works tomorrow, I guess.

- Set `continue-on-error` for both steps, since failures of this workflow shouldn't mark the PR as failing