### PR TITLE
Add a key to SharedArrayBuffer and Atomics

### DIFF
--- a/features/shared-memory.yml
+++ b/features/shared-memory.yml
@@ -5,8 +5,11 @@ spec:
   - https://tc39.es/ecma262/multipage/structured-data.html#sec-sharedarraybuffer-objects
   - https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics-object
 group: javascript
+status:
+  compute_from: javascript.builtins.SharedArrayBuffer
 compat_features:
   - javascript.builtins.Atomics
+  - javascript.builtins.Atomics.Atomic_operations_on_non_shared_buffers
   - javascript.builtins.Atomics.add
   - javascript.builtins.Atomics.and
   - javascript.builtins.Atomics.compareExchange
@@ -21,7 +24,7 @@ compat_features:
   - javascript.builtins.Atomics.xor
   - javascript.builtins.DataView.DataView.sharedarraybuffer_support
   - javascript.builtins.SharedArrayBuffer
+  - javascript.builtins.SharedArrayBuffer.@@species
   - javascript.builtins.SharedArrayBuffer.SharedArrayBuffer
   - javascript.builtins.SharedArrayBuffer.byteLength
   - javascript.builtins.SharedArrayBuffer.slice
-  - javascript.builtins.SharedArrayBuffer.@@species

--- a/features/shared-memory.yml.dist
+++ b/features/shared-memory.yml.dist
@@ -57,3 +57,9 @@ compat_features:
   - javascript.builtins.SharedArrayBuffer.SharedArrayBuffer
   - javascript.builtins.SharedArrayBuffer.byteLength
   - javascript.builtins.SharedArrayBuffer.slice
+
+  # baseline: false
+  # support:
+  #   firefox: "79"
+  #   firefox_android: "79"
+  - javascript.builtins.Atomics.Atomic_operations_on_non_shared_buffers


### PR DESCRIPTION
Adds javascript.builtins.Atomics.Atomic_operations_on_non_shared_buffers to the feature. I don't think this is important enough to deserve its own feature so I think it should be sorted in here.