### PR TITLE
Pin Temporal support to top-level object to show Firefox 139 as supported

### DIFF
--- a/features/temporal.yml
+++ b/features/temporal.yml
@@ -3,3 +3,5 @@ description: The `Temporal` API allows you to work with dates, times, time zones
 spec: https://tc39.es/proposal-temporal/
 group: javascript
 caniuse: temporal
+status:
+  compute_from: javascript.builtins.Temporal

--- a/features/temporal.yml.dist
+++ b/features/temporal.yml.dist
@@ -3,8 +3,11 @@
 
 status:
   baseline: false
-  support: {}
+  support:
+    firefox: "139"
+    firefox_android: "139"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   firefox: "139"
@@ -250,7 +253,6 @@ compat_features:
   - javascript.builtins.Temporal.ZonedDateTime.year
   - javascript.builtins.Temporal.ZonedDateTime.yearOfWeek
 
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support: {}
   - javascript.builtins.Temporal.PlainDate.withCalendar


### PR DESCRIPTION
See #3018 for the reason. In short, Firefox 129 does support Temporal, with the exception of 3 BCD keys which are partial. I don't think web-features should block the Firefox support because of these keys.

Fixes #3018.