### PR TITLE
Add CSSImportRule.supportsText key to @supports

### DIFF
--- a/features/supports.yml
+++ b/features/supports.yml
@@ -6,8 +6,7 @@ group: css
 status:
   compute_from: css.at-rules.supports
 compat_features:
-  # TODO: see discussion on https://github.com/web-platform-dx/web-features/pull/1353#discussion_r1673871428
-  # - api.CSSImportRule.supportsText
+  - api.CSSImportRule.supportsText
   - api.CSSSupportsRule
   - css.at-rules.import.supports
   - css.at-rules.supports

--- a/features/supports.yml.dist
+++ b/features/supports.yml.dist
@@ -55,6 +55,18 @@ compat_features:
   - css.at-rules.supports.font-format
   - css.at-rules.supports.font-tech
 
+  # baseline: low
+  # baseline_low_date: 2024-05-13
+  # support:
+  #   chrome: "121"
+  #   chrome_android: "121"
+  #   edge: "121"
+  #   firefox: "114"
+  #   firefox_android: "114"
+  #   safari: "17.5"
+  #   safari_ios: "17.5"
+  - api.CSSImportRule.supportsText
+
   # baseline: false
   # support:
   #   chrome: "122"


### PR DESCRIPTION
The linked issue says to sort this out on the long tail, which I think we're at. 
https://github.com/web-platform-dx/web-features/pull/1353#discussion_r1673871428

Essentially, `api.CSSImportRule.supportsText` has some data issues, but does not impact baseline. 

In looking into it, Chrome and Firefox data is correct. In both, the CSSOM portions were shipped first. In Chrome, that was accidental, and in Firefox, it was behind a flag in 114, but the CSSOM was still accessible.

For Safari, it looks like `css.at-rules.import.supports` should also be marked as 17.5. I opened https://github.com/mdn/browser-compat-data/issues/24842. I don't think this change needs to be blocked on that.