### PR TITLE
Update `web-animations` pinned keys and description

### DIFF
--- a/features/web-animations.yml
+++ b/features/web-animations.yml
@@ -1,5 +1,5 @@
 name: Web animations
-description: The web animation API programmatically creates, inspects, and controls elements' animations, to change and synchronize elements' appearance over time.
+description: The web animation API programmatically creates, inspects, and controls element animations, to change and synchronize appearance over time.
 spec: https://drafts.csswg.org/web-animations-1/
 caniuse: web-animation
 group: animation

--- a/features/web-animations.yml
+++ b/features/web-animations.yml
@@ -1,10 +1,18 @@
 name: Web animations
-description: The `animate()` method of `Element` objects programmatically animates elements over time and can synchronize the animations of multiple elements.
+description: The web animation API programmatically creates, inspects, and controls elements' animations, to change and synchronize elements' appearance over time.
 spec: https://drafts.csswg.org/web-animations-1/
 caniuse: web-animation
 group: animation
 status:
-  compute_from: api.Element.animate
+  compute_from:
+    - api.Animation.Animation
+    - api.Animation.cancel
+    - api.Animation.pause
+    - api.Animation.play
+    - api.Animation.reverse
+    - api.Document.getAnimations
+    - api.Element.animate
+    - api.Element.getAnimations
 compat_features:
   - api.Element.animate
   - api.Animation

--- a/features/web-animations.yml.dist
+++ b/features/web-animations.yml.dist
@@ -3,16 +3,16 @@
 
 status:
   baseline: high
-  baseline_low_date: 2020-03-24
-  baseline_high_date: 2022-09-24
+  baseline_low_date: 2020-09-16
+  baseline_high_date: 2023-03-16
   support:
-    chrome: "36"
-    chrome_android: "36"
-    edge: "79"
-    firefox: "48"
-    firefox_android: "48"
-    safari: "13.1"
-    safari_ios: "13.4"
+    chrome: "84"
+    chrome_android: "84"
+    edge: "84"
+    firefox: "75"
+    firefox_android: "79"
+    safari: "14"
+    safari_ios: "14"
 compat_features:
   # baseline: high
   # baseline_low_date: 2019-12-17
@@ -29,7 +29,6 @@ compat_features:
   - api.Element.animationiteration_event
   - api.Element.animationstart_event
 
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: high
   # baseline_low_date: 2020-03-24
   # baseline_high_date: 2022-09-24
@@ -172,6 +171,7 @@ compat_features:
   - api.DocumentTimeline.DocumentTimeline
   - api.Element.getAnimations
 
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: high
   # baseline_low_date: 2020-09-16
   # baseline_high_date: 2023-03-16


### PR DESCRIPTION
This PR makes some adjustments to the `web-animations` feature, to more closely align with caniuse and respond to feedback given in #2244.

Specifically, I've made the following changes:

- Pinned the feature's status to a broader part of the API, including `getAnimations()`, the `Animation()` constructor, and some common controls
- Changed the description to a capture the whole utility of programmatic animation, instead of fitting specifically to the `animate()` attribute

The main consequence here is to shift the Baseline low date forward by about 6 months, though still within the same calendar year.

Fixes https://github.com/web-platform-dx/web-features/issues/2244

Closes https://github.com/web-platform-dx/web-features/pull/2251/