### PR TITLE
Mention PerformanceObserver API in performance feature description

### DIFF
--- a/features/performance.yml
+++ b/features/performance.yml
@@ -1,5 +1,5 @@
 name: Performance
-description: The `performance` global object and the `Performance` API provide access to performance-related information for the current execution context.
+description: The `performance` global object and the `PerformanceObserver` API provide access to performance-related information for the current execution context.
 spec:
   - https://w3c.github.io/hr-time/
   - https://w3c.github.io/performance-timeline/


### PR DESCRIPTION
As luck would have it, there was a perfect place to slot it in. The
previous description didn't make sense, because `performance` and
`Performance` are the same thing, one is the instance and one is the
interface.
