### PR TITLE
Split the worklets group from workers

### DIFF
--- a/features/audio-worklet.yml
+++ b/features/audio-worklet.yml
@@ -3,7 +3,7 @@ description: The `AudioWorklet` API runs module code in a separate thread, speci
 spec: https://webaudio.github.io/web-audio-api/#AudioWorklet
 group:
   - web-audio
-  - workers
+  - worklets
 status:
   compute_from:
     - api.AudioWorklet

--- a/features/paint.yml
+++ b/features/paint.yml
@@ -1,7 +1,9 @@
 name: paint()
 description: The `paint()` CSS function creates a custom image, drawn using a paint worklet, for an element's background or border.
 spec: https://drafts.css-houdini.org/css-paint-api-1/
-group: css
+group:
+  - css
+  - worklets
 caniuse: css-paint-api
 status:
   compute_from: css.types.image.paint

--- a/features/shared-storage.yml
+++ b/features/shared-storage.yml
@@ -1,7 +1,9 @@
 name: Shared storage
 description: The `sharedStorage` API stores data to a shared space where the data can then be processed without the ability to track users across the different sites they visit. A common use case is measuring the reach of third-party ads without using user-tracking cookies."
 spec: https://wicg.github.io/shared-storage/
-group: storage
+group:
+  - storage
+  - worklets
 compat_features:
   - api.HTMLIFrameElement.sharedStorageWritable
   - api.HTMLImageElement.sharedStorageWritable

--- a/groups/workers.yml
+++ b/groups/workers.yml
@@ -1,2 +1,3 @@
-# Features for running scripts alongside the main thread (i.e., workers and worklets)
+# https://html.spec.whatwg.org/multipage/workers.html and specific worker
+# types like shared workers, service workers, etc.
 name: Workers

--- a/groups/worklets.yml
+++ b/groups/worklets.yml
@@ -1,0 +1,3 @@
+# https://html.spec.whatwg.org/multipage/worklets.html and specific worklet
+# types like audio worklets, paint worklets, etc.
+name: Worklets


### PR DESCRIPTION
Workers and worklets are similar in concept, but worklets a
"thread-agnostic" and can be run on the main thread, this is an
implementation choice:

https://html.spec.whatwg.org/multipage/worklets.html#worklets-motivations
