### PR TITLE
Prepare release v2.4.0

### DIFF
--- a/packages/web-features/package-lock.json
+++ b/packages/web-features/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-features",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-features",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "tsup": "^8.3.5",

--- a/packages/web-features/package.json
+++ b/packages/web-features/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-features",
   "description": "Curated list of Web platform features",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release for BCD v5.6.11. https://github.com/web-platform-dx/web-features/compare/v2.3.0...4277ec4

As of 4277ec4:

- 1 new feature
- 63.5% coverage of BCD