### PR TITLE
`ua-client-hints`: add new keys

### DIFF
--- a/features/ua-client-hints.yml
+++ b/features/ua-client-hints.yml
@@ -21,8 +21,10 @@ compat_features:
   - http.headers.Sec-CH-UA
   - http.headers.Sec-CH-UA-Arch
   - http.headers.Sec-CH-UA-Bitness
+  - http.headers.Sec-CH-UA-Form-Factors
   - http.headers.Sec-CH-UA-Full-Version-List
   - http.headers.Sec-CH-UA-Mobile
   - http.headers.Sec-CH-UA-Model
   - http.headers.Sec-CH-UA-Platform
   - http.headers.Sec-CH-UA-Platform-Version
+  - http.headers.Sec-CH-UA-WoW64

--- a/features/ua-client-hints.yml.dist
+++ b/features/ua-client-hints.yml.dist
@@ -4,9 +4,9 @@
 status:
   baseline: false
   support:
-    chrome: "98"
-    chrome_android: "98"
-    edge: "98"
+    chrome: "124"
+    chrome_android: "124"
+    edge: "124"
 compat_features:
   # baseline: false
   # support:
@@ -49,10 +49,24 @@ compat_features:
   - api.NavigatorUAData.toJSON
   - http.headers.Sec-CH-UA-Bitness
 
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   chrome: "98"
   #   chrome_android: "98"
   #   edge: "98"
   - http.headers.Sec-CH-UA-Full-Version-List
+
+  # baseline: false
+  # support:
+  #   chrome: "100"
+  #   chrome_android: "100"
+  #   edge: "100"
+  - http.headers.Sec-CH-UA-WoW64
+
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: false
+  # support:
+  #   chrome: "124"
+  #   chrome_android: "124"
+  #   edge: "124"
+  - http.headers.Sec-CH-UA-Form-Factors


### PR DESCRIPTION
https://github.com/mdn/browser-compat-data/pull/25949 added these keys upstream.

I don't know if it's worth the trouble of a `compute_from` for a single-implementation feature. So I didn't bother. I don't know if that's a good call or important in this case.