### PR TITLE
Allow overlapping BCD keys

### DIFF
--- a/features/text-wrap-pretty.yml
+++ b/features/text-wrap-pretty.yml
@@ -2,3 +2,6 @@ name: "text-wrap: pretty"
 description: "The `text-wrap: pretty` CSS declaration prioritizes better layout over speed when text is broken into multiple lines."
 spec: https://drafts.csswg.org/css-text-4/#valdef-text-wrap-style-pretty
 group: text-wrap
+compat_features:
+  - css.properties.text-wrap.pretty
+  - css.properties.text-wrap-style.pretty

--- a/features/text-wrap-pretty.yml.dist
+++ b/features/text-wrap-pretty.yml.dist
@@ -4,8 +4,21 @@
 status:
   baseline: false
   support:
-    chrome: "117"
-    chrome_android: "117"
-    edge: "117"
+    chrome: "130"
+    chrome_android: "130"
+    edge: "130"
 compat_features:
+  # baseline: false
+  # support:
+  #   chrome: "117"
+  #   chrome_android: "117"
+  #   edge: "117"
   - css.properties.text-wrap.pretty
+
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: false
+  # support:
+  #   chrome: "130"
+  #   chrome_android: "130"
+  #   edge: "130"
+  - css.properties.text-wrap-style.pretty

--- a/index.ts
+++ b/index.ts
@@ -167,15 +167,8 @@ for (const [key, data] of yamlEntries('features')) {
         // no effect on what web-features users see.
         data.compat_features.sort();
 
-        // Check that no BCD key is used twice until the meaning is made clear in
-        // https://github.com/web-platform-dx/web-features/issues/1173.
         for (const bcdKey of data.compat_features) {
-            const otherKey = bcdToFeatureId.get(bcdKey);
-            if (otherKey) {
-                throw new Error(`BCD key ${bcdKey} is used in both ${otherKey} and ${key}, which creates ambiguity for some consumers. Please see https://github.com/web-platform-dx/web-features/issues/1173 and help us find a good solution to allow this.`);
-            } else {
-                bcdToFeatureId.set(bcdKey, key);
-            }
+            bcdToFeatureId.set(bcdKey, key);
         }
     }
 


### PR DESCRIPTION
This PR allows BCD keys to exist in multiple features and it demonstrates the capability with a single key, `css.properties.text-wrap-style.pretty`.

`css.properties.text-wrap-style.pretty` already exists in `text-wrap-style`. This PR adds the key to a second feature, `text-wrap-pretty`. This seems pretty logical to me: `text-wrap-style` shows support for the property in general, where `text-wrap-pretty` represents the specific value of `pretty`, which you might use in two properties.

Up to now, we've enforced (but never documented) a limitation that a key can only be in one feature at a time. Last I talked to MDN—the original objector to key duplication—were open to allowing keys to span features. It seems like it'd be nice to introduce this to a single, low-risk pair of features before extending the practice elsewhere.

- Fixes https://github.com/web-platform-dx/web-features/issues/1173
- Fixes https://github.com/web-platform-dx/web-features/issues/2886