### PR TITLE
📦 Release compute-baseline@0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5830,7 +5830,7 @@
       }
     },
     "packages/compute-baseline": {
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@js-temporal/polyfill": "^0.5.1",
@@ -5846,7 +5846,7 @@
         "mocha": "^11.7.1"
       },
       "peerDependencies": {
-        "@mdn/browser-compat-data": ">6.0.0"
+        "@mdn/browser-compat-data": "^7.0.0"
       }
     }
   }

--- a/packages/compute-baseline/package.json
+++ b/packages/compute-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compute-baseline",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A library for computing web-features statuses from browser compatibility data",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Don't merge this unless you're prepared to do the release itself too.

## Proposed release notes

```
## Breaking Changes

* This release requires `@mdn/browser-compat-data@^7.0.0`.
* The `RealSupportStatement` class has been removed. All upstream browser compatibility statements now have "real" values (that is, they do not contain `true` or `null` values where version strings might appear), so the distinction between "real" and "non-real" statements no longer has any meaning. Use the `SupportStatement` class instead.
* The `statement()` factory function has been removed. It serves no purpose without the real/non-real value distinction. Use `new SupportStatement()` instead.

## What's Changed

* Upgrade `compute-baseline` to use BCD 7.0.0 by @ddbeck in https://github.com/web-platform-dx/web-features/pull/3288
* Update `compute-baseline` README: `withAncestors` to `checkAncestors` by @alattalatta in https://github.com/web-platform-dx/web-features/pull/3046
```

## Steps to release

1. Merge this PR.
2. Wait for tests and workflows to complete on `main`.
3. Create a release:

   1. Follow this link: https://github.com/web-platform-dx/web-features/releases/new?tag=compute-baseline/v0.4.0&title=compute-baseline@v0.4.0
   1. Uncheck **Set as the latest release**.
   1. Fill in the release notes using the proposed release notes.
   1. Click **Publish release**.

5. Check out `main` and pull the latest changes.
6. Run `npm publish --workspace="compute-baseline" --dry-run` and make sure it's ready to publish v0.4.0.
7. Run `npm publish --workspace="compute-baseline"`.