### PR TITLE
Fix incorrect syntax in active-view-transition.yml

### DIFF
--- a/features/active-view-transition.yml
+++ b/features/active-view-transition.yml
@@ -1,5 +1,5 @@
 name: Active view transition
-description: The `::active-view-transition` CSS pseudo-class matches the root element when a view transition is active. The `::active-view-transition-type()` CSS pseudo-class matches only when the active view transition was started with the specified type.
+description: The `:active-view-transition` CSS pseudo-class matches the root element when a view transition is active. The `:active-view-transition-type()` CSS pseudo-class matches only when the active view transition was started with the specified type.
 spec: https://drafts.csswg.org/css-view-transitions-2/#the-active-view-transition-pseudo
 group:
   - view-transitions


### PR DESCRIPTION
Pseudo-classes only have one colon.