### PR TITLE
`wasm-string-builtins`: add keys tagged in BCD

### DIFF
--- a/features/wasm-string-builtins.yml
+++ b/features/wasm-string-builtins.yml
@@ -4,3 +4,9 @@ spec: https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-s
 group: webassembly
 compat_features:
   - webassembly.jsStringBuiltins
+  - webassembly.api.Module.Module.compile_options
+  - webassembly.api.compile_static.compile_options
+  - webassembly.api.compileStreaming_static.compile_options
+  - webassembly.api.instantiate_static.compile_options
+  - webassembly.api.instantiateStreaming_static.compile_options
+  - webassembly.api.validate_static.compile_options

--- a/features/wasm-string-builtins.yml.dist
+++ b/features/wasm-string-builtins.yml.dist
@@ -6,7 +6,23 @@ status:
   support:
     chrome: "130"
     edge: "130"
-    firefox: "134"
-    firefox_android: "134"
 compat_features:
+  # baseline: false
+  # support:
+  #   chrome: "130"
+  #   edge: "130"
+  #   firefox: "134"
+  #   firefox_android: "134"
   - webassembly.jsStringBuiltins
+
+  # baseline: false
+  # support:
+  #   chrome: "130"
+  #   chrome_android: "130"
+  #   edge: "130"
+  - webassembly.api.Module.Module.compile_options
+  - webassembly.api.compileStreaming_static.compile_options
+  - webassembly.api.compile_static.compile_options
+  - webassembly.api.instantiateStreaming_static.compile_options
+  - webassembly.api.instantiate_static.compile_options
+  - webassembly.api.validate_static.compile_options


### PR DESCRIPTION
These keys are tagged as part of the feature in BCD, but not here.