### PR TITLE
Uncomment keys excluded for non-real values, now fixed

### DIFF
--- a/features/meta.yml
+++ b/features/meta.yml
@@ -14,8 +14,7 @@ compat_features:
   - html.elements.meta.charset
   - html.elements.meta.content
   - html.elements.meta.http-equiv
-  # Excluded because of a non-real value
-  # - html.elements.meta.http-equiv.content-type
+  - html.elements.meta.http-equiv.content-type
   - html.elements.meta.http-equiv.refresh
   - html.elements.meta.name
   - html.elements.meta.name.referrer

--- a/features/meta.yml.dist
+++ b/features/meta.yml.dist
@@ -62,6 +62,19 @@ compat_features:
   - html.elements.meta.name
 
   # baseline: high
+  # baseline_low_date: 2017-06-06
+  # baseline_high_date: 2019-12-06
+  # support:
+  #   chrome: ≤59
+  #   chrome_android: "59"
+  #   edge: "12"
+  #   firefox: "1"
+  #   firefox_android: "4"
+  #   safari: ≤10.1
+  #   safari_ios: ≤10.3
+  - html.elements.meta.http-equiv.content-type
+
+  # baseline: high
   # baseline_low_date: 2020-01-15
   # baseline_high_date: 2022-07-15
   # support:

--- a/features/table.yml
+++ b/features/table.yml
@@ -53,16 +53,14 @@ compat_features:
   - html.elements.td.colspan
   - html.elements.td.headers
   - html.elements.td.rowspan
-  # Excluded because of a non-real value
-  # - html.elements.td.rowspan.rowspan_zero
+  - html.elements.td.rowspan.rowspan_zero
   - html.elements.tfoot
   - html.elements.th
   - html.elements.th.abbr
   - html.elements.th.colspan
   - html.elements.th.headers
   - html.elements.th.rowspan
-  # Excluded because of a non-real value
-  # - html.elements.th.rowspan.rowspan_zero
+  - html.elements.th.rowspan.rowspan_zero
   - html.elements.th.scope
   - html.elements.thead
   - html.elements.tr

--- a/features/table.yml.dist
+++ b/features/table.yml.dist
@@ -143,3 +143,18 @@ compat_features:
   #   safari: "6"
   #   safari_ios: "6"
   - api.HTMLTableElement.createTBody
+
+  # baseline: false
+  # support:
+  #   chrome: "65"
+  #   chrome_android: "65"
+  #   edge: "79"
+  #   firefox: ≤55
+  #   firefox_android: "55"
+  - html.elements.td.rowspan.rowspan_zero
+
+  # baseline: false
+  # support:
+  #   firefox: ≤55
+  #   firefox_android: "55"
+  - html.elements.th.rowspan.rowspan_zero

--- a/features/text-tracks.yml
+++ b/features/text-tracks.yml
@@ -51,6 +51,4 @@ compat_features:
   - html.elements.track.kind
   - html.elements.track.label
   - html.elements.track.src
-  # Excluded because of a non-real value
-  # - html.elements.track.src.settable_src
   - html.elements.track.srclang


### PR DESCRIPTION
A few such keys remain in drafts, that I expect to be taken care of in https://github.com/web-platform-dx/web-features/pull/2044.