### PR TITLE
Update moveBefore() spec and BCD keys

### DIFF
--- a/features/move-before.yml
+++ b/features/move-before.yml
@@ -1,8 +1,11 @@
 name: moveBefore()
 description: The `moveBefore()` DOM method relocates a node while preserving its state. For example, you can move the active element without losing focus, move an animated element without resetting the animation, or move an iframe without reloading its content.
-spec: https://github.com/whatwg/dom/pull/1307
+spec:
+  - https://dom.spec.whatwg.org/#dom-parentnode-movebefore
+  - https://html.spec.whatwg.org/#preserving-custom-element-state-when-moved
 group: dom
 compat_features:
+  - api.CustomElementRegistry.define.connectedMoveCallback_lifecycle_callback
   - api.Document.moveBefore
   - api.DocumentFragment.moveBefore
   - api.Element.moveBefore

--- a/features/move-before.yml
+++ b/features/move-before.yml
@@ -2,7 +2,7 @@ name: moveBefore()
 description: The `moveBefore()` DOM method relocates a node while preserving its state. For example, you can move the active element without losing focus, move an animated element without resetting the animation, or move an iframe without reloading its content.
 spec:
   - https://dom.spec.whatwg.org/#dom-parentnode-movebefore
-  - https://html.spec.whatwg.org/#preserving-custom-element-state-when-moved
+  - https://html.spec.whatwg.org/multipage/custom-elements.html#preserving-custom-element-state-when-moved
 group: dom
 compat_features:
   - api.CustomElementRegistry.define.connectedMoveCallback_lifecycle_callback

--- a/features/move-before.yml.dist
+++ b/features/move-before.yml.dist
@@ -8,6 +8,7 @@ status:
     chrome_android: "133"
     edge: "133"
 compat_features:
+  - api.CustomElementRegistry.define.connectedMoveCallback_lifecycle_callback
   - api.Document.moveBefore
   - api.DocumentFragment.moveBefore
   - api.Element.moveBefore

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -122,10 +122,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because this is where the application-title meta tag is spec'd at the moment. Remove when https://github.com/whatwg/html/issues/8909 is fixed."
     ],
     [
-        "https://github.com/whatwg/dom/pull/1307",
-        "This is only place moveBefore() is spec'd. Remove this exception when https://github.com/whatwg/dom/pull/1307 merges."
-    ],
-    [
         "https://www.w3.org/TR/2018/SPSD-html5-20180327/embedded-content-0.html#synchronising-multiple-media-elements",
         "Allowed for the mediacontroller feature. This is the superseded HTML5 spec that still contains MediaController."
     ],


### PR DESCRIPTION
Spec changes were landed here:
https://github.com/whatwg/dom/pull/1307
https://github.com/whatwg/html/pull/10657
