### PR TITLE
Fix typo: WASM -> Wasm

### DIFF
--- a/groups/webassembly.yml
+++ b/groups/webassembly.yml
@@ -1,2 +1,2 @@
-# WebAssembly or WASM features and extensions
+# WebAssembly (Wasm) features and extensions
 name: WebAssembly


### PR DESCRIPTION
See https://webassembly.org/: WebAssembly (abbreviated Wasm) is a binary instruction format [...]