### PR TITLE
Advance review date on the Baseline definition

### DIFF
--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -121,7 +121,7 @@ This is but one of several possible stories to help keep in mind the needs and c
 The WebDX community group, through the [web-platform-dx/web-features-set owners group](../GOVERNANCE.md), maintains this document.
 Based on WebDX community group research, the web-features owners group decides matters such as the core browser set, releases, editorial overrides, and so on.
 
-The status definition is due for review by the governance group on 7 November 2024.
+The status definition is due for review by the governance group on 1 June 2025.
 
 ## Status definition
 


### PR DESCRIPTION
Today, the web-features owners group met for our quarterly governance call. We reviewed the definition and decided to make no changes today and bring the definition up for review again next year.

That said, we acknowledge that work at the end of this year and the beginning of next (such as dealing with discouraged features) might lead to changes to the Baseline definition sooner. In any case, we'll revisit the definition in about six months.

(We agreed on the call to this date change, so I wasn't planning to request reviews from the entire owners group.)