### PR TITLE
Make CSS length unit descriptions consistent

### DIFF
--- a/features/cap.yml
+++ b/features/cap.yml
@@ -1,4 +1,4 @@
 name: cap unit
-description: The CSS `cap` unit corresponds to the height of Latin capital letters.
+description: The `cap` CSS length unit corresponds to the height of Latin capital letters.
 spec: https://drafts.csswg.org/css-values-4/#cap
 group: units

--- a/features/ic.yml
+++ b/features/ic.yml
@@ -1,4 +1,4 @@
 name: ic unit
-description: The CSS `ic` unit corresponds to the width of CJK ideographic characters.
+description: The `ic` CSS length unit corresponds to the width of CJK ideographic characters.
 spec: https://drafts.csswg.org/css-values-4/#ic
 group: units

--- a/features/lh.yml
+++ b/features/lh.yml
@@ -1,4 +1,4 @@
 name: lh unit
-description: The CSS `lh` unit corresponds to the requested line height, the computed value of the `line-height` property. Some lines may be higher than this based on their content.
+description: The `lh` CSS length unit corresponds to the requested line height, the computed value of the `line-height` property. Some lines may be higher than this based on their content.
 spec: https://drafts.csswg.org/css-values-4/#lh
 group: units


### PR DESCRIPTION
This is the style of the other units, like `ch`.
