### PR TITLE
Make beforeunload name consistent with other event features

### DIFF
--- a/features/beforeunload.yml
+++ b/features/beforeunload.yml
@@ -1,4 +1,4 @@
-name: Beforeunload
+name: beforeunload
 description: "The `beforeunload` event is fired when the current window is about to be unloaded. Typically this is used to display a dialog to confirm if users really want to leave the page when there is unsaved data that would be lost."
 spec: https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-beforeunloadevent-interface
 status:


### PR DESCRIPTION
Such as beforeinstallprompt, hashchange, and messageerror.
