### PR TITLE
Remove incorrect "not" in beforeinstallprompt comment

### DIFF
--- a/features/beforeinstallprompt.yml
+++ b/features/beforeinstallprompt.yml
@@ -1,6 +1,6 @@
 name: beforeinstallprompt
 description: The `beforeinstallprompt` event fires when a Progressive Web App (PWA) is installable, usually on page load in browsers that support installing PWAs. You can use this event to prevent the install prompt from appearing until after the user interacts with an element on the page.
-# The only engine where beforeinstallprompt is not supported is Chromium, and its implementation differs from the spec.
+# The only engine where beforeinstallprompt is supported is Chromium, and its implementation differs from the spec.
 # BCD/MDN don't link to the spec because of this, and instead document what's in Chromium.
 spec: https://wicg.github.io/manifest-incubations/
 group: progressive-web-app


### PR DESCRIPTION
It is supported in Chromium, but nowhere else.
