### PR TITLE
Close angle brackets in description for `:open` pseudo-class

### DIFF
--- a/features/open-closed.yml
+++ b/features/open-closed.yml
@@ -1,5 +1,5 @@
 name: ":open"
-description: The `:open` CSS pseudo-class matches elements that have open states, like `<details`, `<dialog>`, or `<select>`, based on their state.
+description: The `:open` CSS pseudo-class matches elements that have open states, like `<details>`, `<dialog>`, or `<select>`, based on their state.
 spec: https://drafts.csswg.org/selectors-4/#open-state
 group: selectors
 compat_features:


### PR DESCRIPTION
I saw this in https://github.com/web-platform-dx/web-features/pull/3238#pullrequestreview-3137689488 but failed to actually apply it before merging.