### PR TITLE
Replace many uses of the word "interface"

### DIFF
--- a/features/ambient-light.yml
+++ b/features/ambient-light.yml
@@ -1,5 +1,5 @@
 name: Ambient light sensor
-description: The `AmbientLightSensor` interface returns the current light level in lux of the ambient light level around the device.
+description: The `AmbientLightSensor` API returns the current light level in lux of the ambient light level around the device.
 spec: https://w3c.github.io/ambient-light/
 caniuse: ambient-light
 group: sensors

--- a/features/compression-streams.yml
+++ b/features/compression-streams.yml
@@ -1,5 +1,5 @@
 name: Compression streams
-description: The `CompressionStream` and `DecompressionStream` interfaces compress and decompress data using the gzip or deflate formats.
+description: The `CompressionStream` and `DecompressionStream` APIs compress and decompress data using the gzip or deflate formats.
 spec: https://compression.spec.whatwg.org/
 status:
   compute_from:

--- a/features/cookie-store.yml
+++ b/features/cookie-store.yml
@@ -1,5 +1,5 @@
 name: Cookie store
-description: The `CookieStore` interface is an asynchronous and promise-based API for managing cookies. It does not rely on document and so is available to service workers as well.
+description: The `CookieStore` API is an asynchronous and promise-based API for managing cookies. It does not rely on document and so is available to service workers as well.
 spec: https://cookiestore.spec.whatwg.org/
 caniuse: cookie-store-api
 compat_features:

--- a/features/dom-geometry.yml
+++ b/features/dom-geometry.yml
@@ -1,5 +1,5 @@
 name: DOM Geometry
-description: The `DOMMatrix`, `DOMPoint`, `DOMQuad` and `DOMRect` APIs offer a way to represent points, rectangles, quadrilaterals and transformation matrices within JavaScript. They can be used in transformations in CSS, `<canvas>`, and SVG.
+description: The `DOMMatrix`, `DOMPoint`, `DOMQuad` and `DOMRect` APIs represent points, rectangles, quadrilaterals and transformation matrices within JavaScript. They can be used in transformations in CSS, `<canvas>`, and SVG.
 spec: https://drafts.fxtf.org/geometry-1/
 status:
   compute_from: api.DOMMatrix

--- a/features/dom-geometry.yml
+++ b/features/dom-geometry.yml
@@ -1,5 +1,5 @@
 name: DOM Geometry
-description: The `DOMMatrix`, `DOMPoint`, `DOMQuad` and `DOMRect` interfaces offer a way to represent points, rectangles, quadrilaterals and transformation matrices within JavaScript. They can be used in transformations in CSS, `<canvas>`, and SVG.
+description: The `DOMMatrix`, `DOMPoint`, `DOMQuad` and `DOMRect` APIs offer a way to represent points, rectangles, quadrilaterals and transformation matrices within JavaScript. They can be used in transformations in CSS, `<canvas>`, and SVG.
 spec: https://drafts.fxtf.org/geometry-1/
 status:
   compute_from: api.DOMMatrix

--- a/features/sanitizer.yml
+++ b/features/sanitizer.yml
@@ -1,5 +1,5 @@
 name: Sanitizer API
-description: The `parseHTML()` method for the `Document` interface and the `setHTML()` methods for the `Element` and `ShadowRoot` interfaces parse and insert HTML into the DOM in a way that can prevent cross-site scripting attacks. The `Sanitizer` API can customize the sanitization process.
+description: The `Document.parseHTML()` static method and the `setHTML()` method of `Element` and `ShadowRoot` parses and insert HTML into the DOM in a way that can prevent cross-site scripting attacks. The `Sanitizer` API can customize the sanitization process.
 spec: https://wicg.github.io/sanitizer-api/
 compat_features:
   # The main entry points.

--- a/features/sanitizer.yml
+++ b/features/sanitizer.yml
@@ -1,5 +1,5 @@
 name: Sanitizer API
-description: The `Document.parseHTML()` static method and the `setHTML()` method of `Element` and `ShadowRoot` parses and insert HTML into the DOM in a way that can prevent cross-site scripting attacks. The `Sanitizer` API can customize the sanitization process.
+description: The `Document.parseHTML()` static method and the `setHTML()` method of `Element` and `ShadowRoot` objects parse and insert HTML into the DOM in a way that can prevent cross-site scripting attacks. The `Sanitizer` API can customize the sanitization process.
 spec: https://wicg.github.io/sanitizer-api/
 compat_features:
   # The main entry points.

--- a/features/webdriver.yml
+++ b/features/webdriver.yml
@@ -1,5 +1,5 @@
 name: WebDriver
-description: The WebDriver interface allows out-of-process programs to inspect and control browsers to, for example, run tests of web applications. Also known as WebDriver classic.
+description: The WebDriver protocol allows out-of-process programs to inspect and control browsers to, for example, run tests of web applications. Also known as WebDriver classic.
 spec: https://w3c.github.io/webdriver/
 group: webdriver
 compat_features:


### PR DESCRIPTION
In most places API is more natural and consistent with the rest of
web-features.

Sanitizer is aligned with the wording in parse-html-unsafe.yml.

For WebDriver "interface" isn't wrong, but protocol seems clearer.
