### PR TITLE
Use "owners group" consistently

### DIFF
--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -121,7 +121,7 @@ This is but one of several possible stories to help keep in mind the needs and c
 The WebDX community group, through the [web-platform-dx/web-features-set owners group](../GOVERNANCE.md), maintains this document.
 Based on WebDX community group research, the web-features owners group decides matters such as the core browser set, releases, editorial overrides, and so on.
 
-The status definition is due for review by the governance group on 1 June 2025.
+The status definition is due for review by the owners group on 1 June 2025.
 
 ## Status definition
 
@@ -140,7 +140,7 @@ For each feature definition in `web-features`, an interoperable status shall be 
 2. The feature definition does not have a value set indicating that:
 
    - The specification text contains discouraging language, such as a deprecation notice, obsolescence warning, or legacy tag.
-   - The governance group is withholding or modifying the status (i.e., there is no editorial override of the feature’s status).
+   - The owners group is withholding or modifying the status (i.e., there is no editorial override of the feature’s status).
 
 If the feature has the interoperable status, then the feature’s _keystone date_ shall be set to the last release date on which a browser introduced support for the feature
 If there was more than one introduction (e.g., a feature was withdrawn then reintroduced), then only the latest date applies.
@@ -153,7 +153,7 @@ The feature’s keystone date is on or before today’s date minus 30 months and
 
 * Mozilla Firefox ESR, given by the release date for the latest x.0 release of Firefox ESR (or the previous x.0 release, when there are two active ESR releases).
 
-This duration is selected to approximate developer signals, estimates of browser release uptake over time, an estimate of high total market share support, and the project governance group’s best judgment.
+This duration is selected to approximate developer signals, estimates of browser release uptake over time, an estimate of high total market share support, and the project owners group’s best judgment.
 
 ### Core browser set
 


### PR DESCRIPTION
Fixes #502. The document used a mix of "governance group" and "owners group" to refer to the owners group. To avoid any confusion, this update uses "owners group" everywhere.

(This updates the Baseline definition document, but I'd say that it does not technically change the definition itself!)