### PR TITLE
Remove left-over debugging log message

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -185,7 +185,6 @@ for (const [key, data] of yamlEntries('features')) {
 // Assert that discouraged feature's alternatives are valid
 for (const [id, feature] of Object.entries(features)) {
     for (const alternative of feature.discouraged?.alternatives ?? []) {
-        console.log(`Confirming ${alternative} in feature set`);
         if (!(alternative in features)) {
             throw new Error(`${id}'s alternative "${alternative}" is not a valid feature ID`);
         }


### PR DESCRIPTION
This accidentally slipped in when I was trying to figure out why a previous PR was producing unexpected test results ([original PR](https://github.com/web-platform-dx/web-features/pull/2388/files#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122)).