### PR TITLE
Move `file-and-directory-entries` out of drafts

### DIFF
--- a/features/file-and-directory-entries.yml
+++ b/features/file-and-directory-entries.yml
@@ -1,4 +1,3 @@
-draft_date: 2024-05-07
 name: File and directory entries
 description: File and directory entries represent a virtual file system for working with files and directories dragged and dropped into the browser.
 spec: https://wicg.github.io/entries-api/
@@ -11,14 +10,15 @@ compat_features:
   - api.FileSystemDirectoryEntry.createReader
   - api.FileSystemDirectoryEntry.getDirectory
   - api.FileSystemDirectoryEntry.getFile
-  - api.FileSystemDirectoryHandle
-  - api.FileSystemDirectoryHandle.entries
-  - api.FileSystemDirectoryHandle.getDirectoryHandle
-  - api.FileSystemDirectoryHandle.getFileHandle
-  - api.FileSystemDirectoryHandle.keys
-  - api.FileSystemDirectoryHandle.removeEntry
-  - api.FileSystemDirectoryHandle.resolve
-  - api.FileSystemDirectoryHandle.values
+  # Uncomment on resolving https://github.com/web-platform-dx/web-features/issues/1173
+  # - api.FileSystemDirectoryHandle
+  # - api.FileSystemDirectoryHandle.entries
+  # - api.FileSystemDirectoryHandle.getDirectoryHandle
+  # - api.FileSystemDirectoryHandle.getFileHandle
+  # - api.FileSystemDirectoryHandle.keys
+  # - api.FileSystemDirectoryHandle.removeEntry
+  # - api.FileSystemDirectoryHandle.resolve
+  # - api.FileSystemDirectoryHandle.values
   - api.FileSystemDirectoryHandle.@@asyncIterator
   - api.FileSystemDirectoryReader
   - api.FileSystemDirectoryReader.readEntries
@@ -31,10 +31,11 @@ compat_features:
   - api.FileSystemEntry.name
   - api.FileSystemFileEntry
   - api.FileSystemFileEntry.file
-  - api.FileSystemFileHandle
-  - api.FileSystemFileHandle.getFile
-  - api.FileSystemHandle
-  - api.FileSystemHandle.isSameEntry
-  - api.FileSystemHandle.kind
-  - api.FileSystemHandle.name
+  # Uncomment on resolving https://github.com/web-platform-dx/web-features/issues/1173
+  # - api.FileSystemFileHandle
+  # - api.FileSystemFileHandle.getFile
+  # - api.FileSystemHandle
+  # - api.FileSystemHandle.isSameEntry
+  # - api.FileSystemHandle.kind
+  # - api.FileSystemHandle.name
   - api.HTMLInputElement.webkitEntries

--- a/features/file-and-directory-entries.yml.dist
+++ b/features/file-and-directory-entries.yml.dist
@@ -90,31 +90,6 @@ compat_features:
   - api.FileSystemDirectoryEntry.createReader
 
   # baseline: low
-  # baseline_low_date: 2023-03-14
-  # support:
-  #   chrome: "86"
-  #   chrome_android: "109"
-  #   edge: "86"
-  #   firefox: "111"
-  #   firefox_android: "111"
-  #   safari: "15.2"
-  #   safari_ios: "15.2"
-  - api.FileSystemDirectoryHandle
-  - api.FileSystemDirectoryHandle.entries
-  - api.FileSystemDirectoryHandle.getDirectoryHandle
-  - api.FileSystemDirectoryHandle.getFileHandle
-  - api.FileSystemDirectoryHandle.keys
-  - api.FileSystemDirectoryHandle.removeEntry
-  - api.FileSystemDirectoryHandle.resolve
-  - api.FileSystemDirectoryHandle.values
-  - api.FileSystemFileHandle
-  - api.FileSystemFileHandle.getFile
-  - api.FileSystemHandle
-  - api.FileSystemHandle.isSameEntry
-  - api.FileSystemHandle.kind
-  - api.FileSystemHandle.name
-
-  # baseline: low
   # baseline_low_date: 2023-03-27
   # support:
   #   chrome: "86"

--- a/features/file-system-access.yml
+++ b/features/file-system-access.yml
@@ -4,7 +4,8 @@ spec: https://wicg.github.io/file-system-access/
 caniuse: native-filesystem-api
 group: file-system
 compat_features:
-  - api.FileSystemDirectoryHandle.@@asyncIterator
+  # Uncomment on resolving https://github.com/web-platform-dx/web-features/issues/1173
+  # - api.FileSystemDirectoryHandle.@@asyncIterator
   - api.FileSystemFileHandle.createWritable
   - api.FileSystemHandle.queryPermission
   - api.FileSystemHandle.requestPermission

--- a/features/file-system-access.yml.dist
+++ b/features/file-system-access.yml.dist
@@ -8,18 +8,6 @@ status:
     chrome_android: "132"
     edge: "86"
 compat_features:
-  # baseline: low
-  # baseline_low_date: 2023-03-27
-  # support:
-  #   chrome: "86"
-  #   chrome_android: "109"
-  #   edge: "86"
-  #   firefox: "111"
-  #   firefox_android: "111"
-  #   safari: "16.4"
-  #   safari_ios: "16.4"
-  - api.FileSystemDirectoryHandle.@@asyncIterator
-
   # baseline: false
   # support:
   #   chrome: "86"


### PR DESCRIPTION
This is an extremely old draft feature that we added almost at the very beginning. It kinda works still but overlapping keys are a bit of a fuss.

See also: https://github.com/web-platform-dx/web-features/pull/2632