### PR TITLE
Park more keys in `declarative-shadow-dom`

### DIFF
--- a/features/declarative-shadow-dom.yml
+++ b/features/declarative-shadow-dom.yml
@@ -5,3 +5,14 @@ group:
   - html
   - web-components
 caniuse: declarative-shadow-dom
+status:
+  compute_from: html.elements.template.shadowrootmode
+compat_features:
+  - api.HTMLTemplateElement.shadowRootClonable
+  - api.HTMLTemplateElement.shadowRootMode
+  - api.HTMLTemplateElement.shadowRootDelegatesFocus
+  - api.HTMLTemplateElement.shadowRootSerializable
+  - html.elements.template.shadowrootmode
+  - html.elements.template.shadowrootclonable
+  - html.elements.template.shadowrootdelegatesfocus
+  - html.elements.template.shadowrootserializable

--- a/features/declarative-shadow-dom.yml.dist
+++ b/features/declarative-shadow-dom.yml.dist
@@ -13,5 +13,77 @@ status:
     safari: "16.4"
     safari_ios: "16.4"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: low
+  # baseline_low_date: 2024-02-20
+  # support:
+  #   chrome: "111"
+  #   chrome_android: "111"
+  #   edge: "111"
+  #   firefox: "123"
+  #   firefox_android: "123"
+  #   safari: "16.4"
+  #   safari_ios: "16.4"
   - api.HTMLTemplateElement.shadowRootMode
   - html.elements.template.shadowrootmode
+
+  # baseline: low
+  # baseline_low_date: 2024-09-16
+  # support:
+  #   chrome: "123"
+  #   chrome_android: "123"
+  #   edge: "123"
+  #   firefox: "123"
+  #   firefox_android: "123"
+  #   safari: "18"
+  #   safari_ios: "18"
+  - api.HTMLTemplateElement.shadowRootDelegatesFocus
+
+  # baseline: low
+  # baseline_low_date: 2024-09-16
+  # support:
+  #   chrome: "124"
+  #   chrome_android: "124"
+  #   edge: "124"
+  #   firefox: "125"
+  #   firefox_android: "125"
+  #   safari: "18"
+  #   safari_ios: "18"
+  - api.HTMLTemplateElement.shadowRootClonable
+
+  # baseline: low
+  # baseline_low_date: 2024-09-16
+  # support:
+  #   chrome: "125"
+  #   chrome_android: "125"
+  #   edge: "125"
+  #   firefox: "128"
+  #   firefox_android: "128"
+  #   safari: "18"
+  #   safari_ios: "18"
+  - api.HTMLTemplateElement.shadowRootSerializable
+
+  # baseline: false
+  # support:
+  #   chrome: "123"
+  #   chrome_android: "123"
+  #   edge: "123"
+  #   firefox: "123"
+  #   firefox_android: "123"
+  - html.elements.template.shadowrootdelegatesfocus
+
+  # baseline: false
+  # support:
+  #   chrome: "124"
+  #   chrome_android: "124"
+  #   edge: "124"
+  #   firefox: "125"
+  #   firefox_android: "125"
+  - html.elements.template.shadowrootclonable
+
+  # baseline: false
+  # support:
+  #   chrome: "125"
+  #   chrome_android: "125"
+  #   edge: "125"
+  - html.elements.template.shadowrootserializable


### PR DESCRIPTION
I'm not sure if this is ideal, but it's the compromise I came up with.

I think it's possible that clonable shadow trees is a feature. But I can only find lots and lots of "no you can't clone shadow roots" (and a few blog posts saying why it's a bad idea) and little fanfare over clonable shadow roots.

The bits are even more obscure and I found it difficult to break them into distinct features.