### PR TITLE
Add protocols supported by registerProtocolHandler

### DIFF
--- a/features/registerprotocolhandler.yml
+++ b/features/registerprotocolhandler.yml
@@ -1,6 +1,33 @@
 name: registerProtocolHandler
 description: "The `navigator.registerProtocolHandler()` method declares a site's ability to handle an address scheme (also known as a protocol). For example, an email site can register to open `mailto:` URLs or a VoIP site to open `tel:` URLs."
 spec: https://html.spec.whatwg.org/multipage/system-state.html#custom-handlers
+status:
+  compute_from: api.Navigator.registerProtocolHandler
 compat_features:
   - api.Navigator.registerProtocolHandler
+  - api.Navigator.registerProtocolHandler.scheme_parameter_bitcoin
+  - api.Navigator.registerProtocolHandler.scheme_parameter_ftp
+  - api.Navigator.registerProtocolHandler.scheme_parameter_ftps
+  - api.Navigator.registerProtocolHandler.scheme_parameter_geo
+  - api.Navigator.registerProtocolHandler.scheme_parameter_im
+  - api.Navigator.registerProtocolHandler.scheme_parameter_irc
+  - api.Navigator.registerProtocolHandler.scheme_parameter_ircs
+  - api.Navigator.registerProtocolHandler.scheme_parameter_magnet
+  - api.Navigator.registerProtocolHandler.scheme_parameter_mailto
+  - api.Navigator.registerProtocolHandler.scheme_parameter_matrix
+  - api.Navigator.registerProtocolHandler.scheme_parameter_mms
+  - api.Navigator.registerProtocolHandler.scheme_parameter_news
+  - api.Navigator.registerProtocolHandler.scheme_parameter_nntp
+  - api.Navigator.registerProtocolHandler.scheme_parameter_openpgp4fpr
+  - api.Navigator.registerProtocolHandler.scheme_parameter_sftp
+  - api.Navigator.registerProtocolHandler.scheme_parameter_sip
+  - api.Navigator.registerProtocolHandler.scheme_parameter_sms
+  - api.Navigator.registerProtocolHandler.scheme_parameter_smsto
+  - api.Navigator.registerProtocolHandler.scheme_parameter_ssh
+  - api.Navigator.registerProtocolHandler.scheme_parameter_tel
+  - api.Navigator.registerProtocolHandler.scheme_parameter_urn
+  - api.Navigator.registerProtocolHandler.scheme_parameter_webcal
+  - api.Navigator.registerProtocolHandler.scheme_parameter_wtai
+  - api.Navigator.registerProtocolHandler.scheme_parameter_xmpp
+  - api.Navigator.registerProtocolHandler.secure_context_required
   - api.Navigator.unregisterProtocolHandler

--- a/features/registerprotocolhandler.yml.dist
+++ b/features/registerprotocolhandler.yml.dist
@@ -4,9 +4,12 @@
 status:
   baseline: false
   support:
-    chrome: "38"
+    chrome: "13"
     edge: "79"
+    firefox: "2"
+    firefox_android: "4"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   chrome: "13"
@@ -14,10 +17,101 @@ compat_features:
   #   firefox: "2"
   #   firefox_android: "4"
   - api.Navigator.registerProtocolHandler
+  - api.Navigator.registerProtocolHandler.scheme_parameter_mailto
+  - api.Navigator.registerProtocolHandler.scheme_parameter_mms
+  - api.Navigator.registerProtocolHandler.scheme_parameter_news
+  - api.Navigator.registerProtocolHandler.scheme_parameter_nntp
+  - api.Navigator.registerProtocolHandler.scheme_parameter_sms
+  - api.Navigator.registerProtocolHandler.scheme_parameter_tel
+  - api.Navigator.registerProtocolHandler.scheme_parameter_urn
+  - api.Navigator.registerProtocolHandler.scheme_parameter_webcal
 
-  # ⬇️ Same status as overall feature ⬇️
+  # baseline: false
+  # support:
+  #   chrome: "15"
+  #   edge: "79"
+  #   firefox: "2"
+  #   firefox_android: "4"
+  - api.Navigator.registerProtocolHandler.scheme_parameter_irc
+
+  # baseline: false
+  # support:
+  #   chrome: "26"
+  #   edge: "79"
+  #   firefox: "2"
+  #   firefox_android: "4"
+  - api.Navigator.registerProtocolHandler.scheme_parameter_smsto
+
+  # baseline: false
+  # support:
+  #   chrome: "28"
+  #   edge: "79"
+  #   firefox: "2"
+  #   firefox_android: "4"
+  - api.Navigator.registerProtocolHandler.scheme_parameter_bitcoin
+
+  # baseline: false
+  # support:
+  #   chrome: "30"
+  #   edge: "79"
+  #   firefox: "2"
+  #   firefox_android: "4"
+  - api.Navigator.registerProtocolHandler.scheme_parameter_geo
+  - api.Navigator.registerProtocolHandler.scheme_parameter_im
+  - api.Navigator.registerProtocolHandler.scheme_parameter_ircs
+  - api.Navigator.registerProtocolHandler.scheme_parameter_magnet
+  - api.Navigator.registerProtocolHandler.scheme_parameter_sip
+  - api.Navigator.registerProtocolHandler.scheme_parameter_xmpp
+
+  # baseline: false
+  # support:
+  #   chrome: "31"
+  #   edge: "79"
+  #   firefox: "2"
+  #   firefox_android: "4"
+  - api.Navigator.registerProtocolHandler.scheme_parameter_wtai
+
+  # baseline: false
+  # support:
+  #   chrome: "41"
+  #   edge: "79"
+  #   firefox: "2"
+  #   firefox_android: "4"
+  - api.Navigator.registerProtocolHandler.scheme_parameter_ssh
+
+  # baseline: false
+  # support:
+  #   chrome: "42"
+  #   edge: "79"
+  #   firefox: "2"
+  #   firefox_android: "4"
+  - api.Navigator.registerProtocolHandler.scheme_parameter_openpgp4fpr
+
+  # baseline: false
+  # support:
+  #   chrome: "92"
+  #   edge: "92"
+  #   firefox: "90"
+  #   firefox_android: "90"
+  - api.Navigator.registerProtocolHandler.scheme_parameter_matrix
+
+  # baseline: false
+  # support:
+  #   chrome: "80"
+  #   edge: "79"
+  #   firefox: "62"
+  - api.Navigator.registerProtocolHandler.secure_context_required
+
   # baseline: false
   # support:
   #   chrome: "38"
   #   edge: "79"
   - api.Navigator.unregisterProtocolHandler
+
+  # baseline: false
+  # support:
+  #   firefox: "98"
+  #   firefox_android: "98"
+  - api.Navigator.registerProtocolHandler.scheme_parameter_ftp
+  - api.Navigator.registerProtocolHandler.scheme_parameter_ftps
+  - api.Navigator.registerProtocolHandler.scheme_parameter_sftp


### PR DESCRIPTION
I can't remember if we talked about how to handle this already or not.

If the "feature" is that it is possible for a web page to register itself as the handler for the scheme, then it seems like these are not separate independent features. So I've added them to `registerProtocolHandler` feature for now.