### PR TITLE
Add holding features unspecified platform features

### DIFF
--- a/features/unspecified-apis.yml
+++ b/features/unspecified-apis.yml
@@ -1,0 +1,13 @@
+name: Unspecified APIs
+description: Some browsers implement unspecified APIs. This is an artificial feature that contains references to browser compatibility data entries for those additions. You should not use or rely on anything referenced by this feature.
+spec: link to our own documentation explaining ourselves in more detail
+discouraged:
+  according_to:
+    - TODO link to our own documentation explaining ourselves in more detail
+compat_features: 
+  # These `Screen` properties are broadly interoperable but unspecified.
+  # https://github.com/w3c/window-management/pull/76#discussion_r780596068 contains the only discussion I could find of this fact.
+  - api.Screen.availLeft
+  - api.Screen.availLeft.relative-multi-screen
+  - api.Screen.availTop
+  - api.Screen.availTop.relative-multi-screen

--- a/features/unspecified-css.yml
+++ b/features/unspecified-css.yml
@@ -1,0 +1,9 @@
+name: Unspecified CSS
+description: Some browsers implement unspecified CSS properties or values. This is an artificial feature that contains references to browser compatibility data entries for those additions.
+spec: TODO link to our own documentation explaining ourselves in more detail
+discouraged:
+  according_to:
+    - TODO link to our own documentation explaining ourselves in more detail
+compat_features: 
+  # Removed from the platform, but not yet removed from BCD
+  - -moz-image-region  # To be removed in March 2025

--- a/features/unspecified-javascript.yml
+++ b/features/unspecified-javascript.yml
@@ -1,0 +1,12 @@
+name: Unspecified JavaScript
+description: Some browsers implement unspecified JavaScript properties or methods. This is an artificial feature that contains references to browser compatibility data entries for those additions. You should not use or rely on anything referenced by this feature.
+spec: link to our own documentation explaining ourselves in more detail
+discouraged:
+  according_to:
+    - TODO link to our own documentation explaining ourselves in more detail
+compat_features:
+  # Firefox-only Erorr properties
+  - javascript.builtins.Error.Error.lineNumber_parameter
+  - javascript.builtins.Error.lineNumber
+  - javascript.builtins.Error.Error.fileName_parameter
+  - javascript.builtins.Error.fileName


### PR DESCRIPTION
This PR contains features that hold compat keys for unspecified platform features. See https://github.com/web-platform-dx/web-features/issues/1497#issuecomment-2248096269 for candidate keys. These are features of last resort for keys that cannot be assigned to a "real" feature (discouraged or otherwise), for lack of a specification.

If you have privileges on this repo, then you're welcome to push additional commits to add keys as you review them. But before you do so, please take a few minutes to confirm that:

- The key lacks a `spec_url` value in BCD.
- The key has `standard_track` value set to `false` in BCD.
- The feature was not _formerly_ part of a spec or explicitly excluded from a specification (i.e., the specification process intentionally favored a standardized alternative). Such keys might be candidate for actual features (https://github.com/web-platform-dx/web-features/pull/2565 for an example).

  Good places to find this information include:

  - The BCD key's Git blame view and BCD repo PRs
  - GitHub repos and orgs, such as [w3c/csswg-drafts](https://github.com/w3c/csswg-drafts), [WHATWG](https://github.com/whatwg), and [TC39](https://github.com/tc39).
  - Browser bug trackers (best for keys with single-implementations)
