### PR TITLE
Add a key to server-timing

### DIFF
--- a/features/server-timing.yml
+++ b/features/server-timing.yml
@@ -3,3 +3,14 @@ description: The `serverTiming` property of the `PerformanceResourceTiming` API 
 spec: https://w3c.github.io/server-timing/
 caniuse: server-timing
 group: performance
+status:
+  compute_from: api.PerformanceResourceTiming.serverTiming
+compat_features:
+  - api.PerformanceResourceTiming.serverTiming
+  - api.PerformanceServerTiming
+  - api.PerformanceServerTiming.description
+  - api.PerformanceServerTiming.duration
+  - api.PerformanceServerTiming.name
+  - api.PerformanceServerTiming.toJSON
+  - http.headers.Server-Timing
+  - http.headers.Server-Timing.trailer

--- a/features/server-timing.yml.dist
+++ b/features/server-timing.yml.dist
@@ -42,3 +42,9 @@ compat_features:
   #   safari: "16.4"
   #   safari_ios: "16.4"
   - http.headers.Server-Timing
+
+  # baseline: false
+  # support:
+  #   firefox: "71"
+  #   firefox_android: "79"
+  - http.headers.Server-Timing.trailer


### PR DESCRIPTION
`http.headers.Server-Timing.trailer` comes from https://github.com/mdn/browser-compat-data/pull/25141.

Added a `compute_from` as a consequence.