### PR TITLE
Add missing keys from css-align

### DIFF
--- a/features/absolute-positioning.yml
+++ b/features/absolute-positioning.yml
@@ -2,5 +2,10 @@ name: Absolute positioning
 description: "The `position: absolute` CSS declaration removes an element from the normal flow and positions it relative to its containing block, which is often the root element, or closest positioned ancestor."
 spec: https://drafts.csswg.org/css-position-3/#abspos-insets
 group: positioning
+status:
+  compute_from: css.properties.position.absolute
 compat_features:
   - css.properties.position.absolute
+  - css.properties.place-self.position_absolute_context
+  - css.properties.align-self.position_absolute_context
+  - css.properties.justify-self.position_absolute_context

--- a/features/absolute-positioning.yml.dist
+++ b/features/absolute-positioning.yml.dist
@@ -14,4 +14,25 @@ status:
     safari: "1"
     safari_ios: "1"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: high
+  # baseline_low_date: 2015-07-29
+  # baseline_high_date: 2018-01-29
+  # support:
+  #   chrome: "1"
+  #   chrome_android: "18"
+  #   edge: "12"
+  #   firefox: "1"
+  #   firefox_android: "4"
+  #   safari: "1"
+  #   safari_ios: "1"
   - css.properties.position.absolute
+
+  # baseline: false
+  # support:
+  #   chrome: "122"
+  #   chrome_android: "122"
+  #   edge: "122"
+  - css.properties.align-self.position_absolute_context
+  - css.properties.justify-self.position_absolute_context
+  - css.properties.place-self.position_absolute_context

--- a/features/grid.yml
+++ b/features/grid.yml
@@ -6,21 +6,25 @@ caniuse: css-grid
 status:
   compute_from: css.properties.grid
 compat_features:
-  - css.types.flex
   - css.properties.align-content.grid_context
   - css.properties.align-items.grid_context
+  - css.properties.align-items.grid_context.start_end
   - css.properties.align-self.grid_context
-  - css.properties.justify-content.grid_context
-  - css.properties.justify-items.grid_context
-  - css.properties.justify-self.grid_context
+  - css.properties.column-gap.grid_context
   - css.properties.display.grid
   - css.properties.display.inline-grid
+  - css.properties.gap
+  - css.properties.gap.grid_context
+  - css.properties.gap.grid_context.calc_values
+  - css.properties.gap.grid_context.percentage_values
   - css.properties.grid
   - css.properties.grid-area
+  - css.properties.grid-auto-columns
   - css.properties.grid-auto-flow
   - css.properties.grid-auto-flow.column
   - css.properties.grid-auto-flow.dense
   - css.properties.grid-auto-flow.row
+  - css.properties.grid-auto-rows
   - css.properties.grid-column
   - css.properties.grid-column-end
   - css.properties.grid-column-start
@@ -28,7 +32,6 @@ compat_features:
   - css.properties.grid-row-end
   - css.properties.grid-row-start
   - css.properties.grid-template
-  - css.properties.grid-template.none
   - css.properties.grid-template-areas
   - css.properties.grid-template-areas.none
   - css.properties.grid-template-columns
@@ -38,23 +41,23 @@ compat_features:
   - css.properties.grid-template-columns.min-content
   - css.properties.grid-template-columns.minmax
   - css.properties.grid-template-columns.none
+  - css.properties.grid-template-columns.repeat
   - css.properties.grid-template-rows
-  - css.properties.grid-template-rows.fit-content
-  - css.properties.grid-template-rows.minmax
   - css.properties.grid-template-rows.auto
+  - css.properties.grid-template-rows.fit-content
   - css.properties.grid-template-rows.max-content
   - css.properties.grid-template-rows.min-content
+  - css.properties.grid-template-rows.minmax
   - css.properties.grid-template-rows.none
-  - css.properties.column-gap.grid_context
-  - css.properties.gap.grid_context
-  - css.properties.gap.grid_context.percentage_values
-  - css.properties.row-gap.grid_context
-  - css.properties.gap.grid_context.calc_values
-  - css.properties.align-items.grid_context.start_end
+  - css.properties.grid-template-rows.repeat
+  - css.properties.grid-template.none
+  - css.properties.justify-content.grid_context
+  - css.properties.justify-items.grid_context
+  - css.properties.justify-self
+  - css.properties.justify-self.grid_context
+  - css.properties.place-content.grid_context
   - css.properties.place-items.grid_context
   - css.properties.place-self.grid_context
-  - css.properties.place-content.grid_context
-  - css.properties.grid-auto-columns
-  - css.properties.grid-auto-rows
-  - css.properties.grid-template-columns.repeat
-  - css.properties.grid-template-rows.repeat
+  - css.properties.row-gap
+  - css.properties.row-gap.grid_context
+  - css.types.flex

--- a/features/grid.yml.dist
+++ b/features/grid.yml.dist
@@ -31,6 +31,19 @@ compat_features:
   # baseline_low_date: 2017-10-17
   # baseline_high_date: 2020-04-17
   # support:
+  #   chrome: "47"
+  #   chrome_android: "47"
+  #   edge: "16"
+  #   firefox: "52"
+  #   firefox_android: "52"
+  #   safari: "10.1"
+  #   safari_ios: "10.3"
+  - css.properties.row-gap
+
+  # baseline: high
+  # baseline_low_date: 2017-10-17
+  # baseline_high_date: 2020-04-17
+  # support:
   #   chrome: "57"
   #   chrome_android: "52"
   #   edge: "16"
@@ -55,6 +68,7 @@ compat_features:
   #   safari: "10.1"
   #   safari_ios: "10.3"
   - css.properties.justify-items.grid_context
+  - css.properties.justify-self
   - css.properties.justify-self.grid_context
 
   # ⬇️ Same status as overall feature ⬇️
@@ -71,6 +85,7 @@ compat_features:
   #   safari_ios: "10.3"
   - css.properties.display.grid
   - css.properties.display.inline-grid
+  - css.properties.gap
   - css.properties.grid
   - css.properties.grid-area
   - css.properties.grid-auto-flow

--- a/features/multi-column.yml
+++ b/features/multi-column.yml
@@ -19,3 +19,4 @@ compat_features:
   - css.properties.column-rule-color
   - css.properties.column-rule-style
   - css.properties.column-rule-width
+  - css.properties.gap.multicol_context

--- a/features/multi-column.yml.dist
+++ b/features/multi-column.yml.dist
@@ -74,6 +74,19 @@ compat_features:
   #   safari_ios: "10"
   - css.properties.column-gap.multicol_context
 
+  # baseline: high
+  # baseline_low_date: 2021-04-26
+  # baseline_high_date: 2023-10-26
+  # support:
+  #   chrome: "66"
+  #   chrome_android: "66"
+  #   edge: "16"
+  #   firefox: "61"
+  #   firefox_android: "61"
+  #   safari: "14.1"
+  #   safari_ios: "14.5"
+  - css.properties.gap.multicol_context
+
   # baseline: false
   # support:
   #   chrome: "66"


### PR DESCRIPTION
Root properties were added to where they were first supported.

(There are some remaining keys in css-align that will be dealt with separately)