### PR TITLE
Add missing media query key

### DIFF
--- a/features/media-queries.yml
+++ b/features/media-queries.yml
@@ -15,6 +15,7 @@ compat_features:
   - css.at-rules.media.orientation
   - css.at-rules.media.aspect-ratio
   - css.types.ratio
+  - css.types.ratio.number_value
   - css.at-rules.media.color-index
   - css.at-rules.media.calc
   - css.at-rules.media.media_features

--- a/features/media-queries.yml.dist
+++ b/features/media-queries.yml.dist
@@ -140,3 +140,7 @@ compat_features:
   #   firefox: "59"
   #   firefox_android: "59"
   - css.at-rules.media.media_query_values
+
+  # baseline: false
+  # support: {}
+  - css.types.ratio.number_value


### PR DESCRIPTION
The BCD data here is incorrect, and should have full support- see https://github.com/mdn/browser-compat-data/issues/25034.

Since this feature has a compute_from, adding this key doesn't change baseline, and I don't think we need to block on BCD resolution.