### PR TITLE
Update drafts workflow: document tests workaround

### DIFF
--- a/.github/workflows/update_draft_features_weekly.yml
+++ b/.github/workflows/update_draft_features_weekly.yml
@@ -29,6 +29,8 @@ jobs:
           body: |
             This is an auto-generated PR with draft features by spec updates.
 
+            To let the tests run, close this PR then immediately reopen it.
+
             See https://github.com/web-platform-dx/web-features/blob/main/.github/workflows/update_draft_features_weekly.yml for details.
           labels: |
             generated


### PR DESCRIPTION
Actions-generated PRs won't trigger more workflow runs. This addition to the commit message says how to overcome this limitation.