### PR TITLE
Add mixed type parameters to lab/lch, oklab/oklch

### DIFF
--- a/features/lab.yml
+++ b/features/lab.yml
@@ -3,14 +3,18 @@ description: "The CIE Lab color space expresses colors in terms of lightness and
 spec: https://drafts.csswg.org/css-color-4/#cie-lab
 caniuse: css-lch-lab
 group: color-types
-# Editorial override has been applied to ignore mixed_type_parameters.
 # TODO: The behavior of lightness gradients requiring gamut mapping is a
 # topic of debate, and at least these browser bugs:
 # https://crbug.com/329106317
 # https://webkit.org/b/255939
 # These problems should be captured in notes when we support notes.
+# Editorial override has been applied to ignore mixed_type_parameters.
+status:
+  compute_from:
+    - css.types.color.lab
+    - css.types.color.lch
 compat_features:
   - css.types.color.lab
-  # - css.types.color.lab.mixed_type_parameters
+  - css.types.color.lab.mixed_type_parameters
   - css.types.color.lch
-  # - css.types.color.lch.mixed_type_parameters
+  - css.types.color.lch.mixed_type_parameters

--- a/features/lab.yml.dist
+++ b/features/lab.yml.dist
@@ -13,5 +13,29 @@ status:
     safari: "15"
     safari_ios: "15"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: low
+  # baseline_low_date: 2023-05-09
+  # support:
+  #   chrome: "111"
+  #   chrome_android: "111"
+  #   edge: "111"
+  #   firefox: "113"
+  #   firefox_android: "113"
+  #   safari: "15"
+  #   safari_ios: "15"
   - css.types.color.lab
   - css.types.color.lch
+
+  # baseline: low
+  # baseline_low_date: 2023-08-21
+  # support:
+  #   chrome: "116"
+  #   chrome_android: "116"
+  #   edge: "116"
+  #   firefox: "113"
+  #   firefox_android: "113"
+  #   safari: "16.2"
+  #   safari_ios: "16.2"
+  - css.types.color.lab.mixed_type_parameters
+  - css.types.color.lch.mixed_type_parameters

--- a/features/oklab.yml
+++ b/features/oklab.yml
@@ -2,14 +2,18 @@ name: Oklab and Oklch
 description: "The Oklab color space expresses colors in terms of lightness and how red/green and blue/yellow a color is, aiming to match how humans perceive colors. Oklch is a variant of Oklab with polar coordinates. These color spaces can be used with the CSS `color()`, `oklab()`, and `oklch()` functions."
 spec: https://drafts.csswg.org/css-color-4/#ok-lab
 group: color-types
-# Editorial override has been applied to ignore mixed_type_parameters.
 # TODO: The behavior of lightness gradients requiring gamut mapping is a
 # topic of debate, and at least these browser bugs:
 # https://crbug.com/329106317
 # https://webkit.org/b/255939
 # These problems should be captured in notes when we support notes.
+# Editorial override has been applied to ignore mixed_type_parameters.
+status:
+  compute_from:
+    - css.types.color.oklab
+    - css.types.color.oklch
 compat_features:
   - css.types.color.oklab
-  # - css.types.color.oklab.mixed_type_parameters
+  - css.types.color.oklab.mixed_type_parameters
   - css.types.color.oklch
-  # - css.types.color.oklch.mixed_type_parameters
+  - css.types.color.oklch.mixed_type_parameters

--- a/features/oklab.yml.dist
+++ b/features/oklab.yml.dist
@@ -13,5 +13,29 @@ status:
     safari: "15.4"
     safari_ios: "15.4"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: low
+  # baseline_low_date: 2023-05-09
+  # support:
+  #   chrome: "111"
+  #   chrome_android: "111"
+  #   edge: "111"
+  #   firefox: "113"
+  #   firefox_android: "113"
+  #   safari: "15.4"
+  #   safari_ios: "15.4"
   - css.types.color.oklab
   - css.types.color.oklch
+
+  # baseline: low
+  # baseline_low_date: 2023-08-21
+  # support:
+  #   chrome: "116"
+  #   chrome_android: "116"
+  #   edge: "116"
+  #   firefox: "113"
+  #   firefox_android: "113"
+  #   safari: "16.2"
+  #   safari_ios: "16.2"
+  - css.types.color.oklab.mixed_type_parameters
+  - css.types.color.oklch.mixed_type_parameters


### PR DESCRIPTION
These were excluded because compute_from didn't yet exist. There's an argument to be made that these should be considered baseline in August instead of May, when mixed type parameters were added, and the compute_from should be excluded, but I could be convinced either way.