### PR TITLE
Edit `caret-shape` description

### DIFF
--- a/features/caret-shape.yml
+++ b/features/caret-shape.yml
@@ -1,5 +1,5 @@
 name: caret-shape
-description: The `caret-shape` CSS property controls the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.
+description: The `caret-shape` CSS property sets the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.
 spec: https://drafts.csswg.org/css-ui-4/#propdef-caret-shape
 compat_features:
   - css.properties.caret-shape


### PR DESCRIPTION
Why use two syllables when one can do?