### PR TITLE
Prepare release v2.5.0

### DIFF
--- a/packages/web-features/package-lock.json
+++ b/packages/web-features/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-features",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-features",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "tsup": "^8.3.5",

--- a/packages/web-features/package.json
+++ b/packages/web-features/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-features",
   "description": "Curated list of Web platform features",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release for BCD 5.6.12. https://github.com/web-platform-dx/web-features/compare/v2.4.0...HEAD

As of 69d71c4a62cbc9797bafb74f3c4647a371974fd6:

- 7 new features
- 64.1% coverage of BCD