### PR TITLE
Add a semi-automated release workflow

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,36 @@
+name: Prepare web-features release
+
+on:
+  workflow_dispatch:
+    inputs:
+      semverLevel:
+        description: "Bump to semver level"
+        required: true
+        type: choice
+        default: "minor"
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  open_pr:
+    name: Open PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+      - run: npm ci
+      - name: ./scripts/release.ts init
+        run: npx tsx ./scripts/release.ts init --target-repo=$REPO --reviewers=$ACTOR $SEMVER_LEVEL
+        env:
+          ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SEMVER_LEVEL: ${{ inputs.semverLevel }}

--- a/scripts/release-pull-description.md
+++ b/scripts/release-pull-description.md
@@ -1,1 +1,1 @@
-⚠ Caution! Merging this PR triggers a release. Continue reading before merging. ⚠
+This is a generated release pull request. Don't merge if you're not ready to carry out the release.


### PR DESCRIPTION
This PR adds a workflow to run on demand for new releases. It's more of a proof of concept at this point—there's still some work to do to automatically clean up the release notes, prepopulate with some stats, and so on. But at very least, this means that one owner can cut a release, without the need for the (trivial) review of the `package.json` file.

<img width="361" alt="Example of the proposed GitHub workflow dispatch UI" src="https://github.com/user-attachments/assets/e71b4f99-9dcc-43be-b1c3-73fd3bad0217">
