### PR TITLE
Mark `target-within` as discouraged

### DIFF
--- a/features/target-within.yml
+++ b/features/target-within.yml
@@ -1,7 +1,13 @@
 name: :target-within
 description: The `:target-within` CSS pseudo-class matches the element with an ID matching the URL fragment and its ancestors.
-spec: https://drafts.csswg.org/selectors-4/#the-target-within-pseudo
+spec: https://www.w3.org/TR/2022/WD-selectors-4-20220507/#the-target-within-pseudo
 group: selectors
-# BCD key removed due to no implementation. See https://github.com/web-platform-dx/web-features/issues/2339
-# compat_features:
-#   - css.selectors.target-within
+discouraged:
+  # reason: The `:target-within` pseudo-class was dropped from the specification in favor of `:has(:target)`.
+  # removal_date: 2023-08-16
+  according_to:
+    - https://drafts.csswg.org/selectors-4/#the-target-pseudo
+    - https://github.com/w3c/csswg-drafts/issues/8357
+  alternatives:
+    - has
+    - target

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -136,6 +136,10 @@ const defaultAllowlist: allowlistItem[] = [
     [
         "https://github.com/whatwg/html/pull/11426",
         "This is where speculation rules' prefetch is in the process of being spec'd. Once the PR merges, change the spec url in `speculation-rules`, and remove this exception."
+    ],
+    [
+        "https://www.w3.org/TR/2022/WD-selectors-4-20220507/#the-target-within-pseudo",
+        "Allowed because this is where the feature last appeared in the spec before removal."
     ]
 ];
 


### PR DESCRIPTION
Fixes https://github.com/web-platform-dx/web-features/issues/2339.

Previously, we considered dropping this feature. But in the time since the feature was dropped, we've developed some conventions about removals from specs. This is a better fit now for `discouraged` data, rather than removal; see https://github.com/web-platform-dx/web-features/pull/3186#issuecomment-3298375947 for further discussion.