### PR TITLE
Add more keys to `shadow-dom`

### DIFF
--- a/features/shadow-dom.yml
+++ b/features/shadow-dom.yml
@@ -5,3 +5,19 @@ caniuse: shadowdomv1
 group: web-components
 status:
   compute_from: api.Element.attachShadow
+compat_features:
+  - api.Element.attachShadow
+  - api.Element.shadowRoot
+  - api.Element.attachShadow.options_clonable_parameter
+  - api.Element.attachShadow.options_delegatesFocus_parameter
+  - api.Element.attachShadow.options_serializable_parameter
+  - api.Event.composed
+  - api.Event.composedPath
+  - api.Node.getRootNode
+  - api.Node.isConnected
+  - api.ShadowRoot
+  - api.ShadowRoot.clonable
+  - api.ShadowRoot.delegatesFocus
+  - api.ShadowRoot.host
+  - api.ShadowRoot.mode
+  - api.ShadowRoot.serializable

--- a/features/shadow-dom.yml.dist
+++ b/features/shadow-dom.yml.dist
@@ -108,6 +108,32 @@ compat_features:
   #   safari_ios: "10.3"
   - api.Node.getRootNode
 
+  # baseline: high
+  # baseline_low_date: 2021-11-02
+  # baseline_high_date: 2024-05-02
+  # support:
+  #   chrome: "53"
+  #   chrome_android: "53"
+  #   edge: "79"
+  #   firefox: "94"
+  #   firefox_android: "94"
+  #   safari: "13.1"
+  #   safari_ios: "13.4"
+  - api.Element.attachShadow.options_delegatesFocus_parameter
+
+  # baseline: high
+  # baseline_low_date: 2021-11-02
+  # baseline_high_date: 2024-05-02
+  # support:
+  #   chrome: "53"
+  #   chrome_android: "53"
+  #   edge: "79"
+  #   firefox: "94"
+  #   firefox_android: "94"
+  #   safari: "15"
+  #   safari_ios: "15"
+  - api.ShadowRoot.delegatesFocus
+
   # baseline: low
   # baseline_low_date: 2024-04-18
   # support:
@@ -118,4 +144,24 @@ compat_features:
   #   firefox_android: "123"
   #   safari: "17.4"
   #   safari_ios: "17.4"
+  - api.Element.attachShadow.options_clonable_parameter
   - api.ShadowRoot.clonable
+
+  # baseline: low
+  # baseline_low_date: 2024-09-16
+  # support:
+  #   chrome: "125"
+  #   chrome_android: "125"
+  #   edge: "125"
+  #   firefox: "128"
+  #   firefox_android: "128"
+  #   safari: "18"
+  #   safari_ios: "18"
+  - api.ShadowRoot.serializable
+
+  # baseline: false
+  # support:
+  #   chrome: "125"
+  #   chrome_android: "125"
+  #   edge: "125"
+  - api.Element.attachShadow.options_serializable_parameter


### PR DESCRIPTION
This adds keys in a similar style as https://github.com/web-platform-dx/web-features/pull/2596, but for `attachShadow()`.