### PR TITLE
Update container query specs

### DIFF
--- a/features/container-queries.yml
+++ b/features/container-queries.yml
@@ -1,6 +1,6 @@
 name: Container queries
 description: Container size queries with the `@container` at-rule apply styles to an element based on the dimensions of its container.
-spec: https://drafts.csswg.org/css-contain-3/#container-queries
+spec: https://drafts.csswg.org/css-conditional-5/#container-queries
 group: containment
 caniuse: css-container-queries
 status:

--- a/features/container-queries.yml
+++ b/features/container-queries.yml
@@ -1,7 +1,7 @@
 name: Container queries
 description: Container size queries with the `@container` at-rule apply styles to an element based on the dimensions of its container.
 spec: https://drafts.csswg.org/css-conditional-5/#container-queries
-group: containment
+group: container-queries
 caniuse: css-container-queries
 status:
   compute_from: css.at-rules.container

--- a/features/container-style-queries.yml
+++ b/features/container-style-queries.yml
@@ -1,5 +1,5 @@
 name: Container style queries
 description: Container style queries with the `@container` at-rule apply styles to an element based on the values of custom properties of its container.
 spec: https://drafts.csswg.org/css-conditional-5/#style-container
-group: containment
+group: container-queries
 caniuse: css-container-queries-style

--- a/features/container-style-queries.yml
+++ b/features/container-style-queries.yml
@@ -1,5 +1,5 @@
 name: Container style queries
 description: Container style queries with the `@container` at-rule apply styles to an element based on the values of custom properties of its container.
-spec: https://drafts.csswg.org/css-contain-3/#style-container
+spec: https://drafts.csswg.org/css-conditional-5/#style-container
 group: containment
 caniuse: css-container-queries-style

--- a/groups/container-queries.yml
+++ b/groups/container-queries.yml
@@ -1,0 +1,3 @@
+# https://drafts.csswg.org/css-conditional-5/#container-queries
+name: Container queries
+parent: css


### PR DESCRIPTION
Fixes #2249.

@captainbrosset Since you added the original groups, I thought I'd flag you to verify this makes sense to you. Container queries create containment somewhat as a side effect, but since that's not the point of using them, I put the new `container-queries` group under CSS instead of containment. Does that make sense to you?