### PR TITLE
Fix `sizes-auto` description

### DIFF
--- a/features/sizes-auto.yml
+++ b/features/sizes-auto.yml
@@ -1,5 +1,5 @@
 name: '<img sizes="auto" loading="lazy">'
-description: The `sizes="auto"` attribute for the `<img>` HTML element determines the layout size for the image based on computed layout size when choosing a source from the `srcset`. This attribute only applies to images with the `loading="lazy"` attribute.
+description: The `sizes="auto"` attribute for the `<img>` HTML element sets the layout size for the image based on the computed layout size when choosing a source from the `srcset`. This attribute only applies to images with the `loading="lazy"` attribute.
 spec: https://html.spec.whatwg.org/multipage/images.html#valdef-sizes-auto
 group: images
 compat_features:


### PR DESCRIPTION
Follow up to https://github.com/web-platform-dx/web-features/pull/3430, which did not follow the ["determines" guideline](https://github.com/web-platform-dx/web-features/blob/main/docs/guidelines.md#determines) and was missing an article.