### PR TITLE
Fix capitalization of accesskey attribute in description

### DIFF
--- a/features/accesskey.yml
+++ b/features/accesskey.yml
@@ -1,5 +1,5 @@
 name: accesskey
-description: The `accessKey` global HTML attribute gives a hint for generating a keyboard shortcut for the current element. The attribute value must consist of a single printable character.
+description: The `accesskey` global HTML attribute gives a hint for generating a keyboard shortcut for the current element. The attribute value must consist of a single printable character.
 spec: https://html.spec.whatwg.org/multipage/interaction.html#the-accesskey-attribute
 status:
   compute_from: api.HTMLElement.accessKey


### PR DESCRIPTION
The canonical case of the attribute is `accesskey`. The reflected
property (aka IDL attribute) is `accessKey`, but that's not what the
feature is named after.
