### PR TITLE
Remove backticks from <input type=color> alpha/colorspace name

### DIFF
--- a/features/input-color-alpha.yml
+++ b/features/input-color-alpha.yml
@@ -1,4 +1,4 @@
-name: "`alpha` and `colorspace` attributes for `<input type=color>`"
+name: "alpha and colorspace attributes for <input type=color>"
 description: The ability to control the opacity of a color picked using `<input type="color">` and determine the colorspace of the selected color.
 spec: https://html.spec.whatwg.org/multipage/input.html#attr-input-alpha
 group:


### PR DESCRIPTION
Markdown isn't supported in names, only in descriptions.