### PR TITLE
Add more keys to Web Audio

### DIFF
--- a/features/web-audio.yml
+++ b/features/web-audio.yml
@@ -66,6 +66,11 @@ compat_features:
   - api.AudioListener.upX
   - api.AudioListener.upY
   - api.AudioListener.upZ
+  # The following 2 keys are deprecated, but are currently the only way to set
+  # the listener orientation and position in Firefox. So we're keeping them here
+  # for now.
+  - api.AudioListener.setOrientation
+  - api.AudioListener.setPosition
   - api.AudioNode
   - api.AudioNode.channelCount
   - api.AudioNode.channelCountMode


### PR DESCRIPTION
`api.AudioListener.setOrientation` and `api.AudioListener.setPosition` are deprecated but are currently the only way to set an audio listener's orientation and position in Firefox. So there's no use creating a discouraged feature for this. At least not until https://bugzil.la/1283029 gets fixed and BCD gets updated.

For now, why don't we put these keys under Web Audio. Anyway, the whole feature uses a `compute_from` field which will hide any weirdness from these keys.