### PR TITLE
Bump compute-baseline's BCD peerDependency to ^6.0.0

### DIFF
--- a/packages/compute-baseline/package.json
+++ b/packages/compute-baseline/package.json
@@ -35,7 +35,7 @@
     "mocha": "^11.1.0"
   },
   "peerDependencies": {
-    "@mdn/browser-compat-data": "^5.0.0"
+    "@mdn/browser-compat-data": "^6.0.0"
   },
   "dependencies": {
     "@js-temporal/polyfill": "^0.4.4",


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/releases/tag/v6.0.0. I think it should be safe to bump this to v6. There might be some code cleanup that is now possible (to remove logic for `true` and `null` BCD values), but that could be done later.