### PR TITLE
Move two getCapabilities() methods out of media capabilities

### DIFF
--- a/features/media-capabilities.yml
+++ b/features/media-capabilities.yml
@@ -1,16 +1,9 @@
 name: Media capabilities
 description: The `navigator.mediaCapabilities` API queries the encoding and decoding abilities of the device, such as supported codecs, resolutions, and bitrates.
 spec: https://w3c.github.io/media-capabilities/
-# Computing status because core feature is baseline but this new input device
-# instance of it is not, but doesn't prevent use.
-# - api.InputDeviceInfo.getCapabilities
-status:
-  compute_from: api.MediaCapabilities
 compat_features:
-  - api.InputDeviceInfo.getCapabilities
   - api.MediaCapabilities
   - api.MediaCapabilities.decodingInfo
   - api.MediaCapabilities.encodingInfo
-  - api.MediaStreamTrack.getCapabilities
   - api.Navigator.mediaCapabilities
   - api.WorkerNavigator.mediaCapabilities

--- a/features/media-capabilities.yml.dist
+++ b/features/media-capabilities.yml.dist
@@ -3,18 +3,17 @@
 
 status:
   baseline: high
-  baseline_low_date: 2020-01-15
-  baseline_high_date: 2022-07-15
+  baseline_low_date: 2022-04-28
+  baseline_high_date: 2024-10-28
   support:
-    chrome: "66"
-    chrome_android: "66"
-    edge: "79"
+    chrome: "101"
+    chrome_android: "101"
+    edge: "101"
     firefox: "63"
     firefox_android: "63"
-    safari: "13"
-    safari_ios: "13"
+    safari: "15.4"
+    safari_ios: "15.4"
 compat_features:
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: high
   # baseline_low_date: 2020-01-15
   # baseline_high_date: 2022-07-15
@@ -43,6 +42,7 @@ compat_features:
   #   safari_ios: "15.4"
   - api.WorkerNavigator.mediaCapabilities
 
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: high
   # baseline_low_date: 2022-04-28
   # baseline_high_date: 2024-10-28
@@ -55,24 +55,3 @@ compat_features:
   #   safari: "15.4"
   #   safari_ios: "15.4"
   - api.MediaCapabilities.encodingInfo
-
-  # baseline: low
-  # baseline_low_date: 2024-10-29
-  # support:
-  #   chrome: "59"
-  #   chrome_android: "59"
-  #   edge: "12"
-  #   firefox: "132"
-  #   firefox_android: "132"
-  #   safari: "11"
-  #   safari_ios: "11"
-  - api.MediaStreamTrack.getCapabilities
-
-  # baseline: false
-  # support:
-  #   chrome: "67"
-  #   chrome_android: "67"
-  #   edge: "79"
-  #   safari: "17"
-  #   safari_ios: "17"
-  - api.InputDeviceInfo.getCapabilities

--- a/features/media-capture.yml
+++ b/features/media-capture.yml
@@ -6,6 +6,7 @@ status:
   compute_from: api.MediaDevices.getUserMedia
 compat_features:
   - api.InputDeviceInfo
+  - api.InputDeviceInfo.getCapabilities
   - api.MediaDeviceInfo
   - api.MediaDeviceInfo.deviceId
   - api.MediaDeviceInfo.groupId
@@ -52,6 +53,7 @@ compat_features:
   - api.MediaStreamTrack.enabled
   - api.MediaStreamTrack.ended_event
   - api.MediaStreamTrack.id
+  - api.MediaStreamTrack.getCapabilities
   - api.MediaStreamTrack.getConstraints
   - api.MediaStreamTrack.getSettings
   - api.MediaStreamTrack.kind

--- a/features/media-capture.yml.dist
+++ b/features/media-capture.yml.dist
@@ -440,6 +440,18 @@ compat_features:
   # baseline: low
   # baseline_low_date: 2024-10-29
   # support:
+  #   chrome: "59"
+  #   chrome_android: "59"
+  #   edge: "12"
+  #   firefox: "132"
+  #   firefox_android: "132"
+  #   safari: "11"
+  #   safari_ios: "11"
+  - api.MediaStreamTrack.getCapabilities
+
+  # baseline: low
+  # baseline_low_date: 2024-10-29
+  # support:
   #   chrome: "64"
   #   chrome_android: "64"
   #   edge: "79"
@@ -535,6 +547,15 @@ compat_features:
   #   safari: "11.1"
   #   safari_ios: "11.3"
   - api.OverconstrainedError.constraint
+
+  # baseline: false
+  # support:
+  #   chrome: "67"
+  #   chrome_android: "67"
+  #   edge: "79"
+  #   safari: "17"
+  #   safari_ios: "17"
+  - api.InputDeviceInfo.getCapabilities
 
   # baseline: false
   # support:


### PR DESCRIPTION
These aren't part of the same API. They're defined here:
https://w3c.github.io/mediacapture-main/#dom-inputdeviceinfo-getcapabilities
https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-getcapabilities

Removing the compute_from here to match the feature description makes
the Baseline year change from 2020 to 20222, but this seems OK.
