### PR TITLE
Add missing keys to masks

### DIFF
--- a/features/masks.yml
+++ b/features/masks.yml
@@ -3,6 +3,8 @@ description: The `mask` CSS property (and several longhand properties) partially
 spec: https://drafts.fxtf.org/css-masking-1/#positioned-masks
 group: clipping-shapes-masking
 caniuse: css-masks
+status:
+  compute_from: css.properties.mask
 compat_features:
   - css.properties.mask
   - css.properties.mask-clip
@@ -19,6 +21,9 @@ compat_features:
   - css.properties.mask-mode.luminance
   - css.properties.mask-mode.match-source
   - css.properties.mask-origin
+  - css.properties.mask-origin.fill-box
+  - css.properties.mask-origin.stroke-box
+  - css.properties.mask-origin.view-box
   - css.properties.mask-position
   - css.properties.mask-repeat
   - css.properties.mask-size

--- a/features/masks.yml.dist
+++ b/features/masks.yml.dist
@@ -13,6 +13,17 @@ status:
     safari: "15.4"
     safari_ios: "15.4"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: low
+  # baseline_low_date: 2023-12-07
+  # support:
+  #   chrome: "120"
+  #   chrome_android: "120"
+  #   edge: "120"
+  #   firefox: "53"
+  #   firefox_android: "53"
+  #   safari: "15.4"
+  #   safari_ios: "15.4"
   - css.properties.mask
   - css.properties.mask-clip
   - css.properties.mask-composite
@@ -31,3 +42,14 @@ compat_features:
   - css.properties.mask-position
   - css.properties.mask-repeat
   - css.properties.mask-size
+
+  # baseline: false
+  # support:
+  #   chrome: "120"
+  #   chrome_android: "120"
+  #   edge: "120"
+  #   firefox: "53"
+  #   firefox_android: "53"
+  - css.properties.mask-origin.fill-box
+  - css.properties.mask-origin.stroke-box
+  - css.properties.mask-origin.view-box


### PR DESCRIPTION
This sets a `compute_from` to not change the baseline status.