### PR TITLE
Add more keys to Promise

### DIFF
--- a/features/promise.yml
+++ b/features/promise.yml
@@ -13,3 +13,16 @@ spec:
   - https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.resolve
   - https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.prototype.then
 group: promises
+status:
+  compute_from: javascript.builtins.Promise
+compat_features:
+  - javascript.builtins.Promise
+  - javascript.builtins.Promise.@@species
+  - javascript.builtins.Promise.Promise
+  - javascript.builtins.Promise.all
+  - javascript.builtins.Promise.catch
+  - javascript.builtins.Promise.incumbent_settings_object_tracking
+  - javascript.builtins.Promise.race
+  - javascript.builtins.Promise.reject
+  - javascript.builtins.Promise.resolve
+  - javascript.builtins.Promise.then

--- a/features/promise.yml.dist
+++ b/features/promise.yml.dist
@@ -14,6 +14,18 @@ status:
     safari: "8"
     safari_ios: "8"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: high
+  # baseline_low_date: 2015-07-29
+  # baseline_high_date: 2018-01-29
+  # support:
+  #   chrome: "32"
+  #   chrome_android: "32"
+  #   edge: "12"
+  #   firefox: "29"
+  #   firefox_android: "29"
+  #   safari: "8"
+  #   safari_ios: "8"
   - javascript.builtins.Promise
   - javascript.builtins.Promise.Promise
   - javascript.builtins.Promise.all
@@ -22,3 +34,22 @@ compat_features:
   - javascript.builtins.Promise.reject
   - javascript.builtins.Promise.resolve
   - javascript.builtins.Promise.then
+
+  # baseline: high
+  # baseline_low_date: 2020-01-15
+  # baseline_high_date: 2022-07-15
+  # support:
+  #   chrome: "51"
+  #   chrome_android: "51"
+  #   edge: "79"
+  #   firefox: "48"
+  #   firefox_android: "48"
+  #   safari: "10"
+  #   safari_ios: "10"
+  - javascript.builtins.Promise.@@species
+
+  # baseline: false
+  # support:
+  #   firefox: "50"
+  #   firefox_android: "50"
+  - javascript.builtins.Promise.incumbent_settings_object_tracking


### PR DESCRIPTION
Adds
- javascript.builtins.Promise.@@species
- javascript.builtins.Promise.incumbent_settings_object_tracking

to the Promise feature and also adds `compute_from` (which wasn't around when I first created this feature)