### PR TITLE
Move 3 members of Performance to resource timing

### DIFF
--- a/features/performance.yml
+++ b/features/performance.yml
@@ -3,7 +3,6 @@ description: The `performance` global object and the `Performance` API provide a
 spec:
   - https://w3c.github.io/hr-time/
   - https://w3c.github.io/performance-timeline/
-  - https://w3c.github.io/resource-timing/
   - https://w3c.github.io/user-timing/#extensions-performance-interface
 caniuse:
   - user-timing
@@ -21,11 +20,8 @@ compat_features:
   - api.Performance.getEntries
   - api.Performance.getEntriesByName
   - api.Performance.getEntriesByType
-  - api.Performance.resourcetimingbufferfull_event
-  - api.Performance.setResourceTimingBufferSize
   - api.Performance.clearMarks
   - api.Performance.clearMeasures
-  - api.Performance.clearResourceTimings
   - api.Performance.mark
   - api.Performance.mark.markOptions_parameter
   - api.Performance.mark.returns_performancemark

--- a/features/performance.yml.dist
+++ b/features/performance.yml.dist
@@ -135,8 +135,6 @@ compat_features:
   #   firefox_android: "35"
   #   safari: "11"
   #   safari_ios: "11"
-  - api.Performance.clearResourceTimings
-  - api.Performance.setResourceTimingBufferSize
   - api.PerformanceEntry
   - api.PerformanceEntry.duration
   - api.PerformanceEntry.entryType
@@ -168,19 +166,6 @@ compat_features:
   #   safari: "11"
   #   safari_ios: "11"
   - api.PerformanceEntry.worker_support
-
-  # baseline: high
-  # baseline_low_date: 2020-01-15
-  # baseline_high_date: 2022-07-15
-  # support:
-  #   chrome: "46"
-  #   chrome_android: "46"
-  #   edge: "79"
-  #   firefox: "35"
-  #   firefox_android: "35"
-  #   safari: "11"
-  #   safari_ios: "11"
-  - api.Performance.resourcetimingbufferfull_event
 
   # baseline: high
   # baseline_low_date: 2020-01-15

--- a/features/resource-timing.yml
+++ b/features/resource-timing.yml
@@ -6,6 +6,9 @@ caniuse: resource-timing
 status:
   compute_from: api.PerformanceResourceTiming
 compat_features:
+  - api.Performance.clearResourceTimings
+  - api.Performance.resourcetimingbufferfull_event
+  - api.Performance.setResourceTimingBufferSize
   - api.PerformanceResourceTiming
   - api.PerformanceResourceTiming.connectEnd
   - api.PerformanceResourceTiming.connectStart

--- a/features/resource-timing.yml.dist
+++ b/features/resource-timing.yml.dist
@@ -52,6 +52,20 @@ compat_features:
   - api.PerformanceResourceTiming.responseStart
 
   # baseline: high
+  # baseline_low_date: 2017-09-19
+  # baseline_high_date: 2020-03-19
+  # support:
+  #   chrome: "46"
+  #   chrome_android: "46"
+  #   edge: "12"
+  #   firefox: "35"
+  #   firefox_android: "35"
+  #   safari: "11"
+  #   safari_ios: "11"
+  - api.Performance.clearResourceTimings
+  - api.Performance.setResourceTimingBufferSize
+
+  # baseline: high
   # baseline_low_date: 2017-10-17
   # baseline_high_date: 2020-04-17
   # support:
@@ -102,6 +116,19 @@ compat_features:
   #   safari: "11"
   #   safari_ios: "11"
   - api.PerformanceResourceTiming.secureConnectionStart
+
+  # baseline: high
+  # baseline_low_date: 2020-01-15
+  # baseline_high_date: 2022-07-15
+  # support:
+  #   chrome: "46"
+  #   chrome_android: "46"
+  #   edge: "79"
+  #   firefox: "35"
+  #   firefox_android: "35"
+  #   safari: "11"
+  #   safari_ios: "11"
+  - api.Performance.resourcetimingbufferfull_event
 
   # baseline: false
   # support:


### PR DESCRIPTION
These bits on performance influence the number of
PerformanceResourceTiming objects stored, and belong with the resource
timing feature. They're defined here:
https://w3c.github.io/resource-timing/#sec-extensions-performance-interface
