### PR TITLE
Update spec link and description of :past and :future

### DIFF
--- a/features/time-relative-selectors.yml
+++ b/features/time-relative-selectors.yml
@@ -1,6 +1,6 @@
 name: Time-relative pseudo-selectors
-description: The `:future` and `:past` CSS pseudo-classes match upcoming or prior elements during media playback.
-spec: https://drafts.csswg.org/selectors-4/#time-pseudos
+description: The `:past` and `:future` CSS pseudo-classes match prior or upcoming text track cues during media playback.
+spec: https://w3c.github.io/webvtt/#the-past-and-future-pseudo-classes
 group: selectors
 compat_features:
   - css.selectors.future


### PR DESCRIPTION
https://w3c.github.io/webvtt/#the-past-and-future-pseudo-classes is the better spec link for this, as it defines when these pseudo-classes match.

Use the same order as the spec does, because it makes sense.

Also spell out that this is for text track cues.