### PR TITLE
Make HTML attribute names lowercase.

### DIFF
--- a/features/accesskey.yml
+++ b/features/accesskey.yml
@@ -1,4 +1,4 @@
-name: Accesskey
+name: accesskey
 description: The `accessKey` global HTML attribute gives a hint for generating a keyboard shortcut for the current element. The attribute value must consist of a single printable character.
 spec: https://html.spec.whatwg.org/multipage/interaction.html#the-accesskey-attribute
 status:

--- a/features/autocapitalize.yml
+++ b/features/autocapitalize.yml
@@ -1,4 +1,4 @@
-name: Autocapitalize
+name: autocapitalize
 description: The `autocapitalize` global HTML attribute sets the virtual keyboard capitalization behavior for user input on an element, such as the first letter of sentences or all words.
 spec: https://html.spec.whatwg.org/multipage/interaction.html#autocapitalization
 compat_features:

--- a/features/autocorrect.yml
+++ b/features/autocorrect.yml
@@ -1,4 +1,4 @@
-name: Autocorrect
+name: autocorrect
 description: The `autocorrect` global HTML attribute controls whether to automatically correct spelling or punctuation errors for user input.
 spec: https://html.spec.whatwg.org/multipage/interaction.html#autocorrection
 compat_features:

--- a/features/autofocus.yml
+++ b/features/autofocus.yml
@@ -1,4 +1,4 @@
-name: Autofocus
+name: autofocus
 description: The `autofocus` HTML attribute gives focus to an element on page load.
 spec: https://html.spec.whatwg.org/multipage/interaction.html#the-autofocus-attribute
 caniuse: autofocus

--- a/features/contenteditable.yml
+++ b/features/contenteditable.yml
@@ -1,4 +1,4 @@
-name: Contenteditable
+name: contenteditable
 description: The `contenteditable` global HTML attribute allows the user to edit the content of an element, such as inserting or deleting text.
 spec: https://html.spec.whatwg.org/multipage/interaction.html#contenteditable
 caniuse: contenteditable

--- a/features/enterkeyhint.yml
+++ b/features/enterkeyhint.yml
@@ -1,4 +1,4 @@
-name: Enterkeyhint
+name: enterkeyhint
 description: The `enterkeyhint` global HTML attribute sets the label for a virtual keyboard's <kbd>Enter</kbd> key. For example, `enterkeyhint="search"` may label the key with a magnifying glass icon.
 spec: https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-enterkeyhint-attribute
 compat_features:

--- a/features/inert.yml
+++ b/features/inert.yml
@@ -1,4 +1,4 @@
-name: Inert elements
+name: inert
 description: The `inert` HTML attribute marks an element and its descendants as non-interactive. Inert elements don't get focus or fire `click` events.
 spec: https://html.spec.whatwg.org/multipage/interaction.html#inert-subtrees
 group: html

--- a/features/lang-attr.yml
+++ b/features/lang-attr.yml
@@ -1,4 +1,4 @@
-name: Lang
+name: lang
 description: The `lang` global HTML attribute defines the language of an element. It's used by assistive technology to correctly read the content, translation tools to select the origin language, and other applications.
 spec: https://html.spec.whatwg.org/multipage/dom.html#attr-lang
 compat_features:

--- a/features/spellcheck.yml
+++ b/features/spellcheck.yml
@@ -1,4 +1,4 @@
-name: Spellcheck
+name: spellcheck
 description: The `spellcheck` global HTML attribute sets whether the browser may check an element for spelling errors.
 spec: https://html.spec.whatwg.org/multipage/interaction.html#the-accesskey-attribute
 compat_features:

--- a/features/translate.yml
+++ b/features/translate.yml
@@ -1,3 +1,3 @@
-name: translate attribute
+name: translate
 description: The `translate` HTML attribute marks whether an element's text should be translated.
 spec: https://html.spec.whatwg.org/multipage/dom.html#attr-translate


### PR DESCRIPTION
This fixes #2748 by making most HTML attributes (and global attributes) lowercase and only contain the attribute name. This is similar to CSS property features, where the name of the features is just the property name itself, all lowercase.

There are exceptions to this, notably Popover which is an attribute and an API. So I kept Popover (capitalized).