### PR TITLE
Let Dependabot update all `package.json` files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: npm
+    versioning-strategy: increase
     directories:
       - /
       - packages/web-features
@@ -15,9 +16,6 @@ updates:
       types-node:
         patterns:
           - "@types/node"
-        update-types:
-          - "minor"
-          - "patch"
       typescript:
         patterns:
           - "typescript"


### PR DESCRIPTION
Without this change, Dependabot only updates `package-lock.json` in some cases. See https://github.com/web-platform-dx/web-features/pull/3127/ for an example.

This was previously configured (https://github.com/web-platform-dx/web-features/commit/6ac2ef2325d26b0c430c6dd08665d2361fa4653d) but my recent changes (https://github.com/web-platform-dx/web-features/pull/3118) failed to include this detail.

While I'm here, I removed some spurious group filtering rules that I thought constrained the types of upgrades applied, not which group they appeared in.