### PR TITLE
Move `toggle` event from `popover` to `details`

### DIFF
--- a/features/details.yml
+++ b/features/details.yml
@@ -3,11 +3,11 @@ description: The `<details>` element is a disclosure widget which can be expande
 spec: https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element
 caniuse: details
 group: html-elements
+status:
+  compute_from: html.elements.details
 compat_features:
   - api.HTMLDetailsElement
   - api.HTMLDetailsElement.open
-  # Exclude toggle event as it changes the Chrome/Safari dates by 3-5 years, and
-  # it's not a critical part of the feature.
-  # - api.HTMLDetailsElement.toggle_event
+  - api.HTMLElement.toggle_event
   - html.elements.details
   - html.elements.details.open

--- a/features/details.yml.dist
+++ b/features/details.yml.dist
@@ -42,3 +42,16 @@ compat_features:
   #   safari_ios: "6"
   - html.elements.details
   - html.elements.details.open
+
+  # baseline: high
+  # baseline_low_date: 2020-01-15
+  # baseline_high_date: 2022-07-15
+  # support:
+  #   chrome: "36"
+  #   chrome_android: "36"
+  #   edge: "79"
+  #   firefox: "49"
+  #   firefox_android: "49"
+  #   safari: "10.1"
+  #   safari_ios: "10.3"
+  - api.HTMLElement.toggle_event

--- a/features/popover.yml
+++ b/features/popover.yml
@@ -8,3 +8,26 @@ group: html
 # References:
 # - https://github.com/mdn/browser-compat-data/issues/22927
 # - https://bugs.webkit.org/show_bug.cgi?id=267688
+compat_features:
+  - api.HTMLButtonElement.popoverTargetAction
+  - api.HTMLButtonElement.popoverTargetElement
+  - api.HTMLElement.beforetoggle_event
+  - api.HTMLElement.beforetoggle_event.popover_elements
+  - api.HTMLElement.hidePopover
+  - api.HTMLElement.popover
+  - api.HTMLElement.showPopover
+  - api.HTMLElement.togglePopover
+  - api.HTMLElement.toggle_event.popover_elements
+  - api.HTMLInputElement.popoverTargetAction
+  - api.HTMLInputElement.popoverTargetElement
+  - api.ToggleEvent
+  - api.ToggleEvent.ToggleEvent
+  - api.ToggleEvent.newState
+  - api.ToggleEvent.oldState
+  - css.selectors.backdrop.popover
+  - css.selectors.popover-open
+  - html.elements.button.popovertarget
+  - html.elements.button.popovertargetaction
+  - html.elements.input.popovertarget
+  - html.elements.input.popovertargetaction
+  - html.global_attributes.popover

--- a/features/popover.yml.dist
+++ b/features/popover.yml.dist
@@ -11,19 +11,6 @@ status:
     firefox_android: "125"
     safari: "17"
 compat_features:
-  # baseline: high
-  # baseline_low_date: 2020-01-15
-  # baseline_high_date: 2022-07-15
-  # support:
-  #   chrome: "36"
-  #   chrome_android: "36"
-  #   edge: "79"
-  #   firefox: "49"
-  #   firefox_android: "49"
-  #   safari: "10.1"
-  #   safari_ios: "10.3"
-  - api.HTMLElement.toggle_event
-
   # baseline: low
   # baseline_low_date: 2023-11-21
   # support:


### PR DESCRIPTION
The `toggle` event is much older than popovers, we just hadn't captured that previously as it was before we had the option of `compute_from`.

See https://github.com/web-platform-dx/web-features/pull/2284#discussion_r1850288672.