### PR TITLE
Pin `<link rel="prefetch">` status to the attr only

### DIFF
--- a/features/link-rel-prefetch.yml
+++ b/features/link-rel-prefetch.yml
@@ -2,6 +2,8 @@ name: '<link rel="prefetch">'
 description: The `rel="prefetch"` attribute for the `<link>` HTML element is a hint to the browser that the user is likely to navigate to a resource, so the browser should preemptively fetch and cache the resource.
 spec: https://html.spec.whatwg.org/multipage/links.html#link-type-prefetch
 caniuse: link-rel-prefetch
+status:
+  compute_from: html.elements.link.rel.prefetch
 compat_features:
   - api.PerformanceResourceTiming.deliveryType.navigational-prefetch
   - html.elements.link.rel.prefetch

--- a/features/link-rel-prefetch.yml.dist
+++ b/features/link-rel-prefetch.yml.dist
@@ -3,8 +3,14 @@
 
 status:
   baseline: false
-  support: {}
+  support:
+    chrome: "8"
+    chrome_android: "18"
+    edge: "12"
+    firefox: "2"
+    firefox_android: "4"
 compat_features:
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   chrome: "8"


### PR DESCRIPTION
The other bits are more esoteric and probably not relevant to most uses
of the feature.
