### PR TITLE
Revise `event` description to make it clear that it's generic

### DIFF
--- a/features/events.yml
+++ b/features/events.yml
@@ -1,5 +1,5 @@
 name: Events
-description: Events fire when significant things happen in the page, such as an image loading or a user clicking. You can use the `addEventListener()` method on objects that receive events (event targets), such as windows, documents, and elements, to set a function to be called when an event fires.
+description: The `Event` API and the `addEventListener()` method on objects that receive events (event targets) represent and handle significant things happening on a page. Many APIs fire events for a wide range of situations relating to those APIs, such as an image loading, a user clicking, or a value changing.
 spec:
   - https://html.spec.whatwg.org/multipage/indices.html#events-2
   - https://dom.spec.whatwg.org/#interface-customevent


### PR DESCRIPTION
This is one of those foundational features that's both difficult to avoid and hard to make explicit inside our length constraints.

Fixes https://github.com/web-platform-dx/web-features/issues/2413, I hope.