### PR TITLE
Update `speculation-rules` spec URL

### DIFF
--- a/features/speculation-rules.yml
+++ b/features/speculation-rules.yml
@@ -1,7 +1,7 @@
 name: Speculation rules
 description: Speculation rules are hints to the browser to proactively download pages in the background so they appear instantly when the user navigates to them.
 spec:
-  - https://github.com/whatwg/html/pull/11426
+  - https://html.spec.whatwg.org/multipage/speculative-loading.html#speculation-rules
   - https://wicg.github.io/nav-speculation/prerendering.html
 status:
   compute_from: html.elements.script.type.speculationrules

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -135,10 +135,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed for private-network-access feature. Feature and spec succeeded by local-network-access."
     ],
     [
-        "https://github.com/whatwg/html/pull/11426",
-        "This is where speculation rules' prefetch is in the process of being spec'd. Once the PR merges, change the spec url in `speculation-rules`, and remove this exception."
-    ],
-    [
         "https://www.w3.org/TR/2022/WD-selectors-4-20220507/#the-target-within-pseudo",
         "Allowed because this is where the feature last appeared in the spec before removal."
     ],


### PR DESCRIPTION
This covers the prerender part of the feature.

Fixes https://github.com/web-platform-dx/web-features/issues/3451