### PR TITLE
Update prerelease without creating needless notifications

### DIFF
--- a/.github/workflows/publish_next_web-features.yml
+++ b/.github/workflows/publish_next_web-features.yml
@@ -74,21 +74,32 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Remove the existing pre-release
-        run: gh release delete "$TAG" --cleanup-tag --yes || true
+      - name: Set existing release to draft
+        run: gh release edit --draft "$TAG"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ env.dist_tag }}
+
+      - name: Update the tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag --force "$TAG"
+          git push --force origin "$TAG"
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ env.dist_tag }}
 
       - name: Publish pre-release on GitHub
-        run: >
-          gh release create
-          --title "$PACKAGE@$TAG"
-          --notes "$NOTES"
-          --prerelease
-          --latest=false
-          "$TAG"
-          $ARTIFACTS
+        run: |
+          gh release edit \
+            --verify-tag \
+            --title "$PACKAGE@$TAG" \
+            --notes "$NOTES" \
+            --prerelease \
+            --draft=false \
+            "$TAG"
+          gh release upload --clobber "$TAG" $ARTIFACTS
         env:
           GH_TOKEN: ${{ github.token }}
           PACKAGE: ${{ env.package }}


### PR DESCRIPTION
I think this fixes https://github.com/web-platform-dx/web-features/issues/2068 again and supersedes https://github.com/web-platform-dx/web-features/pull/2453.

This version does these steps:

- Sets the existing pre-release to draft
- Advances the release tag
- Edits the existing pre-release with the latest details and publishes it again

On my fork, this prevented the notifications that @szepeviktor reported.