### PR TITLE
Rename `:not` to `:not()` for consistency

### DIFF
--- a/features/not.yml
+++ b/features/not.yml
@@ -1,4 +1,4 @@
-name: :not
+name: :not()
 description: The `:not()` functional pseudo-class matches elements that do not match the selectors in its argument.
 spec: https://drafts.csswg.org/selectors-4/#negation
 caniuse: css-not-sel-list


### PR DESCRIPTION
Other functional pseudo-classes show the parentheses.