### PR TITLE
Drop "initial support" qualifier for resource timing

### DIFF
--- a/features/resource-timing.yml
+++ b/features/resource-timing.yml
@@ -1,4 +1,4 @@
-name: Resource timing (initial support)
+name: Resource timing
 description: "`PerformanceResourceTiming` entries report when network events happen while loading a resource, such as when connections start and end. You can use this information to measure loading times."
 spec: https://w3c.github.io/resource-timing/
 group: performance


### PR DESCRIPTION
This is a living feature like most others, it's pinned to the initial
support but API surface keeps being added over time.
