### PR TITLE
`cookie-store`: add new keys

### DIFF
--- a/features/cookie-store.yml
+++ b/features/cookie-store.yml
@@ -7,7 +7,21 @@ compat_features:
   - api.CookieStore.change_event
   - api.CookieStore.delete
   - api.CookieStore.get
+  - api.CookieStore.get.domain_return_property
+  - api.CookieStore.get.expires_return_property
+  - api.CookieStore.get.name_return_property
+  - api.CookieStore.get.path_return_property
+  - api.CookieStore.get.sameSite_return_property
+  - api.CookieStore.get.secure_return_property
+  - api.CookieStore.get.value_return_property
   - api.CookieStore.getAll
+  - api.CookieStore.getAll.domain_return_property
+  - api.CookieStore.getAll.expires_return_property
+  - api.CookieStore.getAll.name_return_property
+  - api.CookieStore.getAll.path_return_property
+  - api.CookieStore.getAll.sameSite_return_property
+  - api.CookieStore.getAll.secure_return_property
+  - api.CookieStore.getAll.value_return_property
   - api.CookieStore.set
   - api.CookieStoreManager
   - api.CookieStoreManager.getSubscriptions
@@ -16,8 +30,22 @@ compat_features:
   - api.ServiceWorkerRegistration.cookies
   - api.CookieChangeEvent
   - api.CookieChangeEvent.changed
+  - api.CookieChangeEvent.changed.domain_property
+  - api.CookieChangeEvent.changed.expires_property
+  - api.CookieChangeEvent.changed.name_property
+  - api.CookieChangeEvent.changed.path_property
+  - api.CookieChangeEvent.changed.sameSite_property
+  - api.CookieChangeEvent.changed.secure_property
+  - api.CookieChangeEvent.changed.value_property
   - api.CookieChangeEvent.CookieChangeEvent
   - api.CookieChangeEvent.deleted
+  - api.CookieChangeEvent.deleted.domain_property
+  - api.CookieChangeEvent.deleted.expires_property
+  - api.CookieChangeEvent.deleted.name_property
+  - api.CookieChangeEvent.deleted.path_property
+  - api.CookieChangeEvent.deleted.sameSite_property
+  - api.CookieChangeEvent.deleted.secure_property
+  - api.CookieChangeEvent.deleted.value_property
   - api.ExtendableCookieChangeEvent
   - api.ExtendableCookieChangeEvent.changed
   - api.ExtendableCookieChangeEvent.deleted

--- a/features/cookie-store.yml.dist
+++ b/features/cookie-store.yml.dist
@@ -11,12 +11,40 @@ compat_features:
   - api.CookieChangeEvent
   - api.CookieChangeEvent.CookieChangeEvent
   - api.CookieChangeEvent.changed
+  - api.CookieChangeEvent.changed.domain_property
+  - api.CookieChangeEvent.changed.expires_property
+  - api.CookieChangeEvent.changed.name_property
+  - api.CookieChangeEvent.changed.path_property
+  - api.CookieChangeEvent.changed.sameSite_property
+  - api.CookieChangeEvent.changed.secure_property
+  - api.CookieChangeEvent.changed.value_property
   - api.CookieChangeEvent.deleted
+  - api.CookieChangeEvent.deleted.domain_property
+  - api.CookieChangeEvent.deleted.expires_property
+  - api.CookieChangeEvent.deleted.name_property
+  - api.CookieChangeEvent.deleted.path_property
+  - api.CookieChangeEvent.deleted.sameSite_property
+  - api.CookieChangeEvent.deleted.secure_property
+  - api.CookieChangeEvent.deleted.value_property
   - api.CookieStore
   - api.CookieStore.change_event
   - api.CookieStore.delete
   - api.CookieStore.get
+  - api.CookieStore.get.domain_return_property
+  - api.CookieStore.get.expires_return_property
+  - api.CookieStore.get.name_return_property
+  - api.CookieStore.get.path_return_property
+  - api.CookieStore.get.sameSite_return_property
+  - api.CookieStore.get.secure_return_property
+  - api.CookieStore.get.value_return_property
   - api.CookieStore.getAll
+  - api.CookieStore.getAll.domain_return_property
+  - api.CookieStore.getAll.expires_return_property
+  - api.CookieStore.getAll.name_return_property
+  - api.CookieStore.getAll.path_return_property
+  - api.CookieStore.getAll.sameSite_return_property
+  - api.CookieStore.getAll.secure_return_property
+  - api.CookieStore.getAll.value_return_property
   - api.CookieStore.set
   - api.CookieStoreManager
   - api.CookieStoreManager.getSubscriptions


### PR DESCRIPTION
BCD added a lot of new detail to this API.

https://github.com/mdn/browser-compat-data/pull/25894