### PR TITLE
Update the web-animations description

### DIFF
--- a/features/web-animations.yml
+++ b/features/web-animations.yml
@@ -1,5 +1,5 @@
 name: Web animations
-description: The `animate()` method of `Element` objects programmatically animates elements over time and can synchronize the animations of multiple elements.
+description: The programmatic Animation interface for animating elements over time and synchronizing the animations of multiple elements. This can be used to construct new animations through the `animate()` method or `Animation` constructor as well as query and modify CSS animations and transitions retrieved via the `getAnimations()` method.
 spec: https://drafts.csswg.org/web-animations-1/
 caniuse: web-animation
 group: animation


### PR DESCRIPTION
Update the web-animations description to include
* Construction of an `Animation` directly
* Querying and modifying CSS animations and transitions retrieved via `getAnimations()`

This fixes #2244.