### PR TITLE
Auto-advance date of the `next` tag

### DIFF
--- a/.github/workflows/publish_next_web-features.yml
+++ b/.github/workflows/publish_next_web-features.yml
@@ -68,20 +68,33 @@ jobs:
           VERSION: ${{ steps.version.outputs.VERSION }}
           TIMESTAMP: ${{ steps.timestamp_and_hash.outputs.TIMESTAMP }}
           SHORT_HASH: ${{ steps.timestamp_and_hash.outputs.SHORT_HASH }}
-      - run: npm publish --tag ${{ env.dist_tag }}
+      - if: ${{ env.NODE_AUTH_TOKEN }}
+        run: npm publish --tag ${{ env.dist_tag }}
         working-directory: ${{ env.package_dir }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Remove the existing pre-release
+        run: gh release delete "$TAG" --cleanup-tag --yes || true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ env.dist_tag }}
+
       - name: Publish pre-release on GitHub
-        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 #v2.0.8
-        with:
-          files: |
+        run: >
+          gh release create
+          --title "$PACKAGE@$TAG"
+          --notes "$NOTES"
+          --prerelease
+          --latest=false
+          "$TAG"
+          $ARTIFACTS
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE: ${{ env.package }}
+          TAG: ${{ env.dist_tag }}
+          NOTES: This is a continuously-updated prerelease generated from `main` (currently at ${{ steps.timestamp_and_hash.outputs.SHORT_HASH }}).
+          ARTIFACTS: >
             schemas/data.schema.json
             ${{ env.package_dir }}/data.json
             data.extended.json
-          prerelease: true
-          name: web-features@next
-          body: This is a continuously-updated prerelease generated from `main` (currently at ${{ steps.timestamp_and_hash.outputs.SHORT_HASH }}).
-          tag_name: ${{ env.dist_tag }}
-          fail_on_unmatched_files: true


### PR DESCRIPTION
Removes softprops/action-gh-release in favor of the `gh` CLI.

Fixes https://github.com/web-platform-dx/web-features/issues/2068

Closes https://github.com/web-platform-dx/web-features/pull/2425