### PR TITLE
Add leftover filter property BCD keys

### DIFF
--- a/features/filter.yml
+++ b/features/filter.yml
@@ -5,6 +5,16 @@ group: css
 caniuse: css-filters
 compat_features:
   - css.properties.filter
+  - css.properties.filter.blur
+  - css.properties.filter.brightness
+  - css.properties.filter.contrast
+  - css.properties.filter.drop-shadow
+  - css.properties.filter.grayscale
+  - css.properties.filter.hue-rotate
+  - css.properties.filter.invert
+  - css.properties.filter.opacity
+  - css.properties.filter.saturate
+  - css.properties.filter.sepia
   - css.types.filter-function
   - css.types.filter-function.blur
   - css.types.filter-function.brightness

--- a/features/filter.yml.dist
+++ b/features/filter.yml.dist
@@ -50,3 +50,13 @@ compat_features:
   #   safari: "9.1"
   #   safari_ios: "9.3"
   - css.properties.filter
+  - css.properties.filter.blur
+  - css.properties.filter.brightness
+  - css.properties.filter.contrast
+  - css.properties.filter.drop-shadow
+  - css.properties.filter.grayscale
+  - css.properties.filter.hue-rotate
+  - css.properties.filter.invert
+  - css.properties.filter.opacity
+  - css.properties.filter.saturate
+  - css.properties.filter.sepia


### PR DESCRIPTION
I found these BCD keys that should probably have been added to the `filter` feature. So I added them, and that didn't change the overall status, so that's a pretty easy one to do.