### PR TITLE
Use GitHub Discussions for periodic announcements

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -4,12 +4,12 @@
 
 web-features uses a GitHub Discussions thread to give notice of breaking changes and other major changes to interested web-features consumers.
 
-If you want to receive these announcements, subscribe to the [Upcoming changes](https://github.com/web-platform-dx/web-features/discussions/123456789) <!-- TODO: link to the actual discussion thread, after it's created --> announcements thread or to all discussions through the repository's _Watch_ menu.
+If you want to receive these announcements, subscribe to the [Upcoming changes](https://github.com/web-platform-dx/web-features/discussions/2613) announcements thread or to all discussions through the repository's _Watch_ menu.
 
 > [!NOTE]
 > The remainder of this section is for [project owners](../GOVERNANCE.md#roles-and-responsibilities).
 
-If you're planning to publish a breaking release (see [Regular releases](#regular-releases)) in the next two weeks, then post a message to the [Upcoming changes](https://github.com/web-platform-dx/web-features/discussions/123456789) <!-- TODO: link to the actual discussion thread, after it's created --> announcements thread.
+If you're planning to publish a breaking release (see [Regular releases](#regular-releases)) in the next two weeks, then post a message to the [Upcoming changes](https://github.com/web-platform-dx/web-features/discussions/2613) announcements thread.
 Include a summary of the expected changes, citing relevant issues and pull requests.
 
 Note that an announcement is not a substitute for seeking consumer feedback early in the design and implementation process.
@@ -68,7 +68,7 @@ These are the steps to publish a regular release on npm and as a GitHub release:
    1. Append this message to the end of the release notes:
 
       ```markdown
-      Subscribe to the [Upcoming changes](https://github.com/web-platform-dx/web-features/discussions/123456789) <!-- TODO: link to the actual discussion thread, after it's created --> announcements thread for news about upcoming releases, such as breaking changes or major features.
+      Subscribe to the [Upcoming changes](https://github.com/web-platform-dx/web-features/discussions/2613) announcements thread for news about upcoming releases, such as breaking changes or major features.
       ```
 
    1. Click **Publish release**.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -65,6 +65,12 @@ These are the steps to publish a regular release on npm and as a GitHub release:
       ```
 
    1. Remove all lines from Dependabot.
+   1. Append this message to the end of the release notes:
+
+      ```markdown
+      Subscribe to our [Upcoming changes](https://github.com/web-platform-dx/web-features/discussions/123456789) <!-- TODO: link to the actual discussion thread, after it's created --> announcements thread, for advance notice of breaking changes or other significant changes.
+      ```
+
    1. Click **Publish release**.
 
    Publishing the GitHub release creates the tag. This triggers the [Publish web-features GitHub Actions workflows](https://github.com/web-platform-dx/web-features/blob/main/.github/workflows/publish_web-features.yml), uploads GitHub release artifacts and publishes the package to npm.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -68,7 +68,7 @@ These are the steps to publish a regular release on npm and as a GitHub release:
    1. Append this message to the end of the release notes:
 
       ```markdown
-      Subscribe to our [Upcoming changes](https://github.com/web-platform-dx/web-features/discussions/123456789) <!-- TODO: link to the actual discussion thread, after it's created --> announcements thread, for advance notice of breaking changes or other significant changes.
+      Subscribe to the [Upcoming changes](https://github.com/web-platform-dx/web-features/discussions/123456789) <!-- TODO: link to the actual discussion thread, after it's created --> announcements thread for news about upcoming releases, such as breaking changes or major features.
       ```
 
    1. Click **Publish release**.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,9 +1,24 @@
-# Publishing
+# Publishing releases
+
+## Announcements
+
+web-features uses a GitHub Discussions thread to give notice of breaking changes and other major changes to interested web-features consumers.
+
+If you want to receive these announcements, subscribe to the [Upcoming changes](https://github.com/web-platform-dx/web-features/discussions/123456789) <!-- TODO: link to the actual discussion thread, after it's created --> announcements thread or to all discussions through the repository's _Watch_ menu.
+
+> [!NOTE]
+> The remainder of this section is for [project owners](../GOVERNANCE.md#roles-and-responsibilities).
+
+If you're planning to publish a breaking release (see [Regular releases](#regular-releases)) in the next two weeks, then post a message to the [Upcoming changes](https://github.com/web-platform-dx/web-features/discussions/123456789) <!-- TODO: link to the actual discussion thread, after it's created --> announcements thread.
+Include a summary of the expected changes, citing relevant issues and pull requests.
+
+Note that an announcement is not a substitute for seeking consumer feedback early in the design and implementation process.
+Announcements should not provoke surprising responses from consumers.
 
 ## Regular releases
 
 > [!NOTE]
-> This information is for [project owners](../GOVERNANCE.md#roles-and-responsibilities).
+> This section is for [project owners](../GOVERNANCE.md#roles-and-responsibilities).
 
 These are the steps to publish a regular release on npm and as a GitHub release:
 
@@ -69,7 +84,7 @@ You can install these prereleases using a command such as `npm install web-featu
 ## Secrets
 
 > [!NOTE]
-> This information is for [project owners](../GOVERNANCE.md#roles-and-responsibilities).
+> This section is for [project owners](../GOVERNANCE.md#roles-and-responsibilities).
 
 Publishing requires the `NPM_TOKEN` repository secret.
 

--- a/packages/web-features/README.md
+++ b/packages/web-features/README.md
@@ -2,7 +2,7 @@
 
 [web-features](https://web-platform-dx.github.io/web-features/web-features/) is the package that describes Web platform features and provides [Baseline](https://web-platform-dx.github.io/web-features/) status reports.
 
-Subscribe to the [Upcoming changes](https://github.com/web-platform-dx/web-features/discussions/123456789) <!-- TODO: link to the actual discussion thread, after it's created --> announcements thread for news about upcoming releases, such as breaking changes or major features.
+Subscribe to the [Upcoming changes](https://github.com/web-platform-dx/web-features/discussions/2613) announcements thread for news about upcoming releases, such as breaking changes or major features.
 
 ## Usage
 

--- a/packages/web-features/README.md
+++ b/packages/web-features/README.md
@@ -1,5 +1,9 @@
 # Curated list of Web platform features
 
+[web-features](https://web-platform-dx.github.io/web-features/web-features/) is the package that describes Web platform features and provides [Baseline](https://web-platform-dx.github.io/web-features/) status reports.
+
+Subscribe to the [Upcoming changes](https://github.com/web-platform-dx/web-features/discussions/123456789) <!-- TODO: link to the actual discussion thread, after it's created --> announcements thread for news about upcoming releases, such as breaking changes or major features.
+
 ## Usage
 
 ```sh


### PR DESCRIPTION
A couple of weeks ago, it came up on the WebDX call that we should have a dedicated announcements channel for web-features consumers. This is my proposal for doing that.

This PR adds documentation describing a process for publishing project announcements to GitHub Discussions.

If we choose to merge this PR, then we'll need to do the following just before merging:

- [x] Turn on Discussions in the repository settings.
- [x] Create a thread to post announcements to that is open to subscribing for notifications, but not open generally to replies (i.e., is locked)
- [x] Turn off all other discussions (we don't really have a use for non-announcements yet).
- [x] Update the documentation to link to the thread.

After merging, we should:

- [ ] Link to discussion thread and this PR's documentation in the next release's release notes.