### PR TITLE
Pin Reporting API to its entry points

### DIFF
--- a/features/reporting.yml
+++ b/features/reporting.yml
@@ -5,6 +5,10 @@ spec:
   - https://wicg.github.io/intervention-reporting/
   - https://wicg.github.io/deprecation-reporting/
   - https://w3c.github.io/webappsec-csp/#reporting
+status:
+  compute_from:
+    - api.ReportingObserver.ReportingObserver
+    - http.headers.Reporting-Endpoints
 compat_features:
   - api.DeprecationReportBody
   - api.DeprecationReportBody.anticipatedRemoval

--- a/features/reporting.yml.dist
+++ b/features/reporting.yml.dist
@@ -7,6 +7,8 @@ status:
     chrome: "96"
     chrome_android: "96"
     edge: "96"
+    safari: "16.4"
+    safari_ios: "16.4"
 compat_features:
   # baseline: false
   # support:
@@ -21,6 +23,7 @@ compat_features:
   - api.ReportingObserver.observe
   - api.ReportingObserver.takeRecords
 
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   chrome: "96"


### PR DESCRIPTION
This matches the description. As a result the overall feature is now
considered supported in Safari as well.
