### PR TITLE
Correct sizes=auto

### DIFF
--- a/features/sizes-auto.yml
+++ b/features/sizes-auto.yml
@@ -1,5 +1,5 @@
 name: '<img sizes="auto" loading="lazy">'
-description: The `sizes="auto"` attribute for the `<img>` HTML element reserves layout space for an image before it loads, avoiding some layout shifts. This attribute only applies to images with the `loading="lazy"` attribute.
+description: The `sizes="auto"` attribute for the `<img>` HTML element determines the layout size for the image based on computed layout size when choosing a source from the `srcset`. This attribute only applies to images with the `loading="lazy"` attribute.
 spec: https://html.spec.whatwg.org/multipage/images.html#valdef-sizes-auto
 group: images
 compat_features:


### PR DESCRIPTION
The previous definition was incorrect