### PR TITLE
`intl`: add constructor symbol keys

### DIFF
--- a/features/intl.yml
+++ b/features/intl.yml
@@ -26,6 +26,7 @@ compat_features:
   - javascript.builtins.Intl.Collator.supportedLocalesOf
   - javascript.builtins.Intl.DateTimeFormat
   - javascript.builtins.Intl.DateTimeFormat.DateTimeFormat
+  - javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.IntlLegacyConstructedSymbol
   - javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.locales_parameter
   - javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter
   - javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter.options_calendar_parameter
@@ -48,6 +49,7 @@ compat_features:
   - javascript.builtins.Intl.DateTimeFormat.supportedLocalesOf
   - javascript.builtins.Intl.NumberFormat
   - javascript.builtins.Intl.NumberFormat.NumberFormat
+  - javascript.builtins.Intl.NumberFormat.NumberFormat.IntlLegacyConstructedSymbol
   - javascript.builtins.Intl.NumberFormat.NumberFormat.locales_parameter
   - javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter
   - javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_compactDisplay_parameter

--- a/features/intl.yml.dist
+++ b/features/intl.yml.dist
@@ -391,6 +391,20 @@ compat_features:
   - javascript.builtins.Intl.Collator.Collator.options_collation_parameter
 
   # baseline: high
+  # baseline_low_date: 2021-05-27
+  # baseline_high_date: 2023-11-27
+  # support:
+  #   chrome: "91"
+  #   chrome_android: "91"
+  #   edge: "91"
+  #   firefox: "54"
+  #   firefox_android: "56"
+  #   safari: "14.1"
+  #   safari_ios: "14.5"
+  - javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.IntlLegacyConstructedSymbol
+  - javascript.builtins.Intl.NumberFormat.NumberFormat.IntlLegacyConstructedSymbol
+
+  # baseline: high
   # baseline_low_date: 2021-07-22
   # baseline_high_date: 2024-01-22
   # support:


### PR DESCRIPTION
This adds two keys which recently had their deprecation status changed (https://github.com/mdn/browser-compat-data/pull/25749). This is a weird little corner of the `Intl` API but widely supported, so it's easy to slot in here. 

See also: https://github.com/web-platform-dx/web-features/pull/2564