### PR TITLE
Disallow unused variables

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,8 +4,15 @@ import tseslint from "typescript-eslint";
 export default tseslint.config(tseslint.configs.base, {
   plugins: { newWithError },
   rules: {
-    "no-throw-literal": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        caughtErrors: "none",
+      },
+    ],
     "newWithError/new-with-error": "error",
+    "no-duplicate-imports": "error",
+    "no-throw-literal": "error",
   },
   files: ["**/*.ts"],
 });

--- a/packages/compute-baseline/src/browser-compat-data/feature.test.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 
 import { feature } from "./feature.js";
-import { browser, Compat } from "./index.js";
+import { browser } from "./index.js";
 
 describe("features", function () {
   describe("feature()", function () {
@@ -104,7 +104,6 @@ describe("features", function () {
 
     describe("supportedIn()", function () {
       it("returns support for features supported with and without qualification", function () {
-        const compat = new Compat();
         const cr = browser("chrome");
 
         // { version_added: "…" }

--- a/scripts/caniuse.ts
+++ b/scripts/caniuse.ts
@@ -5,7 +5,7 @@ import { features } from '../index.js';
 
 const logger = winston.createLogger({
     level: 'info',
-    format: winston.format.printf(({level, message}) => `${message}`)
+    format: winston.format.printf(({message}) => `${message}`)
 })
 
 if (process.argv.includes("--quiet")) {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -74,8 +74,6 @@ yargs(process.argv.slice(2))
 function init(args) {
   preflight({ expectedBranch: "main" });
 
-  const diff = diffJson();
-
   // Start a release branch
   // Convention borrowed from https://github.com/w3c/webref/blob/60ebf71b9d555c523975cfefb08f5420d12b7293/tools/prepare-release.js#L164-L165
   const releaseBranch = `release/web-features/${new Date()


### PR DESCRIPTION
This enables an eslint rule to prevent unused variables everywhere, cementing a suggestion from @Elchi3 in https://github.com/web-platform-dx/web-features/pull/2544#discussion_r1923807759.