### PR TITLE
Add option param to caretPositionFromPoint() feature

### DIFF
--- a/features/document-caretpositionfrompoint.yml
+++ b/features/document-caretpositionfrompoint.yml
@@ -1,9 +1,12 @@
 name: document.caretPositionFromPoint()
 description: The `document.caretPositionFromPoint()` method finds an insertion point, represented by a DOM node and an offset within that node, for given coordinates in the viewport.
 spec: https://drafts.csswg.org/cssom-view-1/#dom-document-caretpositionfrompoint
+status:
+  compute_from: api.Document.caretPositionFromPoint
 compat_features:
   - api.CaretPosition
   - api.CaretPosition.getClientRect
   - api.CaretPosition.offset
   - api.CaretPosition.offsetNode
   - api.Document.caretPositionFromPoint
+  - api.Document.caretPositionFromPoint.options_parameter

--- a/features/document-caretpositionfrompoint.yml.dist
+++ b/features/document-caretpositionfrompoint.yml.dist
@@ -7,8 +7,8 @@ status:
     chrome: "128"
     chrome_android: "128"
     edge: "128"
-    firefox: "23"
-    firefox_android: "23"
+    firefox: "20"
+    firefox_android: "20"
 compat_features:
   # baseline: low
   # baseline_low_date: 2025-03-31
@@ -36,6 +36,7 @@ compat_features:
   #   safari_ios: "18.4"
   - api.CaretPosition.getClientRect
 
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   chrome: "128"
@@ -44,3 +45,10 @@ compat_features:
   #   firefox: "20"
   #   firefox_android: "20"
   - api.Document.caretPositionFromPoint
+
+  # baseline: false
+  # support:
+  #   chrome: "128"
+  #   chrome_android: "128"
+  #   edge: "128"
+  - api.Document.caretPositionFromPoint.options_parameter


### PR DESCRIPTION
This is a new addition. Pin the feature to just the entry point. This
changes the Firefox version to 20 instead of 23, and getClientRect() is
the bit that previously pushed it to 23. This seems OK as it's in the
distant past and doesn't change the Baseline dates.
