### PR TITLE
`stats.ts`: count correctly the number keys remaining to be mapped

### DIFF
--- a/scripts/stats.ts
+++ b/scripts/stats.ts
@@ -44,7 +44,7 @@ export function stats(detailed: boolean = false) {
   const result = {
     features: featureCount,
     compatKeys: doneKeys.length,
-    compatKeysUnmapped: toDoKeys.length + deprecatedNonStandardKeys.length,
+    compatKeysUnmapped: keys.length - doneKeys.length,
     compatCoverage: doneKeys.length / keys.length,
     compatKeysPerFeatureMean: doneKeys.length / featureCount,
     compatKeysPerFeatureMedian: (() => {

--- a/scripts/stats.ts
+++ b/scripts/stats.ts
@@ -17,8 +17,8 @@ export function stats(detailed: boolean = false) {
   const featureCount = Object.keys(features).length;
 
   const keys = [];
-  const doneKeys = Object.values(features).flatMap(
-    (f) => f.compat_features ?? [],
+  const doneKeys = Array.from(
+    new Set(Object.values(features).flatMap((f) => f.compat_features ?? [])),
   );
   const toDoKeys = [];
   const deprecatedNonStandardKeys = [];


### PR DESCRIPTION
Now that we're adding discouraged features, we shouldn't exclude those keys from the count. This correctly measures the total keys remaining (with `currentBurndownSize` continuing to represent standard, non-deprecated keys).

I've also future proofed the count, in the case of allowing a key to appear in multiple features.