### PR TITLE
Add more keys to HTTP/1.1

### DIFF
--- a/features/http11.yml
+++ b/features/http11.yml
@@ -1,3 +1,55 @@
 name: HTTP/1.1
 description: HTTP/1.1 is a network protocol used by browsers and servers. It has been superseded by HTTP/2 and HTTP/3.
 spec: https://httpwg.org/specs/rfc9112.html
+status:
+  compute_from: http.methods.GET
+compat_features:
+  - http.headers.Accept
+  - http.headers.Accept-Encoding
+  - http.headers.Accept-Language
+  - http.headers.Accept-Ranges
+  - http.headers.Age
+  - http.headers.Authorization
+  - http.headers.Authorization.Basic
+  - http.headers.Cache-Control
+  - http.headers.Connection
+  - http.headers.Content-Disposition
+  - http.headers.Content-Encoding
+  - http.headers.Content-Language
+  - http.headers.Content-Length
+  - http.headers.Content-Location
+  - http.headers.Content-Range
+  - http.headers.Content-Type
+  - http.headers.Date
+  - http.headers.ETag
+  - http.headers.Expires
+  - http.headers.From
+  - http.headers.Host
+  - http.headers.If-Match
+  - http.headers.If-Modified-Since
+  - http.headers.If-None-Match
+  - http.headers.If-Range
+  - http.headers.If-Unmodified-Since
+  - http.headers.Keep-Alive
+  - http.headers.Last-Modified
+  - http.headers.Location
+  - http.headers.Origin
+  - http.headers.Proxy-Authenticate
+  - http.headers.Range
+  - http.headers.Referer
+  - http.headers.Server
+  - http.headers.TE
+  - http.headers.Trailer
+  - http.headers.Transfer-Encoding
+  - http.headers.User-Agent
+  - http.headers.Vary
+  - http.headers.Via
+  - http.headers.WWW-Authenticate
+  - http.headers.WWW-Authenticate.Basic
+  - http.methods.CONNECT
+  - http.methods.DELETE
+  - http.methods.GET
+  - http.methods.HEAD
+  - http.methods.OPTIONS
+  - http.methods.POST
+  - http.methods.PUT

--- a/features/http11.yml.dist
+++ b/features/http11.yml.dist
@@ -14,4 +14,76 @@ status:
     safari: "1"
     safari_ios: "1"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: high
+  # baseline_low_date: 2015-07-29
+  # baseline_high_date: 2018-01-29
+  # support:
+  #   chrome: "1"
+  #   chrome_android: "18"
+  #   edge: "12"
+  #   firefox: "1"
+  #   firefox_android: "4"
+  #   safari: "1"
+  #   safari_ios: "1"
+  - http.headers.Accept
+  - http.headers.Accept-Encoding
+  - http.headers.Accept-Language
+  - http.headers.Accept-Ranges
+  - http.headers.Age
+  - http.headers.Authorization
+  - http.headers.Authorization.Basic
+  - http.headers.Cache-Control
+  - http.headers.Connection
+  - http.headers.Content-Disposition
+  - http.headers.Content-Encoding
+  - http.headers.Content-Language
+  - http.headers.Content-Length
+  - http.headers.Content-Location
+  - http.headers.Content-Range
+  - http.headers.Content-Type
+  - http.headers.Date
+  - http.headers.ETag
+  - http.headers.Expires
+  - http.headers.From
+  - http.headers.Host
+  - http.headers.If-Match
+  - http.headers.If-Modified-Since
+  - http.headers.If-None-Match
+  - http.headers.If-Range
+  - http.headers.If-Unmodified-Since
+  - http.headers.Keep-Alive
+  - http.headers.Last-Modified
+  - http.headers.Location
+  - http.headers.Proxy-Authenticate
+  - http.headers.Range
+  - http.headers.Referer
+  - http.headers.Server
+  - http.headers.TE
+  - http.headers.Trailer
+  - http.headers.Transfer-Encoding
+  - http.headers.User-Agent
+  - http.headers.Vary
+  - http.headers.Via
+  - http.headers.WWW-Authenticate
+  - http.headers.WWW-Authenticate.Basic
+  - http.methods.CONNECT
+  - http.methods.DELETE
   - http.methods.GET
+  - http.methods.HEAD
+  - http.methods.OPTIONS
+  - http.methods.POST
+  - http.methods.PUT
+
+  # baseline: high
+  # baseline_low_date: 2020-07-28
+  # baseline_high_date: 2023-01-28
+  # support:
+  #   chrome: "1"
+  #   chrome_android: "18"
+  #   edge: "12"
+  #   firefox: "70"
+  #   firefox_android: "79"
+  #   safari: "1"
+  #   safari_ios: "1"
+  - http.headers.Origin


### PR DESCRIPTION
I think we wanted to do this a while ago but back then 1) BCD had no real version numbers for many HTTP/1.1 keys and 2) we had no `compute_from`. 