### PR TITLE
Update http3 for Safari support

### DIFF
--- a/features/http3.yml
+++ b/features/http3.yml
@@ -6,10 +6,13 @@ caniuse: http3
 # from https://caniuse.com/http3. TODO: capture partial support in Safari with
 # notes. caniuse says "Enabled by default for a portion of users."
 status:
-  baseline: false
+  baseline: low
+  baseline_low_date: 2024-09-16
   support:
     chrome: "87"
     chrome_android: "87"
     edge: "87"
     firefox: "88"
     firefox_android: "88"
+    safari: "18"
+    safari_ios: "18"


### PR DESCRIPTION
Since HTTP/3 has no representation in BCD, the following version numbers are from https://caniuse.com/http3.

Closes #2369 