### PR TITLE
Pin CSS numeric factory functions to the earliest ones

### DIFF
--- a/features/numeric-factory-functions.yml
+++ b/features/numeric-factory-functions.yml
@@ -2,6 +2,8 @@ name: Numeric factory functions
 description: The numeric factory functions, such as `CSS.px()` or `CSS.kHz()`, return a `CSSUnitValue` representing a CSS number value (as in `12px` or `440kHz`).
 spec: https://drafts.css-houdini.org/css-typed-om-1/#numeric-factory
 group: cssom
+status:
+  compute_from: api.CSS.px_static
 compat_features:
   - api.CSS.Hz_static
   - api.CSS.Q_static

--- a/features/numeric-factory-functions.yml.dist
+++ b/features/numeric-factory-functions.yml.dist
@@ -4,12 +4,13 @@
 status:
   baseline: false
   support:
-    chrome: "118"
-    chrome_android: "118"
-    edge: "118"
-    safari: "17.2"
-    safari_ios: "17.2"
+    chrome: "66"
+    chrome_android: "66"
+    edge: "79"
+    safari: "16.4"
+    safari_ios: "16.4"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   chrome: "66"
@@ -100,7 +101,6 @@ compat_features:
   - api.CSS.lh_static
   - api.CSS.rlh_static
 
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   chrome: "118"


### PR DESCRIPTION
New units keep being added to the platform, but it's not reasonable for
this feature to keep changing in response.

Note that the versions now match CSS Typed OM exactly, which makes sense
since this is really part of that feature.
