### PR TITLE
Publishing docs: document CLI usage for setting a repository secret

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -73,7 +73,8 @@ You can install these prereleases using a command such as `npm install web-featu
 
 Publishing requires the `NPM_TOKEN` repository secret.
 
-Set the secret by running `gh secret set --repo=web-platform-dx/web-features NPM_TOKEN`
+Set the secret by running `gh secret set --repo=web-platform-dx/web-features NPM_TOKEN`,
+which prompts you to paste the secret,
 or via the repository settings (_Settings_ → _Secrets and variables_ → _Actions_).
 
 If you're replacing this token, then use the following settings:

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -71,7 +71,11 @@ You can install these prereleases using a command such as `npm install web-featu
 > [!NOTE]
 > This information is for [project owners](../GOVERNANCE.md#roles-and-responsibilities).
 
-Publishing requires the `NPM_TOKEN` repository secret (set via _Settings_ → _Secrets and variables_ → _Actions_).
+Publishing requires the `NPM_TOKEN` repository secret.
+
+Set the secret by running `gh secret set --repo=web-platform-dx/web-features NPM_TOKEN`
+or via the repository settings (_Settings_ → _Secrets and variables_ → _Actions_).
+
 If you're replacing this token, then use the following settings:
 
 | Setting                         | Value                                                                                                      |


### PR DESCRIPTION
Setting via the UI is a little bit of a chore.

Learned via https://jvns.ca/til/setting-secrets-with-the-github-cli-is-great/