### PR TITLE
Flag the "Towards features" document as historical

### DIFF
--- a/towards-features.md
+++ b/towards-features.md
@@ -1,3 +1,6 @@
+> [!Note]
+> **This document should be seen as historical**. It was put together in 2022, when the web-features project started, to inform initial development discussions. The web-features project has made significant progress towards establishing a common list of web features since then. Learnings from this work have not been reflected back in this document.
+
 # Towards a common list of web features
 
 ## Abstract


### PR DESCRIPTION
We haven't reviewed the "Towards a common list of web features" document since work on the web-features project started. It may contain content that we would no longer agree with, or that we would consider incomplete or outdated.

It could be worthwhile to revisit the document in a not too distant future. In the meantime, I'm proposing to add an introductory note to flag the document as historical.

Cc @captainbrosset, @atopal