### PR TITLE
Fix `execCommand()` browser support status (still not Baseline)

### DIFF
--- a/features/execcommand.yml
+++ b/features/execcommand.yml
@@ -8,6 +8,8 @@ discouraged:
   alternatives:
     - async-clipboard
     - contenteditable
+status:
+  compute_from: api.Document.execCommand
 compat_features:
   - api.Document.execCommand
   - api.Document.execCommand.copy

--- a/features/execcommand.yml.dist
+++ b/features/execcommand.yml.dist
@@ -4,9 +4,15 @@
 status:
   baseline: false
   support:
+    chrome: "1"
+    chrome_android: "18"
+    edge: "12"
     firefox: "69"
     firefox_android: "79"
+    safari: "1.3"
+    safari_ios: "1"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   chrome: "1"
@@ -45,7 +51,6 @@ compat_features:
   - api.Document.execCommand.copy
   - api.Document.execCommand.cut
 
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   firefox: "69"


### PR DESCRIPTION
execCommand() is supported everywhere, it's just discouraged.
