### PR TITLE
Pin scroll snap events status to the events themselves

### DIFF
--- a/features/scroll-snap-events.yml
+++ b/features/scroll-snap-events.yml
@@ -2,6 +2,14 @@ name: Scroll snap events
 description: The `scrollsnapchanging` and `scrollsnapchange` events fire when a scroll gesture changes the selected scroll snap target.
 spec: https://drafts.csswg.org/css-scroll-snap-2/#scrollsnapchange-and-scrollsnapchanging
 group: scrolling
+status:
+  compute_from:
+    - api.Document.scrollsnapchange_event
+    - api.Document.scrollsnapchanging_event
+    - api.Element.scrollsnapchange_event
+    - api.Element.scrollsnapchanging_event
+    - api.Window.scrollsnapchange_event
+    - api.Window.scrollsnapchanging_event
 compat_features:
   - api.Document.scrollsnapchange_event
   - api.Document.scrollsnapchanging_event

--- a/features/scroll-snap-events.yml.dist
+++ b/features/scroll-snap-events.yml.dist
@@ -3,8 +3,12 @@
 
 status:
   baseline: false
-  support: {}
+  support:
+    chrome: "129"
+    chrome_android: "129"
+    edge: "129"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   chrome: "129"
@@ -20,7 +24,6 @@ compat_features:
   - api.Window.scrollsnapchange_event
   - api.Window.scrollsnapchanging_event
 
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support: {}
   - api.SnapEvent.SnapEvent


### PR DESCRIPTION
The SnapEvent constructor itself is missing, but event constructors have
little practical use, so this shouldn't affect the status.
