### PR TITLE
Update notes on relative colors

### DIFF
--- a/features/relative-color.yml
+++ b/features/relative-color.yml
@@ -3,23 +3,20 @@ description: "The `from` keyword for color functions (`color()`, `hsl()`, `oklch
 spec: https://drafts.csswg.org/css-color-5/#relative-colors
 group: css
 caniuse: css-relative-colors
-# TODO: Revisit when this has shipped in Firefox if we should retroactively
-# claim partial support in Chrome and Safari for some versions. If so, also make
-# the same changes in caniuse.
+# TODO: Full implementation in Chromium 125, Safari 18, Firefox 128. 
+# This will move baseline_low from 2024-07-09 to 2024-10-??.
+# Caniuse also needs cleanup- see https://github.com/Fyrd/caniuse/issues/7191
 compat_features:
   # These are the only two features that don't use partial implementation for
   # some browser, so they can represent initial support for the feature.
   - css.types.color.lab.relative_syntax
   - css.types.color.oklab.relative_syntax
-  # Partial implementation claims that need further research, see
-  # https://github.com/mdn/browser-compat-data/issues/22961
+  # Following BCD keys pending https://github.com/mdn/browser-compat-data/issues/24528.
   # - css.types.color.color.relative_syntax
   # - css.types.color.hsl.relative_syntax
   # - css.types.color.hwb.relative_syntax
   # - css.types.color.lch.relative_syntax
   # - css.types.color.oklch.relative_syntax
-  # Seemingly incorrect notes, see
-  # https://github.com/mdn/browser-compat-data/pull/22960
   # - css.types.color.rgb.relative_syntax
   # calc.color_component is tagged as `web-features:calc`, but should be moved here instead.
   #- css.types.calc.color_component

--- a/features/relative-color.yml
+++ b/features/relative-color.yml
@@ -3,7 +3,7 @@ description: "The `from` keyword for color functions (`color()`, `hsl()`, `oklch
 spec: https://drafts.csswg.org/css-color-5/#relative-colors
 group: css
 caniuse: css-relative-colors
-# TODO: Full implementation in Chromium 125, Safari 18, Firefox 128. 
+# TODO: Full implementation in Chromium 125, Safari 18, Firefox 128.
 # This will move baseline_low from 2024-07-09 to 2024-10-??.
 # Caniuse also needs cleanup- see https://github.com/Fyrd/caniuse/issues/7191
 compat_features:

--- a/features/relative-color.yml
+++ b/features/relative-color.yml
@@ -3,9 +3,9 @@ description: "The `from` keyword for color functions (`color()`, `hsl()`, `oklch
 spec: https://drafts.csswg.org/css-color-5/#relative-colors
 group: css
 caniuse: css-relative-colors
-# TODO: Sort out support with https://github.com/mdn/browser-compat-data/issues/24528 
+# TODO: Sort out support with https://github.com/mdn/browser-compat-data/issues/24528
 # Support for Relative colors in Chromium 119, Safari 16.4, Firefox 128.
-# Support for currentColor in relative colors in Chromium 131, Safari 16.4, Firefox 133. 
+# Support for currentColor in relative colors in Chromium 131, Safari 16.4, Firefox 133.
 # We don't need separate features, but should pin the feature on one of those.
 compat_features:
   # These are the only two features that don't use partial implementation for

--- a/features/relative-color.yml
+++ b/features/relative-color.yml
@@ -3,15 +3,15 @@ description: "The `from` keyword for color functions (`color()`, `hsl()`, `oklch
 spec: https://drafts.csswg.org/css-color-5/#relative-colors
 group: css
 caniuse: css-relative-colors
-# TODO: Full implementation in Chromium 125, Safari 18, Firefox 128.
-# This will move baseline_low from 2024-07-09 to 2024-10-??.
-# Caniuse also needs cleanup- see https://github.com/Fyrd/caniuse/issues/7191
+# TODO: Sort out support with https://github.com/mdn/browser-compat-data/issues/24528 
+# Support for Relative colors in Chromium 119, Safari 16.4, Firefox 128.
+# Support for currentColor in relative colors in Chromium 131, Safari 16.4, Firefox 133. 
+# We don't need separate features, but should pin the feature on one of those.
 compat_features:
   # These are the only two features that don't use partial implementation for
   # some browser, so they can represent initial support for the feature.
   - css.types.color.lab.relative_syntax
   - css.types.color.oklab.relative_syntax
-  # Following BCD keys pending https://github.com/mdn/browser-compat-data/issues/24528.
   # - css.types.color.color.relative_syntax
   # - css.types.color.hsl.relative_syntax
   # - css.types.color.hwb.relative_syntax


### PR DESCRIPTION
This does not change keys, but just updates notes on relative colors.

Related issues-

- https://github.com/Fyrd/caniuse/issues/7191
- https://github.com/mdn/browser-compat-data/issues/24528