### PR TITLE
Add root types where they were first used

### DIFF
--- a/features/gradients.yml
+++ b/features/gradients.yml
@@ -9,6 +9,7 @@ status:
 # TODO: we should have separate linear and radial gradients when https://github.com/web-platform-dx/web-features/issues/971 is resolved.
 compat_features:
   - css.properties.background-image.gradients
+  - css.types.image
   - css.types.image.gradient
   - css.types.image.gradient.linear-gradient
   - css.types.image.gradient.linear-gradient.doubleposition

--- a/features/gradients.yml.dist
+++ b/features/gradients.yml.dist
@@ -21,6 +21,19 @@ compat_features:
   #   chrome: "1"
   #   chrome_android: "18"
   #   edge: "12"
+  #   firefox: "1"
+  #   firefox_android: "4"
+  #   safari: "1"
+  #   safari_ios: "1"
+  - css.types.image
+
+  # baseline: high
+  # baseline_low_date: 2015-07-29
+  # baseline_high_date: 2018-01-29
+  # support:
+  #   chrome: "1"
+  #   chrome_android: "18"
+  #   edge: "12"
   #   firefox: "3.6"
   #   firefox_android: "4"
   #   safari: "4"

--- a/features/inherit-value.yml
+++ b/features/inherit-value.yml
@@ -3,4 +3,5 @@ description: The `inherit` keyword resets any CSS property to the computed value
 group: explicit-defaults
 spec: https://drafts.csswg.org/css-cascade-3/#inherit
 compat_features:
+  - css.types.global_keywords
   - css.types.global_keywords.inherit

--- a/features/inherit-value.yml.dist
+++ b/features/inherit-value.yml.dist
@@ -14,4 +14,5 @@ status:
     safari: "1"
     safari_ios: "1"
 compat_features:
+  - css.types.global_keywords
   - css.types.global_keywords.inherit


### PR DESCRIPTION
Adds `css.types.image` to `gradient`, and `css.types.global_keywords` to `inherit`. No changes in baseline. A good candidate for #1173.