### PR TITLE
Refine `ruby-position` and `display-ruby` key selection

### DIFF
--- a/features/display-ruby.yml
+++ b/features/display-ruby.yml
@@ -10,3 +10,4 @@ compat_features:
   - css.properties.display.ruby-base-container
   - css.properties.display.ruby-text
   - css.properties.display.ruby-text-container
+  - css.properties.ruby-position.alternate

--- a/features/display-ruby.yml.dist
+++ b/features/display-ruby.yml.dist
@@ -4,8 +4,8 @@
 status:
   baseline: false
   support:
-    firefox: "38"
-    firefox_android: "38"
+    firefox: "88"
+    firefox_android: "88"
 compat_features:
   # baseline: false
   # support:
@@ -16,7 +16,6 @@ compat_features:
   - css.properties.display.ruby
   - css.properties.display.ruby-text
 
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   firefox: "38"
@@ -24,3 +23,10 @@ compat_features:
   - css.properties.display.ruby-base
   - css.properties.display.ruby-base-container
   - css.properties.display.ruby-text-container
+
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: false
+  # support:
+  #   firefox: "88"
+  #   firefox_android: "88"
+  - css.properties.ruby-position.alternate

--- a/features/ruby-position.yml
+++ b/features/ruby-position.yml
@@ -3,10 +3,12 @@ description: The `ruby-position` CSS property sets the position of a ruby annota
 spec: https://drafts.csswg.org/css-ruby-1/#rubypos
 group: ruby
 status:
-  compute_from: css.properties.ruby-position
+  compute_from:
+    - css.properties.ruby-position
+    - css.properties.ruby-position.over
+    - css.properties.ruby-position.under
 compat_features:
   - css.properties.ruby-position
-  - css.properties.ruby-position.alternate
   - css.properties.ruby-position.inter-character
   - css.properties.ruby-position.over
   - css.properties.ruby-position.under

--- a/features/ruby-position.yml.dist
+++ b/features/ruby-position.yml.dist
@@ -33,9 +33,3 @@ compat_features:
   #   safari: "18.2"
   #   safari_ios: "18.2"
   - css.properties.ruby-position.inter-character
-
-  # baseline: false
-  # support:
-  #   firefox: "88"
-  #   firefox_android: "88"
-  - css.properties.ruby-position.alternate


### PR DESCRIPTION
Fixes https://github.com/web-platform-dx/web-features/issues/2634, mostly based on a subject matter expert's commentary given in https://github.com/web-platform-dx/web-features/issues/2634#issuecomment-2660850912.

This PR makes two changes to the feature definitions for ruby annotations:

- Moves `css.properties.ruby-position.alternate` to `display-ruby`, under the understanding that the behavior is only meaningful in the context of multi-level ruby, which is represented by the `display: ruby-text-container` declaration.

  This affects the reported version numbers for support, but since it's a limited-availability feature anyway I thought it was better to group the closely-related keys.
  
- Explicitly pin `ruby-position` to the `over` and `under` values.

A note on something I did **not** do: Xidorn's suggestion notwithstanding, I did not make a standalone feature for `ruby-position: inter-character`. If there's interest, I could do this, but I chose not to since I couldn't find a lot of evidence that developers are seeking this feature (e.g., no Stack Overflow questions; no further commentary on our own issue). I recognize, however, that my reading is very much biased toward English-language and Latin-characterset sources. I chose not to create a feature because while we always retain the option to mint a new feature later, it's currently harder to merge a feature if we decide that was a mistake.