### PR TITLE
Add direction to vertical form controls

### DIFF
--- a/features/vertical-form-controls.yml
+++ b/features/vertical-form-controls.yml
@@ -1,6 +1,9 @@
 name: Vertical form controls
-description: The `writing-mode` property orients form elements (such as radio buttons, progress bars, or select menus) vertically when the writing mode is `vertical-lr` or `vertical-rl`.
+description: The `writing-mode` CSS property orients form elements (such as radio buttons, progress bars, or select menus) vertically when the writing mode is `vertical-lr` or `vertical-rl`. The `direction` CSS property sets whether inputs flow from top to bottom or bottom to top.
 group: css
 spec: https://drafts.csswg.org/css-writing-modes-4/#vertical-modes
+status:
+  compute_from: css.properties.writing-mode.vertical_oriented_form_controls
 compat_features:
   - css.properties.writing-mode.vertical_oriented_form_controls
+  - css.properties.direction.vertical_slider_direction

--- a/features/vertical-form-controls.yml.dist
+++ b/features/vertical-form-controls.yml.dist
@@ -13,4 +13,22 @@ status:
     safari: "17.4"
     safari_ios: "17.4"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: low
+  # baseline_low_date: 2024-04-18
+  # support:
+  #   chrome: "124"
+  #   chrome_android: "124"
+  #   edge: "124"
+  #   firefox: "120"
+  #   firefox_android: "120"
+  #   safari: "17.4"
+  #   safari_ios: "17.4"
   - css.properties.writing-mode.vertical_oriented_form_controls
+
+  # baseline: false
+  # support:
+  #   chrome: "124"
+  #   chrome_android: "124"
+  #   edge: "124"
+  - css.properties.direction.vertical_slider_direction


### PR DESCRIPTION
This adds using `direction` to change slider direction. 

Firefox and Safari only have partial support per https://github.com/mdn/content/pull/32142#issuecomment-1961833182. I checked and that still is the case. I chose to `compute_from: writing-mode.vertical_oriented_form_controls` but alternatively we could move the feature to `baseline: false`. 