### PR TITLE
Increment compute-baseline version to 0.3.1

### DIFF
--- a/packages/compute-baseline/package.json
+++ b/packages/compute-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compute-baseline",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A library for computing web-features statuses from browser compatibility data",
   "repository": {
     "type": "git",


### PR DESCRIPTION
#2824 bumped the peer dependency for @mdn/browser-compat-data to ^6.0.0. https://github.com/openwebdocs/web-docs-backlog/actions/runs/14171284132/job/39695462685 failed because of a conflicting peer dependency in compute-baseline.

Doing this as in #2764, though I'm unsure if this should be 0.4.0 or 0.3.1