### PR TITLE
Unlink `createimagebitmap` feature from caniuse

### DIFF
--- a/features/createimagebitmap.yml
+++ b/features/createimagebitmap.yml
@@ -1,7 +1,11 @@
 name: createImageBitmap
 description: The `createImageBitmap()` global method creates an `ImageBitmap` object from a source such as an image, SVG, blob, or canvas. An `ImageBitmap` object represents pixel data that can be drawn to a canvas with lower latency than other types, such as `ImageData`.
 spec: https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmap
-caniuse: createimagebitmap
+# We broke from caniuse's definition of this feature in
+# https://github.com/web-platform-dx/web-features/pull/3165 We could reinstate
+# this link if caniuse changes its definition or if we develop a way to convey
+# partially supported information
+# caniuse: createimagebitmap
 status:
   compute_from:
     - api.createImageBitmap


### PR DESCRIPTION
https://github.com/web-platform-dx/web-features/pull/3165 broke our feature from caniuse's definition; we shouldn't claim equivalence (or allow the Baseline banner to appear there).

Related issues:

- https://github.com/web-platform-dx/web-features/issues/3139
- https://github.com/web-platform-dx/web-features/pull/3140
