### PR TITLE
Move service worker event to the messageerror feature

### DIFF
--- a/features/messageerror.yml
+++ b/features/messageerror.yml
@@ -8,11 +8,11 @@ status:
   compute_from:
     - api.DedicatedWorkerGlobalScope.messageerror_event
     - api.MessagePort.messageerror_event
-    - api.ServiceWorkerContainer.messageerror_event
     - api.Window.messageerror_event
 compat_features:
   - api.DedicatedWorkerGlobalScope.messageerror_event
   - api.MessagePort.messageerror_event
   - api.ServiceWorkerContainer.messageerror_event
+  - api.ServiceWorkerGlobalScope.messageerror_event
   - api.Window.messageerror_event
   - api.Worker.messageerror_event

--- a/features/messageerror.yml.dist
+++ b/features/messageerror.yml.dist
@@ -5,14 +5,15 @@ status:
   baseline: low
   baseline_low_date: 2023-03-27
   support:
-    chrome: "80"
-    chrome_android: "80"
-    edge: "80"
-    firefox: "65"
-    firefox_android: "65"
+    chrome: "60"
+    chrome_android: "60"
+    edge: "18"
+    firefox: "57"
+    firefox_android: "57"
     safari: "16.4"
     safari_ios: "16.4"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: low
   # baseline_low_date: 2023-03-27
   # support:
@@ -27,7 +28,6 @@ compat_features:
   - api.MessagePort.messageerror_event
   - api.Window.messageerror_event
 
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: low
   # baseline_low_date: 2023-03-27
   # support:
@@ -39,6 +39,15 @@ compat_features:
   #   safari: "16.4"
   #   safari_ios: "16.4"
   - api.ServiceWorkerContainer.messageerror_event
+
+  # baseline: false
+  # support:
+  #   chrome: "81"
+  #   chrome_android: "81"
+  #   edge: "81"
+  #   firefox: "65"
+  #   firefox_android: "65"
+  - api.ServiceWorkerGlobalScope.messageerror_event
 
   # baseline: false
   # support:

--- a/features/service-workers.yml
+++ b/features/service-workers.yml
@@ -88,7 +88,6 @@ compat_features:
   - api.ServiceWorkerGlobalScope.fetch_event
   - api.ServiceWorkerGlobalScope.install_event
   - api.ServiceWorkerGlobalScope.message_event
-  - api.ServiceWorkerGlobalScope.messageerror_event
   - api.ServiceWorkerGlobalScope.registration
   - api.ServiceWorkerGlobalScope.serviceWorker
   - api.ServiceWorkerGlobalScope.skipWaiting

--- a/features/service-workers.yml.dist
+++ b/features/service-workers.yml.dist
@@ -486,15 +486,6 @@ compat_features:
 
   # baseline: false
   # support:
-  #   chrome: "81"
-  #   chrome_android: "81"
-  #   edge: "81"
-  #   firefox: "65"
-  #   firefox_android: "65"
-  - api.ServiceWorkerGlobalScope.messageerror_event
-
-  # baseline: false
-  # support:
   #   firefox: "133"
   #   firefox_android: "133"
   #   safari: "11.1"


### PR DESCRIPTION
The event on ServiceWorkerContainer and ServiceWorkerGlobalScope should
be given the same treatment for consistency. messageerror shipped after
service workers in all features in all browsers, so this seems like the
right move, rather than letting the service worker feature have both.

The moved event isn't Baseline, so again for consistency exclude both
from the compute_from list. This changes some browser versions to be
earlier, but doesn't change the Baseline date, determined by Safari.
