### PR TITLE
Use `gh pr comment` instead of `peter-evans/create-or-update-comment`

### DIFF
--- a/.github/workflows/bcd_upgrade_checklist.yml
+++ b/.github/workflows/bcd_upgrade_checklist.yml
@@ -18,12 +18,14 @@ jobs:
 
       - if: ${{ contains(steps.dependabot-metadata.outputs.dependency-names, '@mdn/browser-compat-data') }}
         continue-on-error: true
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 #v4.0.0
-        with:
-          issue-number: ${{ github.event.number }}
+        run: gh pr comment --repo="$GITHUB_REPOSITORY" "$GITHUB_EVENT_NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_NUMBER: ${{ github.event.number }}
           # TODO: reinstate this post-merge checklist item when https://github.com/web-platform-dx/web-features/issues/1672 is resolved
           # - [ ] (Optional) [Trigger a workflow run to remove tagged compat features](https://github.com/web-platform-dx/web-features/actions/workflows/remove_tagged_compat_features.yml).
-          body: |
+          BODY: |
             Complete this checklist for every `@mdn/browser-compat-data` upgrade PR.
 
             - [ ] Check out this branch locally.


### PR DESCRIPTION
This eliminates a dependency and runs slightly faster. Closes https://github.com/web-platform-dx/web-features/pull/3414/.

I've tested this on my fork and it works. But if it fails, it's not a huge problem. 