### PR TITLE
Change notifications-apps Baseline status to high

### DIFF
--- a/features/notifications-apps.yml
+++ b/features/notifications-apps.yml
@@ -8,8 +8,9 @@ description: Notifications via service worker registration's `showNotification()
 spec: https://notifications.spec.whatwg.org/#service-worker-api
 caniuse: notifications
 status:
-  baseline: low
+  baseline: high
   baseline_low_date: 2023-03-27
+  baseline_high_date: 2025-09-27
   support:
     chrome: "20"
     chrome_android: "42"


### PR DESCRIPTION
Progress on #3417

In the Matrix chat @captainbrosset said:

> Ah, I think you're right, that we should just change "low" to "high" in this feature.
> It would have been good to break the build here. I thought we had sanity checks for these kinds of things.
> I actually came across a test just yesterday that, I think, is supposed to check for dates and baseline stages ...
> But I'll need @ddbeck to investigate more deeply here

This PR addresses the immediate issue of manually updating the feature's status to "high" but there's still some investigation needed into why it didn't get flagged sooner.