### PR TITLE
Remove backtick markdown tagging from feature names

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -73,7 +73,7 @@ This table lists the fields that can be found in a feature file, and provides a 
 
 | Field | Description | Type | Mandatory |
 |---|---|---|---|
-| `name` | The name of the feature. | String | Yes |
+| `name` | The name of the feature. | Plain text string | Yes |
 | `description` | A short description of the feature. | Markdown-formatted string | Yes |
 | `spec` | One or more specification URLs for this feature. | String, or array of strings | Yes |
 | `group` | An optional group, or list of groups that this feature belongs to. See the definition of groups under [Create a new feature from scratch](#create-a-new-feature-from-scratch). | String, or array of strings | No |

--- a/features/overflow-overlay.yml
+++ b/features/overflow-overlay.yml
@@ -1,4 +1,4 @@
-name: "`overflow: overlay`"
+name: "overflow: overlay"
 description: "The `overflow: overlay` CSS declaration is an alias to `overflow: auto`. Historically, it caused non-standard behavior, allowing scrollbars to overlay content without taking up layout space."
 spec: https://drafts.csswg.org/css-overflow-3/#propdef-overflow
 group: css

--- a/features/text-decoration-line-blink.yml
+++ b/features/text-decoration-line-blink.yml
@@ -1,4 +1,4 @@
-name: "`text-decoration-line: blink`"
+name: "text-decoration-line: blink"
 description: "The `text-decoration: blink` CSS declaration flashes text between visible and invisible."
 spec: https://drafts.csswg.org/css-text-decor-3/#valdef-text-decoration-line-blink
 group:

--- a/features/word-break-break-word.yml
+++ b/features/word-break-break-word.yml
@@ -1,4 +1,4 @@
-name: "`word-break: break-word`"
+name: "word-break: break-word"
 description: "The `word-break: break-word` CSS declaration sets word breaks to occur according to their customary rules. Superseded by `overflow-wrap: anywhere`."
 spec: https://drafts.csswg.org/css-text-3/#word-break-property
 group: css


### PR DESCRIPTION
Fixes #2678.

There are only a few features which names use backtick characters for code. The vast majority of the features only use plain text for the `name` field.

This PR removes the backtick markdown tagging from the feature names.