### PR TITLE
Reinstate "input (event)" name for `input-event` feature

### DIFF
--- a/features/input-event.yml
+++ b/features/input-event.yml
@@ -1,4 +1,4 @@
-name: Input events
+name: input (event)
 description: The `input` event fires when a form control changes or an element with the `contenteditable` attribute changes.
 spec: https://w3c.github.io/uievents/#event-type-input
 caniuse: input-event


### PR DESCRIPTION
From https://github.com/web-platform-dx/web-features/issues/2324#issuecomment-3196841483, I'm restoring the previous name for this feature.

I think it's _possible_ that `beforeinput` is its own feature, but I'm not certain and I don't wish to commit to it. There's some weirdness about `beforeinput` anyway (see the note at the top of [the MDN reference page](https://developer.mozilla.org/en-US/docs/Web/API/Element/beforeinput_event)), so I think we should not explicitly mention it and just treat it as "an event that tells you that `input` is about to fire" for now.

Fixes https://github.com/web-platform-dx/web-features/issues/2324