### PR TITLE
Upgrade `compute-baseline` to use BCD 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       "devDependencies": {
         "@eslint/js": "^9.34.0",
         "@js-temporal/polyfill": "^0.5.1",
-        "@mdn/browser-compat-data": "^6.1.5",
+        "@mdn/browser-compat-data": "^7.0.0",
         "@octokit/rest": "^22.0.0",
         "@types/caniuse-lite": "^1.0.4",
         "@types/node": "^20.19.11",
@@ -797,9 +797,9 @@
       }
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-6.1.5.tgz",
-      "integrity": "sha512-PzdZZzRhcXvKB0begee28n5lvwAcinGKYuLZOVxHAZm+n7y01ddEGfdS1ZXRuVcV+ndG6mSEAE8vgudom5UjYg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-7.0.0.tgz",
+      "integrity": "sha512-qyM4cMWS0ks9vwckN9gZ+opeNvnGTQKp83dANUlE06LlaINQEzfauG3QDQcyUPLsmMoV+br9GGAoSy4038mvRA==",
       "license": "CC0-1.0"
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -5846,7 +5846,7 @@
         "mocha": "^11.7.1"
       },
       "peerDependencies": {
-        "@mdn/browser-compat-data": "^6.0.2"
+        "@mdn/browser-compat-data": ">6.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@eslint/js": "^9.34.0",
     "@js-temporal/polyfill": "^0.5.1",
-    "@mdn/browser-compat-data": "^6.1.5",
+    "@mdn/browser-compat-data": "^7.0.0",
     "@octokit/rest": "^22.0.0",
     "@types/caniuse-lite": "^1.0.4",
     "@types/node": "^20.19.11",

--- a/packages/compute-baseline/package.json
+++ b/packages/compute-baseline/package.json
@@ -35,7 +35,7 @@
     "mocha": "^11.7.1"
   },
   "peerDependencies": {
-    "@mdn/browser-compat-data": "^6.0.2"
+    "@mdn/browser-compat-data": "^7.0.0"
   },
   "dependencies": {
     "@js-temporal/polyfill": "^0.5.1",

--- a/packages/compute-baseline/src/browser-compat-data/feature.ts
+++ b/packages/compute-baseline/src/browser-compat-data/feature.ts
@@ -4,8 +4,6 @@ import { Compat, defaultCompat } from "./compat.js";
 import { Release } from "./release.js";
 import {
   Qualifications,
-  RealSupportStatement,
-  statement,
   Supported,
   SupportStatement,
   UnknownSupport,
@@ -95,12 +93,11 @@ export class Feature {
   }
 
   /**
-   * Get this feature's `SupportStatement` or `RealSupportStatement` objects,
-   * for a given browser.
+   * Get this feature's `SupportStatement` objects, for a given browser.
    */
   supportStatements(browser: Browser): SupportStatement[] {
-    return this.rawSupportStatements(browser).map((raw) =>
-      statement(raw, browser, this),
+    return this.rawSupportStatements(browser).map(
+      (raw) => new SupportStatement(raw, browser, this),
     );
   }
 
@@ -114,8 +111,6 @@ export class Feature {
   ): (Supported | Unsupported | UnknownSupport)[] {
     const result = [];
     for (const s of this.supportStatements(release.browser)) {
-      this.assertRealSupportStatement(s, release.browser);
-
       result.push(s.supportedInDetails(release));
     }
     return result;
@@ -130,8 +125,6 @@ export class Feature {
   supportedIn(release: Release): boolean | null {
     let unknown = false;
     for (const s of this.supportStatements(release.browser)) {
-      this.assertRealSupportStatement(s, release.browser);
-
       const supported = s.supportedInDetails(release);
       if (supported.supported && !supported.qualifications) {
         return true;
@@ -152,8 +145,6 @@ export class Feature {
   ): { release: Release; qualifications?: Qualifications }[] {
     const result = [];
     for (const s of this.supportStatements(browser)) {
-      this.assertRealSupportStatement(s, browser);
-
       result.push(...s.supportedBy());
     }
 
@@ -174,18 +165,5 @@ export class Feature {
       result.push(...this._supportedBy(b));
     }
     return result;
-  }
-
-  /**
-   * Throws when a support statement contains non-real values.
-   */
-  assertRealSupportStatement(
-    statement: SupportStatement,
-    browser: Browser,
-  ): asserts statement is RealSupportStatement {
-    if (!(statement instanceof RealSupportStatement))
-      throw new Error(
-        `${this.id} contains non-real values for ${browser.name}. Cannot expand support.`,
-      );
   }
 }

--- a/packages/compute-baseline/src/browser-compat-data/index.ts
+++ b/packages/compute-baseline/src/browser-compat-data/index.ts
@@ -4,8 +4,6 @@ import { feature, Feature } from "./feature.js";
 import { query } from "./query.js";
 import { Release } from "./release.js";
 import {
-  RealSupportStatement,
-  statement,
   SupportStatement,
 } from "./supportStatements.js";
 import { walk } from "./walk.js";
@@ -17,9 +15,7 @@ export {
   feature,
   Feature,
   query,
-  RealSupportStatement,
   Release,
-  statement,
   SupportStatement,
-  walk,
+  walk
 };

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
@@ -1,7 +1,6 @@
 import {
   FlagStatement,
   SimpleSupportStatement,
-  VersionValue,
 } from "@mdn/browser-compat-data";
 
 import { Browser } from "./browser.js";
@@ -54,7 +53,7 @@ export class SupportStatement {
    * A version string for the first supporting release. If the feature was never
    * supported, then it is `false`.
    */
-  get version_added(): VersionValue {
+  get version_added(): string | false {
     return this.data?.version_added;
   }
 

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
@@ -1,6 +1,7 @@
 import {
   FlagStatement,
   SimpleSupportStatement,
+  VersionValue,
 } from "@mdn/browser-compat-data";
 
 import { Browser } from "./browser.js";
@@ -33,23 +34,35 @@ export class SupportStatement {
     this.feature = feature;
   }
 
+  /**
+   * An array of `FlagStatement` objects. If there are no flags, then the array
+   * is empty.
+   */
   get flags(): FlagStatement[] {
     return this.data?.flags ?? [];
   }
 
+  /**
+   * A `true` value, if support exists but may be incompatible with other
+   * implementations; otherwise, `false`.
+   */
   get partial_implementation(): boolean {
-    // Strictness guarantee: unset partial_implementation returns false
     return this.data?.partial_implementation ?? false;
   }
 
   /**
-   * Get the `version_added` value
+   * A version string for the first supporting release. If the feature was never
+   * supported, then it is `false`.
    */
-  get version_added() {
+  get version_added(): VersionValue {
     return this.data?.version_added;
   }
 
-  get version_removed() {
+  /**
+   * A version string for the first unsupporting release after `version_added`.
+   * If the feature is still supported, then it is `undefined`.
+   */
+  get version_removed(): string | undefined {
     return this.data?.version_removed;
   }
 

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
@@ -54,7 +54,7 @@ export class SupportStatement {
    * supported, then it is `false`.
    */
   get version_added(): string | false {
-    return this.data?.version_added;
+    return this.data?.version_added ?? false;
   }
 
   /**

--- a/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
+++ b/packages/compute-baseline/src/browser-compat-data/supportStatements.ts
@@ -42,8 +42,9 @@ export class SupportStatement {
   }
 
   /**
-   * A `true` value, if support exists but may be incompatible with other
-   * implementations; otherwise, `false`.
+   * A `true` value when evidence of support exists, such an API exposure, but
+   * its behavior is irregular (for example, by deviating from the
+   * specification). Otherwise, `false`.
    */
   get partial_implementation(): boolean {
     return this.data?.partial_implementation ?? false;

--- a/scripts/find-troublesome-ancestors.ts
+++ b/scripts/find-troublesome-ancestors.ts
@@ -8,7 +8,7 @@ const c = new Compat();
 const needles = [];
 
 for (const feature of c.walk()) {
-  if (feature.id.startsWith("webextensions")) {
+  if (feature.id.startsWith("webextensions.")) {
     continue;
   }
 

--- a/scripts/find-troublesome-ancestors.ts
+++ b/scripts/find-troublesome-ancestors.ts
@@ -8,6 +8,10 @@ const c = new Compat();
 const needles = [];
 
 for (const feature of c.walk()) {
+  if (feature.id.startsWith("webextensions")) {
+    continue;
+  }
+
   try {
     const lone = computeBaseline({
       compatKeys: [feature.id],
@@ -25,10 +29,12 @@ for (const feature of c.walk()) {
       ]);
     }
   } catch (err) {
-    if (err instanceof Error) {
-      err.message.includes("contains non-real values");
+    if (
+      err instanceof Error &&
+      err.message.includes("contains no support data for")
+    ) {
       console.warn(
-        `${feature.id} or an ancestor contains non-real-values. Skipping.`,
+        `${feature.id} contains no support data for one or more core browser set browsers. Skipping.`,
       );
       continue;
     }


### PR DESCRIPTION
This upgrades `compute-baseline` (and the project generally) to use `@mdn/browser-compat-data@7.0.0`. Since v7.0.0 does not contain any data changes over v6.1.5, this has no impact on the data, as expected.

This causes the following breaking changes (maybe use this text when making a release):

- The `RealSupportStatement` class has been removed. All BCD statements now have "real" values (that is, they do not contain `true` or `null` values where version strings might appear), so the distinction between "real" and "non-real" statements no longer has any meaning. Use the `SupportStatement` class instead.

- The `statement()` factory function has been removed. It serves no purpose without the real/non-real value distinction. Use `new SupportStatement()` instead.