### PR TITLE
docs: fix some typos in publishing doc

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -29,7 +29,7 @@ These are the steps to publish a regular release on npm and as a GitHub release:
    When the workflow finishes, your review is requested on a new release pull request.
 
 1. Review the PR.
-   
+
    1. Close and reopen the release PR, to allow the tests to run.
    1. Review and approve the changes.
    1. When you're ready to complete the remaining steps, merge the PR.
@@ -56,7 +56,7 @@ These are the steps to publish a regular release on npm and as a GitHub release:
 
 1. Remove the "[major version required][major-version]" and "[minor version required][minor-version]" labels from any pull requests that were included in the release.
 
-1. (*Optional*) If this release contained schema changes, notify highly-visible donwstream consumers, such as Can I Use (@Fryd), MDN (@LeoMcA), or webstatus.dev (@jcscottiii).
+1. (_Optional_) If this release contained schema changes, notify highly-visible downstream consumers, such as Can I Use (@Fyrd), MDN (@LeoMcA), or webstatus.dev (@jcscottiii).
 
 [major-version]: https://github.com/web-platform-dx/web-features/pulls?q=is%3Apr+is%3Amerged+label%3A%22major+version+required%22+sort%3Aupdated-desc
 [minor-version]: https://github.com/web-platform-dx/web-features/pulls?q=is%3Apr+is%3Amerged+label%3A%22minor+version+required%22+sort%3Aupdated-desc
@@ -74,11 +74,11 @@ You can install these prereleases using a command such as `npm install web-featu
 Publishing requires the `NPM_TOKEN` repository secret (set via _Settings_ → _Secrets and variables_ → _Actions_).
 If you're replacing this token, then use the following settings:
 
-| Setting                          | Value                                                                                                      |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| Token type                       | _Granular Access Token_                                                                                    |
-| Expiration                       | The first day of the next quarter (1 January, 1 April, 1 July, or 1 October) or the first weekday after it |
-| Packages and scopes permsissions | _Read and write_                                                                                           |
-| Select packages                  | _Only select packages and scopes_                                                                          |
-| Select packages and scopes       | `compute-baseline` and `web-features`                                                                      |
-| Organizations                    | _No access_                                                                                                |
+| Setting                         | Value                                                                                                      |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Token type                      | _Granular Access Token_                                                                                    |
+| Expiration                      | The first day of the next quarter (1 January, 1 April, 1 July, or 1 October) or the first weekday after it |
+| Packages and scopes permissions | _Read and write_                                                                                           |
+| Select packages                 | _Only select packages and scopes_                                                                          |
+| Select packages and scopes      | `compute-baseline` and `web-features`                                                                      |
+| Organizations                   | _No access_                                                                                                |


### PR DESCRIPTION
Spotted some typos in `docs/publishing.md`, sending in a fix & other changes from formatting.