### PR TITLE
Fix `<samp>` description

### DIFF
--- a/features/samp.yml
+++ b/features/samp.yml
@@ -1,5 +1,5 @@
 name: <samp>
-description: The `<small>` element represents side-comments and small print, like copyright and legal text, styling text in a reduced font size by default.
+description: The `<samp>` element represents a sample or quoted output from a computer program. Styled in a monospace font by default.
 spec: https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-samp-element
 group: html-elements
 compat_features:


### PR DESCRIPTION
This has originally been copied from the `<small>` feature by accident.