### PR TITLE
Add more keys to SAB in WebGL

### DIFF
--- a/features/webgl-sab.yml
+++ b/features/webgl-sab.yml
@@ -7,16 +7,31 @@ group: webgl
 compat_features:
   - api.WebGL2RenderingContext.bufferData.srcData_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.bufferSubData.srcData_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.clearBufferfv.values_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.clearBufferiv.values_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.clearBufferuiv.values_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.compressedTexImage2D.pixels_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.compressedTexImage3D.pixels_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.compressedTexSubImage2D.srcData_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.getBufferSubData.dstData_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.readPixels.pixels_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.texImage3D.srcData_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.texSubImage3D.srcData_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.uniformMatrix2fv.value_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.uniformMatrix2x3fv.data_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.uniformMatrix2x4fv.data_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.uniformMatrix3fv.value_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.uniformMatrix3x2fv.data_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.uniformMatrix3x4fv.data_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.uniformMatrix4fv.value_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.uniformMatrix4x2fv.data_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.uniformMatrix4x3fv.data_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.vertexAttrib1fv.value_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.vertexAttrib2fv.value_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.vertexAttrib3fv.value_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.vertexAttrib4fv.value_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.vertexAttribI4iv.value_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.vertexAttribI4uiv.value_param_accepts_SharedArrayBuffer
   - api.WebGLRenderingContext.compressedTexImage2D.pixels_param_accepts_SharedArrayBuffer
   - api.WebGLRenderingContext.vertexAttrib1fv.value_param_accepts_SharedArrayBuffer
   - api.WebGLRenderingContext.vertexAttrib2fv.value_param_accepts_SharedArrayBuffer

--- a/features/webgl-sab.yml.dist
+++ b/features/webgl-sab.yml.dist
@@ -20,16 +20,31 @@ compat_features:
   #   firefox_android: "79"
   - api.WebGL2RenderingContext.bufferData.srcData_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.bufferSubData.srcData_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.clearBufferfv.values_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.clearBufferiv.values_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.clearBufferuiv.values_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.compressedTexImage2D.pixels_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.compressedTexImage3D.pixels_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.compressedTexSubImage2D.srcData_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.getBufferSubData.dstData_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.readPixels.pixels_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.texImage3D.srcData_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.texSubImage3D.srcData_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.uniformMatrix2fv.value_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.uniformMatrix2x3fv.data_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.uniformMatrix2x4fv.data_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.uniformMatrix3fv.value_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.uniformMatrix3x2fv.data_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.uniformMatrix3x4fv.data_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.uniformMatrix4fv.value_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.uniformMatrix4x2fv.data_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.uniformMatrix4x3fv.data_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.vertexAttrib1fv.value_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.vertexAttrib2fv.value_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.vertexAttrib3fv.value_param_accepts_SharedArrayBuffer
   - api.WebGL2RenderingContext.vertexAttrib4fv.value_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.vertexAttribI4iv.value_param_accepts_SharedArrayBuffer
+  - api.WebGL2RenderingContext.vertexAttribI4uiv.value_param_accepts_SharedArrayBuffer
 
   # baseline: false
   # support:


### PR DESCRIPTION
I missed this in https://github.com/web-platform-dx/web-features/pull/2067.
The WebGL2 draft feature also has additional keys (and I wasn't expecting this feature to be 30 keys large in total)