### PR TITLE
Add new `setScreenshareActive` key to `media-session`

### DIFF
--- a/features/media-session.yml
+++ b/features/media-session.yml
@@ -35,5 +35,6 @@ compat_features:
   - api.MediaSession.setActionHandler.togglemicrophone_type
   - api.MediaSession.setCameraActive
   - api.MediaSession.setMicrophoneActive
+  - api.MediaSession.setScreenshareActive
   - api.MediaSession.setPositionState
   - api.Navigator.mediaSession

--- a/features/media-session.yml.dist
+++ b/features/media-session.yml.dist
@@ -128,3 +128,7 @@ compat_features:
   - api.ChapterInformation.startTime
   - api.ChapterInformation.title
   - api.MediaMetadata.chapterInfo
+
+  # baseline: false
+  # support: {}
+  - api.MediaSession.setScreenshareActive


### PR DESCRIPTION
I thought this looked similar enough to `setCameraActive` and `setMicrophoneActive` to let it stay with its siblings.