### PR TITLE
Clean up fullscreen todo comments

### DIFF
--- a/features/fullscreen.yml
+++ b/features/fullscreen.yml
@@ -2,6 +2,10 @@ name: Fullscreen API
 description: The fullscreen API makes a specific element fill the whole screen and hides most browser UI.
 spec: https://fullscreen.spec.whatwg.org/
 caniuse: fullscreen
+# compute_from ignores css.selectors.fullscreen.all_elements.
+# It is only supported in Firefox and non-essential since only the topmost
+# fullscreen element is typically visible. For this to matter, you need nested
+# fullscreen with non-opaque background in the topmost fullscreen element.
 status:
   compute_from: api.Document.fullscreenElement
 compat_features:

--- a/features/fullscreen.yml
+++ b/features/fullscreen.yml
@@ -2,11 +2,11 @@ name: Fullscreen API
 description: The fullscreen API makes a specific element fill the whole screen and hides most browser UI.
 spec: https://fullscreen.spec.whatwg.org/
 caniuse: fullscreen
+status:
+  compute_from: api.Document.fullscreenElement
 compat_features:
   - api.Document.exitFullscreen
   - api.Document.exitFullscreen.returns_promise
-  # Historical in spec, deprecated in BCD.
-  # - api.Document.fullscreen
   - api.Document.fullscreenchange_event
   - api.Document.fullscreenElement
   - api.Document.fullscreenEnabled
@@ -19,8 +19,5 @@ compat_features:
   - api.ShadowRoot.fullscreenElement
   - css.selectors.backdrop.fullscreen
   - css.selectors.fullscreen
-  # Only supported in Firefox and non-essential since only the topmost
-  # fullscreen element is typically visible. For this to matter, you need nested
-  # fullscreen with non-opaque background in the topmost fullscreen element.
-  # - css.selectors.fullscreen.all_elements
+  - css.selectors.fullscreen.all_elements
   - html.elements.iframe.allowfullscreen

--- a/features/fullscreen.yml.dist
+++ b/features/fullscreen.yml.dist
@@ -73,3 +73,9 @@ compat_features:
   - api.Element.requestFullscreen
   - api.Element.requestFullscreen.returns_promise
   - api.ShadowRoot.fullscreenElement
+
+  # baseline: false
+  # support:
+  #   firefox: "64"
+  #   firefox_android: "64"
+  - css.selectors.fullscreen.all_elements


### PR DESCRIPTION
Added a compute_from to ignore `css.selectors.fullscreen.all_elements`, and remove a now-deprecated key.