### PR TITLE
Disambiguate fetch-request-streams feature

### DIFF
--- a/features/fetch-request-streams.yml
+++ b/features/fetch-request-streams.yml
@@ -1,5 +1,6 @@
-name: Fetch upload streams
-description: A `fetch()` request uploads a stream of data to the server when a request's `body` property is a `ReadableStream` object.
+name: Request body property
+description: A `ReadableStream` can be used as the body of a `Request` object.
 spec: https://fetch.spec.whatwg.org/#concept-body-stream
 compat_features:
   - api.Request.body
+  - api.Request.Request.request_body_readablestream

--- a/features/fetch-request-streams.yml.dist
+++ b/features/fetch-request-streams.yml.dist
@@ -7,7 +7,20 @@ status:
     chrome: "105"
     chrome_android: "105"
     edge: "105"
-    safari: "11.1"
-    safari_ios: "11.3"
 compat_features:
+  # baseline: false
+  # support:
+  #   chrome: "105"
+  #   chrome_android: "105"
+  #   edge: "105"
+  #   safari: "11.1"
+  #   safari_ios: "11.3"
   - api.Request.body
+
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: false
+  # support:
+  #   chrome: "105"
+  #   chrome_android: "105"
+  #   edge: "105"
+  - api.Request.Request.request_body_readablestream

--- a/features/fetch.yml
+++ b/features/fetch.yml
@@ -25,7 +25,6 @@ compat_features:
   - api.Request.Request.cross_origin_stripped
   - api.Request.Request.init_keepalive_parameter
   - api.Request.Request.init_referrer_parameter
-  - api.Request.Request.request_body_readablestream
   - api.Request.Request.response_body_readablestream
   - api.Request.arrayBuffer
   - api.Request.blob

--- a/features/fetch.yml.dist
+++ b/features/fetch.yml.dist
@@ -444,13 +444,6 @@ compat_features:
 
   # baseline: false
   # support:
-  #   chrome: "105"
-  #   chrome_android: "105"
-  #   edge: "105"
-  - api.Request.Request.request_body_readablestream
-
-  # baseline: false
-  # support:
   #   chrome: "131"
   #   edge: "131"
   - api.Request.duplex


### PR DESCRIPTION
Rewrite the fetch-request-streams feature to make it more clear what precise property it covers, and add a new fetch-body-stream feature to cover the `body` option to the `fetch` function supporting `ReadableStream` objects.