### PR TITLE
Add missing shape keys

### DIFF
--- a/features/shape-outside.yml
+++ b/features/shape-outside.yml
@@ -15,3 +15,4 @@ compat_features:
   - css.properties.shape-outside.inset
   - css.properties.shape-outside.path
   - css.properties.shape-outside.polygon
+  - css.properties.shape-image-threshold.percentages

--- a/features/shape-outside.yml.dist
+++ b/features/shape-outside.yml.dist
@@ -37,5 +37,14 @@ compat_features:
   - css.properties.shape-outside.polygon
 
   # baseline: false
+  # support:
+  #   chrome: "78"
+  #   chrome_android: "78"
+  #   edge: "79"
+  #   firefox: "70"
+  #   firefox_android: "79"
+  - css.properties.shape-image-threshold.percentages
+
+  # baseline: false
   # support: {}
   - css.properties.shape-outside.path

--- a/features/shapes.yml
+++ b/features/shapes.yml
@@ -13,4 +13,5 @@ compat_features:
   - css.types.basic-shape.inset
   - css.types.basic-shape.polygon
   - css.types.basic-shape.rect
+  - css.types.basic-shape.shape
   - css.types.basic-shape.xywh

--- a/features/shapes.yml.dist
+++ b/features/shapes.yml.dist
@@ -41,3 +41,7 @@ compat_features:
   #   safari_ios: "17.2"
   - css.types.basic-shape.rect
   - css.types.basic-shape.xywh
+
+  # baseline: false
+  # support: {}
+  - css.types.basic-shape.shape


### PR DESCRIPTION
No changes to baseline due to existing `compute_from`s.