### PR TITLE
Clarify downstream browser support on gh-pages site

### DIFF
--- a/gh-pages/src/index.md
+++ b/gh-pages/src/index.md
@@ -27,6 +27,28 @@ You can find at-a-glance Baseline statuses on [Can I Use](https://caniuse.com/) 
 
 You can [use Baseline on your site](/use-baseline/) too.
 
+## What about other browsers?
+
+Most modern browsers are built on the rendering engine from one of the browsers in the Baseline core browser set.
+
+All browsers on iOS currently implement WebKit, the Safari rendering engine.
+
+The majority of browsers outside the core browser set on Android, Windows and macOS are built on Chromium/Blink, the open source engine underpinning Chrome and Edge.  These browsers can usually be mapped back to the Baseline feature set they support based on the Chromium version they implement.  The [`baseline-browser-mapping`](https://github.com/web-platform-dx/baseline-browser-mapping) module tracks these mappings, and currently includes data on the following browsers:
+
+- Opera Desktop and Mobile
+- Samsung Internet
+- Android WebView
+- QQ Browser Mobile*
+- UC Browser Mobile*
+- Yandex Browser Mobile*
+
+> **NOTE**
+> Baseline support for the browsers marked with an asterisk (*) is based on mapping their version number and stated Chromium version from user agent strings captured by [useragents.io](https://useragents.io).  This information is provided on a best-effort basis.  For more information on how these mappings are generated, please see [the `baseline-browser-mapping` README](https://github.com/web-platform-dx/baseline-browser-mapping/blob/main/README.md#downstream-browsers).
+
+KaiOS - a feature phone operating system used for flip phones - implements the Gecko engine from Firefox.  It is possible to derive feature support in KaiOS based on Gecko feature support, but please be aware that KaiOS has a significantly different set of UI limitations and interaction model compared to the other browsers on this page.  For more information, see the [KaiOS developer documentation](https://developer.kaiostech.com/docs/sfp-3.0/).
+
+Other browsers built on Chromium/Blink, Gecko and WebKit will also support Baseline features, and the WebDX Community Group is continuing to work on mapping downstream browser versions back to the engine they implement.  If you work on a browser and can provide data connecting your versions back to their upstream engine for `baseline-browser-mapping`, please [create an issue in the repository](https://github.com/web-platform-dx/baseline-browser-mapping/issues/new).
+
 ## Who owns and maintains Baseline?
 
 The Baseline definition is written by the [web-features owners group](https://github.com/web-platform-dx/web-features/blob/main/GOVERNANCE.md).

--- a/gh-pages/src/index.md
+++ b/gh-pages/src/index.md
@@ -33,7 +33,7 @@ Most modern browsers are built on the rendering engine from one of the browsers 
 
 All browsers on iOS currently implement WebKit, the Safari rendering engine.
 
-The majority of browsers outside the core browser set on Android, Windows and macOS are built on Chromium/Blink, the open source engine underpinning Chrome and Edge.  These browsers can usually be mapped back to the Baseline feature set they support based on the Chromium version they implement.  The [`baseline-browser-mapping`](https://github.com/web-platform-dx/baseline-browser-mapping) module tracks these mappings, and currently includes data on the following browsers:
+The majority of browsers outside the core browser set on Android, Windows and macOS are built on Chromium/Blink, the open source engine underpinning Chrome and Edge. These browsers can usually be mapped back to the Baseline feature set they support based on the Chromium version they implement. The [`baseline-browser-mapping`](https://github.com/web-platform-dx/baseline-browser-mapping) module tracks these mappings, and currently includes data on the following browsers:
 
 - Opera Desktop and Mobile
 - Samsung Internet
@@ -43,11 +43,11 @@ The majority of browsers outside the core browser set on Android, Windows and ma
 - Yandex Browser Mobile*
 
 > **NOTE**
-> Baseline support for the browsers marked with an asterisk (*) is based on mapping their version number and stated Chromium version from user agent strings captured by [useragents.io](https://useragents.io).  This information is provided on a best-effort basis.  For more information on how these mappings are generated, please see [the `baseline-browser-mapping` README](https://github.com/web-platform-dx/baseline-browser-mapping/blob/main/README.md#downstream-browsers).
+> Baseline support for the browsers marked with an asterisk (*) is based on mapping their version number and stated Chromium version from user agent strings captured by [useragents.io](https://useragents.io). This information is provided on a best-effort basis. For more information on how these mappings are generated, please see [the `baseline-browser-mapping` README](https://github.com/web-platform-dx/baseline-browser-mapping/blob/main/README.md#downstream-browsers).
 
-KaiOS - a feature phone operating system used for flip phones - implements the Gecko engine from Firefox.  It is possible to derive feature support in KaiOS based on Gecko feature support, but please be aware that KaiOS has a significantly different set of UI limitations and interaction model compared to the other browsers on this page.  For more information, see the [KaiOS developer documentation](https://developer.kaiostech.com/docs/sfp-3.0/).
+KaiOS - a feature phone operating system used for flip phones - implements the Gecko engine from Firefox. It is possible to derive feature support in KaiOS based on Gecko feature support, but please be aware that KaiOS has a significantly different set of UI limitations and interaction model compared to the other browsers on this page. For more information, see the [KaiOS developer documentation](https://developer.kaiostech.com/docs/sfp-3.0/).
 
-Other browsers built on Chromium/Blink, Gecko and WebKit will also support Baseline features, and the WebDX Community Group is continuing to work on mapping downstream browser versions back to the engine they implement.  If you work on a browser and can provide data connecting your versions back to their upstream engine for `baseline-browser-mapping`, please [create an issue in the repository](https://github.com/web-platform-dx/baseline-browser-mapping/issues/new).
+Other browsers built on Chromium/Blink, Gecko and WebKit will also support Baseline features, and the WebDX Community Group is continuing to work on mapping downstream browser versions back to the engine they implement. If you work on a browser and can provide data connecting your versions back to their upstream engine for `baseline-browser-mapping`, please [create an issue in the repository](https://github.com/web-platform-dx/baseline-browser-mapping/issues/new).
 
 ## Who owns and maintains Baseline?
 


### PR DESCRIPTION
As discussed in this week's WebDX CG meeting, this draft adds a section in the main Baseline definition page that describes the relationship between Baseline and browsers outside the core set.

CC: @ddbeck @ai @rviscomi 