### PR TITLE
Report unmapped non-deprecated, standard keys

### DIFF
--- a/scripts/stats.ts
+++ b/scripts/stats.ts
@@ -41,3 +41,16 @@ const stats = {
 };
 
 console.log(JSON.stringify(stats, undefined, 2));
+
+const todoKeys = [...new Compat().walk()]
+  .filter((f) => !f.id.startsWith("webextensions") && !f.deprecated)
+  .map((f) => f.id);
+
+const doneKeys = Object.values(features).flatMap(
+  (f) => f.compat_features ?? [],
+);
+
+let symDifference = todoKeys
+  .filter((x) => !doneKeys.includes(x))
+  .concat(doneKeys.filter((x) => !todoKeys.includes(x)));
+console.dir(symDifference, { maxArrayLength: null });

--- a/scripts/stats.ts
+++ b/scripts/stats.ts
@@ -1,56 +1,82 @@
 import { Compat } from "compute-baseline/browser-compat-data";
+import { fileURLToPath } from "node:url";
+import yargs from "yargs";
 import { features } from "../index.js";
 
-const featureCount = Object.keys(features).length;
+const argv = yargs(process.argv.slice(2))
+  .scriptName("stats")
+  .usage("$0", "Generate statistics")
+  .option("verbose", {
+    alias: "v",
+    describe: "Show more detailed stats",
+    type: "count",
+    default: 0,
+  }).argv;
 
-const keys = [...new Compat().walk()]
-  .filter((f) => !f.id.startsWith("webextensions"))
-  .map((f) => f.id).length;
+export function stats(detailed: boolean = false) {
+  const featureCount = Object.keys(features).length;
 
-const compatKeys = Object.values(features).flatMap(
-  (f) => f.compat_features ?? [],
-).length;
+  const keys = [];
+  const doneKeys = Object.values(features).flatMap(
+    (f) => f.compat_features ?? [],
+  );
+  const toDoKeys = [];
+  const deprecatedNonStandardKeys = [];
 
-const featureSizes = Object.values(features)
-  .map((feature) => (feature.compat_features ?? []).length)
-  .sort((a, b) => a - b);
+  for (const f of new Compat().walk()) {
+    if (!f.id.startsWith("webextensions")) {
+      keys.push(f.id);
 
-const stats = {
-  features: featureCount,
-  compatKeys,
-  compatCoverage: compatKeys / keys,
-  compatKeysPerFeatureMean: compatKeys / featureCount,
-  compatKeysPerFeatureMedian: (() => {
-    const sizes = featureSizes;
-    const middle = Math.floor(sizes.length / 2);
-    return sizes.length % 2
-      ? sizes[middle]
-      : (sizes[middle - 1] + sizes[middle]) / 2;
-  })(),
-  compatKeysPerFeatureMode: (() => {
-    const frequencyMap = new Map<number, number>();
-    for (const size of featureSizes) {
-      frequencyMap.set(size, (frequencyMap.get(size) ?? 0) + 1);
+      if (!f.deprecated && f.standard_track) {
+        if (!doneKeys.includes(f.id)) {
+          toDoKeys.push(f.id);
+        }
+      } else {
+        deprecatedNonStandardKeys.push(f.id);
+      }
     }
-    return [...frequencyMap.entries()]
-      .sort(
-        ([sizeA, frequencyA], [sizeB, frequencyB]) => frequencyA - frequencyB,
-      )
-      .pop()[0];
-  })(),
-};
+  }
 
-console.log(JSON.stringify(stats, undefined, 2));
+  const featureSizes = Object.values(features)
+    .map((feature) => (feature.compat_features ?? []).length)
+    .sort((a, b) => a - b);
 
-const todoKeys = [...new Compat().walk()]
-  .filter((f) => !f.id.startsWith("webextensions") && !f.deprecated)
-  .map((f) => f.id);
+  const result = {
+    features: featureCount,
+    compatKeys: doneKeys.length,
+    compatKeysUnmapped: toDoKeys.length,
+    compatCoverage: doneKeys.length / keys.length,
+    compatKeysPerFeatureMean: doneKeys.length / featureCount,
+    compatKeysPerFeatureMedian: (() => {
+      const sizes = featureSizes;
+      const middle = Math.floor(sizes.length / 2);
+      return sizes.length % 2
+        ? sizes[middle]
+        : (sizes[middle - 1] + sizes[middle]) / 2;
+    })(),
+    compatKeysPerFeatureMode: (() => {
+      const frequencyMap = new Map<number, number>();
+      for (const size of featureSizes) {
+        frequencyMap.set(size, (frequencyMap.get(size) ?? 0) + 1);
+      }
+      return [...frequencyMap.entries()]
+        .sort(
+          ([sizeA, frequencyA], [sizeB, frequencyB]) => frequencyA - frequencyB,
+        )
+        .pop()[0];
+    })(),
+    toBeMapped: undefined,
+  };
 
-const doneKeys = Object.values(features).flatMap(
-  (f) => f.compat_features ?? [],
-);
+  if (detailed) {
+    result.toBeMapped = toDoKeys;
+  }
 
-let symDifference = todoKeys
-  .filter((x) => !doneKeys.includes(x))
-  .concat(doneKeys.filter((x) => !todoKeys.includes(x)));
-console.dir(symDifference, { maxArrayLength: null });
+  return result;
+}
+
+if (import.meta.url.startsWith("file:")) {
+  if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    console.log(JSON.stringify(stats(argv.verbose), undefined, 2));
+  }
+}

--- a/scripts/stats.ts
+++ b/scripts/stats.ts
@@ -44,7 +44,7 @@ export function stats(detailed: boolean = false) {
   const result = {
     features: featureCount,
     compatKeys: doneKeys.length,
-    compatKeysUnmapped: toDoKeys.length,
+    compatKeysUnmapped: toDoKeys.length + deprecatedNonStandardKeys.length,
     compatCoverage: doneKeys.length / keys.length,
     compatKeysPerFeatureMean: doneKeys.length / featureCount,
     compatKeysPerFeatureMedian: (() => {
@@ -65,11 +65,12 @@ export function stats(detailed: boolean = false) {
         )
         .pop()[0];
     })(),
-    toBeMapped: undefined,
+    currentBurndown: undefined,
+    currentBurndownSize: toDoKeys.length,
   };
 
   if (detailed) {
-    result.toBeMapped = toDoKeys;
+    result.currentBurndown = toDoKeys;
   }
 
   return result;


### PR DESCRIPTION
This adds a few things to the `stats` script:

- a `compatKeysUnmapped` count
- a `currentBurndownSize` count (standard, non-deprecated keys to go)
- a `--verbose` flag, to get the list of `currentBurndown` keys
- an export, so I can use this script's output to generate part of the releases (to come later)

If you want only the burndown list, then `npx tsx ./scripts/stats.ts --verbose | jq --raw-output '.currentBurndown[]'` pretty prints it (that probably deserves an entry in `npm run`, honestly).

Built atop #2211.