### PR TITLE
Pass GitHub token to audit consumers script

### DIFF
--- a/.github/workflows/audit_consumers.yml
+++ b/.github/workflows/audit_consumers.yml
@@ -19,6 +19,8 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run audit-consumers --silent | tee issue-body.md
+        env:
+          GH_TOKEN: ${{ github.token }}
       - run: gh issue create --title "web-features consumers report for $(date -I)" --label generated --body-file issue-body.md
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/audit-consumers.ts
+++ b/scripts/audit-consumers.ts
@@ -135,7 +135,9 @@ async function chromeStatusReport(): Promise<Report> {
 }
 
 async function wptReport(): Promise<Report> {
-  const octokit = new Octokit();
+  const octokit = new Octokit({
+    auth: process.env.GH_TOKEN,
+  });
 
   const params = { owner: "web-platform-tests", repo: "wpt" };
   const release = await octokit.rest.repos.getLatestRelease(params);
@@ -204,4 +206,7 @@ async function main() {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Also handle errors so that the workflow fails instead of continuing to file an empty report.