### PR TITLE
Add type to `alternatives` in JSONSchema

### DIFF
--- a/schemas/data.schema.json
+++ b/schemas/data.schema.json
@@ -70,7 +70,9 @@
             },
             "alternatives": {
               "description": "IDs for features that substitute some or all of this feature's utility",
-              "items": {},
+              "items": {
+                "type": "string"
+              },
               "type": "array"
             }
           },


### PR DESCRIPTION
Currently, the alternatives field is described to be an array. But the
type of item is missing. This change adds the type as string for each alternative.