### PR TITLE
Add `AggregateError.serializable_object` to `Promise.any()` feature

### DIFF
--- a/features/promise-any.yml
+++ b/features/promise-any.yml
@@ -3,8 +3,11 @@ description: The `Promise.any()` static method returns a promise that fulfills a
 snapshot: ecmascript-2021
 spec: https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.any
 group: promises
+status:
+  compute_from: javascript.builtins.Promise.any
 compat_features:
   - javascript.builtins.Promise.any
   - javascript.builtins.AggregateError
   - javascript.builtins.AggregateError.AggregateError
+  - javascript.builtins.AggregateError.serializable_object
   - javascript.builtins.AggregateError.errors

--- a/features/promise-any.yml.dist
+++ b/features/promise-any.yml.dist
@@ -14,7 +14,31 @@ status:
     safari: "14"
     safari_ios: "14"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: high
+  # baseline_low_date: 2020-09-16
+  # baseline_high_date: 2023-03-16
+  # support:
+  #   chrome: "85"
+  #   chrome_android: "85"
+  #   edge: "85"
+  #   firefox: "79"
+  #   firefox_android: "79"
+  #   safari: "14"
+  #   safari_ios: "14"
   - javascript.builtins.AggregateError
   - javascript.builtins.AggregateError.AggregateError
   - javascript.builtins.AggregateError.errors
   - javascript.builtins.Promise.any
+
+  # baseline: low
+  # baseline_low_date: 2023-09-18
+  # support:
+  #   chrome: "98"
+  #   chrome_android: "98"
+  #   edge: "98"
+  #   firefox: "103"
+  #   firefox_android: "103"
+  #   safari: "17"
+  #   safari_ios: "17"
+  - javascript.builtins.AggregateError.serializable_object


### PR DESCRIPTION
This assigns a key for AggregateError to the best place I think it belongs at the moment.

There's a case to be made that it belongs with `serializable-errors`. I did not go this route because a) the description excludes AggregateError and b) the standardization of this behavior is weird.

See https://github.com/mdn/browser-compat-data/pull/25744 and https://github.com/mdn/browser-compat-data/pull/25795 for more details about the standardization and implementation history.