### PR TITLE
Add missing flexbox, font-face and text-emphasis keys

### DIFF
--- a/features/flexbox.yml
+++ b/features/flexbox.yml
@@ -46,6 +46,7 @@ compat_features:
   - css.properties.flex-direction.row-reverse
   - css.properties.flex-flow
   - css.properties.flex-grow
+  - css.properties.flex-grow.less_than_zero_animate
   - css.properties.flex-shrink
   - css.properties.flex-wrap
   - css.properties.flex-wrap.nowrap

--- a/features/flexbox.yml.dist
+++ b/features/flexbox.yml.dist
@@ -359,6 +359,15 @@ compat_features:
 
   # baseline: false
   # support:
+  #   chrome: "49"
+  #   chrome_android: "49"
+  #   edge: "79"
+  #   firefox: "32"
+  #   firefox_android: "32"
+  - css.properties.flex-grow.less_than_zero_animate
+
+  # baseline: false
+  # support:
   #   firefox: "52"
   #   firefox_android: "52"
   - css.properties.align-content.flex_context.last_baseline

--- a/features/font-face.yml
+++ b/features/font-face.yml
@@ -17,6 +17,7 @@ compat_features:
   - css.at-rules.font-face.src
   - css.at-rules.font-face.src.drop_invalid_item
   - css.at-rules.font-face.src.format_keyword
+  - css.at-rules.font-face.src.format_variations
   - css.at-rules.font-face.src.tech_keyword
   - css.at-rules.font-face.unicode-range
   - css.at-rules.font-face.WOFF

--- a/features/font-face.yml.dist
+++ b/features/font-face.yml.dist
@@ -96,6 +96,19 @@ compat_features:
   #   safari_ios: "10"
   - css.at-rules.font-face.WOFF_2
 
+  # baseline: high
+  # baseline_low_date: 2018-09-05
+  # baseline_high_date: 2021-03-05
+  # support:
+  #   chrome: "66"
+  #   chrome_android: "66"
+  #   edge: "17"
+  #   firefox: "62"
+  #   firefox_android: "62"
+  #   safari: "11"
+  #   safari_ios: "11"
+  - css.at-rules.font-face.src.format_variations
+
   # baseline: low
   # baseline_low_date: 2023-09-18
   # support:

--- a/features/text-emphasis.yml
+++ b/features/text-emphasis.yml
@@ -8,6 +8,7 @@ compat_features:
   - css.properties.text-emphasis
   - css.properties.text-emphasis-color
   - css.properties.text-emphasis-position
+  - css.properties.text-emphasis-position.auto
   - css.properties.text-emphasis-position.left
   - css.properties.text-emphasis-position.over
   - css.properties.text-emphasis-position.right

--- a/features/text-emphasis.yml.dist
+++ b/features/text-emphasis.yml.dist
@@ -76,3 +76,9 @@ compat_features:
   #   safari_ios: ≤13.4
   - css.properties.text-emphasis-position.over
   - css.properties.text-emphasis-position.under
+
+  # baseline: false
+  # support:
+  #   firefox: "132"
+  #   firefox_android: "132"
+  - css.properties.text-emphasis-position.auto


### PR DESCRIPTION
No changes to baseline. These keys weren't getting picked up by the drafts script.