### PR TITLE
Add new popover-related keys

### DIFF
--- a/features/anchor-positioning.yml
+++ b/features/anchor-positioning.yml
@@ -80,6 +80,10 @@ compat_features:
   - api.CSSPositionTryRule
   - api.CSSPositionTryRule.name
   - api.CSSPositionTryRule.style
+  - api.HTMLButtonElement.popoverTargetElement.implicit_anchor_reference
+  - api.HTMLElement.showPopover.source.implicit_anchor_reference
+  - api.HTMLElement.togglePopover.source.implicit_anchor_reference
+  - api.HTMLInputElement.popoverTargetElement.implicit_anchor_reference
   - css.at-rules.position-try
   - css.properties.align-items.anchor-center
   - css.properties.align-self.anchor-center
@@ -197,3 +201,5 @@ compat_features:
   - css.properties.right.anchor-size
   - css.properties.top.anchor-size
   - css.types.anchor-size.inset_margin
+  - html.elements.button.popovertarget.implicit_anchor_reference
+  - html.elements.input.popovertarget.implicit_anchor_reference

--- a/features/anchor-positioning.yml.dist
+++ b/features/anchor-positioning.yml.dist
@@ -228,5 +228,17 @@ compat_features:
   - css.types.anchor-size.inset_margin
 
   # baseline: false
+  # support:
+  #   chrome: "133"
+  #   chrome_android: "133"
+  #   edge: "133"
+  - api.HTMLButtonElement.popoverTargetElement.implicit_anchor_reference
+  - api.HTMLElement.showPopover.source.implicit_anchor_reference
+  - api.HTMLElement.togglePopover.source.implicit_anchor_reference
+  - api.HTMLInputElement.popoverTargetElement.implicit_anchor_reference
+  - html.elements.button.popovertarget.implicit_anchor_reference
+  - html.elements.input.popovertarget.implicit_anchor_reference
+
+  # baseline: false
   # support: {}
   - css.properties.position-anchor.auto

--- a/features/popover.yml
+++ b/features/popover.yml
@@ -8,6 +8,10 @@ group: html
 # References:
 # - https://github.com/mdn/browser-compat-data/issues/22927
 # - https://bugs.webkit.org/show_bug.cgi?id=267688
+status:
+  compute_from:
+    - api.HTMLElement.popover
+    - api.HTMLElement.togglePopover.returns_boolean
 compat_features:
   - api.HTMLButtonElement.popoverTargetAction
   - api.HTMLButtonElement.popoverTargetElement
@@ -16,8 +20,10 @@ compat_features:
   - api.HTMLElement.hidePopover
   - api.HTMLElement.popover
   - api.HTMLElement.showPopover
+  - api.HTMLElement.showPopover.source
   - api.HTMLElement.togglePopover
   - api.HTMLElement.togglePopover.returns_boolean
+  - api.HTMLElement.togglePopover.source
   - api.HTMLElement.toggle_event.popover_elements
   - api.HTMLInputElement.popoverTargetAction
   - api.HTMLInputElement.popoverTargetElement

--- a/features/popover.yml.dist
+++ b/features/popover.yml.dist
@@ -79,3 +79,11 @@ compat_features:
   #   safari: "17"
   #   safari_ios: "18.3"
   - api.HTMLElement.popover
+
+  # baseline: false
+  # support:
+  #   chrome: "133"
+  #   chrome_android: "133"
+  #   edge: "133"
+  - api.HTMLElement.showPopover.source
+  - api.HTMLElement.togglePopover.source


### PR DESCRIPTION
This adds some new popover keys, one set for creating implicit anchor positioning references and the other that creates an API for comparable to the declarative `popovertarget`.

See also:

- https://chromestatus.com/feature/5120638407409664
- https://github.com/whatwg/html/pull/10728