### PR TITLE
Fix capitalization of fetchpriority HTML attribute

### DIFF
--- a/features/fetch-priority.yml
+++ b/features/fetch-priority.yml
@@ -1,5 +1,5 @@
 name: Fetch priority
-description: The `fetch()` `priority` option and the `fetchPriority` HTML attribute give hints to the browser about which requests to do before other requests of the same type.
+description: The `fetch()` `priority` option and the `fetchpriority` HTML attribute give hints to the browser about which requests to do before other requests of the same type.
 spec:
   - https://fetch.spec.whatwg.org/#request-priority
   - https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attributes


### PR DESCRIPTION
Canonical case for HTML attributes is lowercase.