### PR TITLE
`title-attr`: add missing key

### DIFF
--- a/features/title-attr.yml
+++ b/features/title-attr.yml
@@ -1,4 +1,4 @@
-name: Title
+name: title (attribute)
 description: The `title` global HTML attribute sets information about an element, such as a name or description. The value is typically shown as a tooltip that appears on mouse over. Since it's not often available to touch-only, keyboard-only, or assistive technology users, it's not a substitute for other text.
 spec: https://html.spec.whatwg.org/multipage/dom.html#attr-title
 status:

--- a/features/title-attr.yml
+++ b/features/title-attr.yml
@@ -1,6 +1,9 @@
 name: Title
 description: The `title` global HTML attribute sets information about an element, such as a name or description. The value is typically shown as a tooltip that appears on mouse over. Since it's not often available to touch-only, keyboard-only, or assistive technology users, it's not a substitute for other text.
 spec: https://html.spec.whatwg.org/multipage/dom.html#attr-title
+status:
+  compute_from: html.global_attributes.title
 compat_features:
   - api.HTMLElement.title
   - html.global_attributes.title
+  - html.global_attributes.title.multi-line_titles

--- a/features/title-attr.yml.dist
+++ b/features/title-attr.yml.dist
@@ -40,3 +40,16 @@ compat_features:
   #   safari: ≤4
   #   safari_ios: ≤3.2
   - html.global_attributes.title
+
+  # baseline: high
+  # baseline_low_date: ≤2018-01-23
+  # baseline_high_date: ≤2020-07-23
+  # support:
+  #   chrome: ≤64
+  #   chrome_android: ≤64
+  #   edge: "12"
+  #   firefox: ≤58
+  #   firefox_android: ≤58
+  #   safari: ≤11
+  #   safari_ios: ≤11
+  - html.global_attributes.title.multi-line_titles


### PR DESCRIPTION
This adds a missing key.

While I was here, I fixed up the title of `title-attr` (this title) to better distinguish from the title of `title` (for `<title>`).