### PR TITLE
Add `Array[Symbol.species]` to `symbol`

### DIFF
--- a/features/symbol.yml
+++ b/features/symbol.yml
@@ -4,7 +4,9 @@ spec: https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol-obje
 group: primitive-types
 status:
   compute_from: javascript.builtins.Symbol
+# TODO: move javascript.builtins.Array.@@species to `array` when https://github.com/web-platform-dx/web-features/issues/91 is resolved
 compat_features:
+  - javascript.builtins.Array.@@species
   - javascript.builtins.Symbol
   - javascript.builtins.Symbol.Symbol
   - javascript.builtins.Symbol.description

--- a/features/symbol.yml.dist
+++ b/features/symbol.yml.dist
@@ -156,6 +156,19 @@ compat_features:
   # baseline_low_date: 2020-01-15
   # baseline_high_date: 2022-07-15
   # support:
+  #   chrome: "51"
+  #   chrome_android: "51"
+  #   edge: "79"
+  #   firefox: "48"
+  #   firefox_android: "48"
+  #   safari: "10"
+  #   safari_ios: "10"
+  - javascript.builtins.Array.@@species
+
+  # baseline: high
+  # baseline_low_date: 2020-01-15
+  # baseline_high_date: 2022-07-15
+  # support:
   #   chrome: "70"
   #   chrome_android: "70"
   #   edge: "79"


### PR DESCRIPTION
I'll admit it: this is a bit of a hack.

Like other `species` keys, this key properly belongs in the `array` feature. But it we can't put it there just yet.

Because we added the array features early, it's broken down much more finely than other JavaScript collections (and lot of it ought to be combined, when we've dealt with https://github.com/web-platform-dx/web-features/issues/91). That means this key doesn't fit into very neatly into `array` or any of the other existing array features.

But it also doesn't make sense as a standalone feature. It's really hard to describe [an iffy contrivance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/species#using_species) as a "feature." I'm not even sure what the pitch is, exactly ("You can make a subclass of Array pretend to be an array"?). It's too weird.

So here I propose parking the key with the `symbol` feature and cleaning this up more thoroughly later.