### PR TITLE
Assign `worker_support` keys

### DIFF
--- a/features/base64encodedecode.yml
+++ b/features/base64encodedecode.yml
@@ -5,3 +5,5 @@ caniuse: atob-btoa
 compat_features:
   - api.atob
   - api.btoa
+  - api.atob.worker_support
+  - api.btoa.worker_support

--- a/features/base64encodedecode.yml.dist
+++ b/features/base64encodedecode.yml.dist
@@ -3,16 +3,42 @@
 
 status:
   baseline: high
-  baseline_low_date: 2015-07-29
-  baseline_high_date: 2018-01-29
+  baseline_low_date: 2016-09-20
+  baseline_high_date: 2019-03-20
   support:
-    chrome: "4"
-    chrome_android: "18"
+    chrome: "30"
+    chrome_android: "30"
     edge: "12"
-    firefox: "1"
+    firefox: "4"
     firefox_android: "4"
-    safari: "3"
-    safari_ios: "1"
+    safari: "10"
+    safari_ios: "10"
 compat_features:
+  # baseline: high
+  # baseline_low_date: 2015-07-29
+  # baseline_high_date: 2018-01-29
+  # support:
+  #   chrome: "4"
+  #   chrome_android: "18"
+  #   edge: "12"
+  #   firefox: "1"
+  #   firefox_android: "4"
+  #   safari: "3"
+  #   safari_ios: "1"
   - api.atob
   - api.btoa
+
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: high
+  # baseline_low_date: 2016-09-20
+  # baseline_high_date: 2019-03-20
+  # support:
+  #   chrome: "30"
+  #   chrome_android: "30"
+  #   edge: "12"
+  #   firefox: "4"
+  #   firefox_android: "4"
+  #   safari: "10"
+  #   safari_ios: "10"
+  - api.atob.worker_support
+  - api.btoa.worker_support

--- a/features/canvas-2d.yml
+++ b/features/canvas-2d.yml
@@ -88,6 +88,7 @@ compat_features:
   - api.CanvasRenderingContext2D.translate
   - api.CanvasRenderingContext2D.wordSpacing
   - api.ImageData
+  - api.ImageData.worker_support
   - api.ImageData.ImageData
   - api.ImageData.colorSpace
   - api.ImageData.data

--- a/features/canvas-2d.yml.dist
+++ b/features/canvas-2d.yml.dist
@@ -217,6 +217,19 @@ compat_features:
   #   chrome: "36"
   #   chrome_android: "36"
   #   edge: "14"
+  #   firefox: "25"
+  #   firefox_android: "25"
+  #   safari: "7"
+  #   safari_ios: "7"
+  - api.ImageData.worker_support
+
+  # baseline: high
+  # baseline_low_date: 2016-08-02
+  # baseline_high_date: 2019-02-02
+  # support:
+  #   chrome: "36"
+  #   chrome_android: "36"
+  #   edge: "14"
   #   firefox: "29"
   #   firefox_android: "29"
   #   safari: "8"

--- a/features/setinterval.yml
+++ b/features/setinterval.yml
@@ -3,4 +3,6 @@ description: "The `setInterval()` global function repeatedly executes provided c
 spec: https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers
 compat_features:
   - api.setInterval
+  - api.setInterval.worker_support
   - api.clearInterval
+  - api.clearInterval.worker_support

--- a/features/setinterval.yml.dist
+++ b/features/setinterval.yml.dist
@@ -6,13 +6,39 @@ status:
   baseline_low_date: 2015-07-29
   baseline_high_date: 2018-01-29
   support:
-    chrome: "1"
+    chrome: "3"
     chrome_android: "18"
     edge: "12"
-    firefox: "1"
+    firefox: "3.5"
     firefox_android: "4"
-    safari: "1"
-    safari_ios: "1"
+    safari: "4"
+    safari_ios: "5"
 compat_features:
+  # baseline: high
+  # baseline_low_date: 2015-07-29
+  # baseline_high_date: 2018-01-29
+  # support:
+  #   chrome: "1"
+  #   chrome_android: "18"
+  #   edge: "12"
+  #   firefox: "1"
+  #   firefox_android: "4"
+  #   safari: "1"
+  #   safari_ios: "1"
   - api.clearInterval
   - api.setInterval
+
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: high
+  # baseline_low_date: 2015-07-29
+  # baseline_high_date: 2018-01-29
+  # support:
+  #   chrome: "3"
+  #   chrome_android: "18"
+  #   edge: "12"
+  #   firefox: "3.5"
+  #   firefox_android: "4"
+  #   safari: "4"
+  #   safari_ios: "5"
+  - api.clearInterval.worker_support
+  - api.setInterval.worker_support

--- a/features/settimeout.yml
+++ b/features/settimeout.yml
@@ -3,4 +3,6 @@ description: "The `setTimeout()` global function executes provided code after a 
 spec: https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers
 compat_features:
   - api.setTimeout
+  - api.setTimeout.worker_support
   - api.clearTimeout
+  - api.clearTimeout.worker_support

--- a/features/settimeout.yml.dist
+++ b/features/settimeout.yml.dist
@@ -6,13 +6,13 @@ status:
   baseline_low_date: 2015-07-29
   baseline_high_date: 2018-01-29
   support:
-    chrome: "1"
+    chrome: "3"
     chrome_android: "18"
     edge: "12"
-    firefox: "1"
+    firefox: "3.5"
     firefox_android: "4"
     safari: "4"
-    safari_ios: "1"
+    safari_ios: "5"
 compat_features:
   # baseline: high
   # baseline_low_date: 2015-07-29
@@ -27,7 +27,6 @@ compat_features:
   #   safari_ios: "1"
   - api.setTimeout
 
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: high
   # baseline_low_date: 2015-07-29
   # baseline_high_date: 2018-01-29
@@ -40,3 +39,18 @@ compat_features:
   #   safari: "4"
   #   safari_ios: "1"
   - api.clearTimeout
+
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: high
+  # baseline_low_date: 2015-07-29
+  # baseline_high_date: 2018-01-29
+  # support:
+  #   chrome: "3"
+  #   chrome_android: "18"
+  #   edge: "12"
+  #   firefox: "3.5"
+  #   firefox_android: "4"
+  #   safari: "4"
+  #   safari_ios: "5"
+  - api.clearTimeout.worker_support
+  - api.setTimeout.worker_support


### PR DESCRIPTION
Most of these don't make much of a difference, but `features/base64encodedecode.yml` shifts the Baseline date by 13 months. We could do a `compute_from` on that one, if desired.