### PR TITLE
Redefine `open-closed` to be only about :open

### DIFF
--- a/features/open-closed.yml
+++ b/features/open-closed.yml
@@ -1,7 +1,6 @@
-name: Open and closed selectors
-description: The `:open` and `:closed` CSS pseudo-classes match elements that have open and closed states, like `<details`, `<dialog>`, or `<select>`, based on their state.
+name: ":open"
+description: The `:open` CSS pseudo-class matches elements that have open states, like `<details`, `<dialog>`, or `<select>`, based on their state.
 spec: https://drafts.csswg.org/selectors-4/#open-state
 group: selectors
 compat_features:
-  - css.selectors.closed
   - css.selectors.open

--- a/features/open-closed.yml.dist
+++ b/features/open-closed.yml.dist
@@ -3,18 +3,11 @@
 
 status:
   baseline: false
-  support: {}
+  support:
+    chrome: "133"
+    chrome_android: "133"
+    edge: "133"
+    firefox: "136"
+    firefox_android: "136"
 compat_features:
-  # baseline: false
-  # support:
-  #   chrome: "133"
-  #   chrome_android: "133"
-  #   edge: "133"
-  #   firefox: "136"
-  #   firefox_android: "136"
   - css.selectors.open
-
-  # ⬇️ Same status as overall feature ⬇️
-  # baseline: false
-  # support: {}
-  - css.selectors.closed


### PR DESCRIPTION
The :closed pseudo-class was removed from the spec:
https://github.com/w3c/csswg-drafts/pull/11326

This feature should be renamed to just `open` once we support renaming,
but it's OK that the `open-closed` identifier is taken because if
:closed is added in the future, it would be as `closed`, at least until
the very far future where they could merge again...
