### PR TITLE
Add API for features

### DIFF
--- a/.github/workflows/gh-pages-build-deploy.yml
+++ b/.github/workflows/gh-pages-build-deploy.yml
@@ -41,7 +41,11 @@ jobs:
         with:
           cache: npm
           node-version-file: .node-version
-      - name: NPM Install
+      - name: NPM Install web-features
+        run: npm ci
+      - name: NPM Build web-features
+        run: npm run build
+      - name: NPM Install gh-pages
         run: npm ci
         working-directory: gh-pages/
       - name: Build pages

--- a/gh-pages/src/api/api.11tydata.js
+++ b/gh-pages/src/api/api.11tydata.js
@@ -1,0 +1,7 @@
+module.exports = async function () {
+    const { features } = await import('../../../packages/web-features/index.js');
+    return {
+        features: Object.keys(features).map(id => ({ ...features[id], id })),
+        featureList: { features: Object.keys(features) },
+    };
+}

--- a/gh-pages/src/api/feature.liquid
+++ b/gh-pages/src/api/feature.liquid
@@ -1,0 +1,9 @@
+---
+pagination:
+  data: features
+  size: 1
+  alias: feature
+permalink: "api/v1/features/{{ feature.id | slugify }}.json"
+---
+{{ feature | json }}
+

--- a/gh-pages/src/api/features.liquid
+++ b/gh-pages/src/api/features.liquid
@@ -1,0 +1,5 @@
+---
+permalink: "api/v1/features.json"
+---
+{{ featureList | json }}
+


### PR DESCRIPTION
This adds a simple static api to the GitHub Pages site. 

- `/api/v1/features.json` returns a list of all keys.
- `/api/v1/features/[id].json` returns a single feature (with the addition of the id).

We could easily add additional endpoints down the road.

While there is an API available at `https://api.webstatus.dev/v1/features/[id]`, I think this has some benefits-

- Anyone can (very) simply host their own version
- The returned data is in the same format as the web-features data (the webstatus.dev API renames fields and changes the structure slightly)
- We have better control over the update cadence

@tidoust says it better here- https://github.com/web-platform-dx/web-features/issues/204#issuecomment-2360935818.

This does add a dependency from the `gh-pages` submodule on `packages/web-features`, and I think currently the API would get updated whenever the gh-pages repo is updated. We need to consider if the API should be updated with every update to main, or only on releases.

- [ ] Document API
- [ ] Configure API update cadence