### PR TITLE
Update the peers list

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -75,12 +75,8 @@ Inactive _Peers_ (no activity on the project for months or more) might be marked
 
 #### List of current Peers
 
-- Adriana Jara ([@tropicadri](https://github.com/tropicadri))
-- Brian Kardell ([@bkardell](https://github.com/bkardell))
-- Dietrich Ayala ([@autonome](https://github.com/autonome/))
 - James Stuckey Weber ([@jamesnw](https://github.com/jamesnw))
-- Mariko Kosaka ([@kosamari](https://github.com/kosamari))
-- Pete LePage ([@petele](https://github.com/petele))
+- Rick Viscomi ([@rviscomi](https://github.com/rviscomi))
 
 A _Peer_ who shows an above-average level of contribution to the project, particularly with respect to its strategic direction and long-term health, may be nominated to become an _Owner_, described below.
 
@@ -397,13 +393,15 @@ The chair is responsible for summarizing the discussion of each agenda item and 
   </tbody>
 </table>
 
-<!--
 ## Peers and owners emeriti
 
-The project would like to thank the following former Owners and Peers for their contributions and the countless hours invested.
+The project would like to thank the following inactive Owners and Peers for their contributions.
 
-* (This list is currently empty.)
--->
+- Adriana Jara ([@tropicadri](https://github.com/tropicadri))
+- Brian Kardell ([@bkardell](https://github.com/bkardell))
+- Dietrich Ayala ([@autonome](https://github.com/autonome/))
+- Mariko Kosaka ([@kosamari](https://github.com/kosamari))
+- Pete LePage ([@petele](https://github.com/petele))
 
 ## Credits
 


### PR DESCRIPTION
This edits the governance doc, mostly to refresh the peers list to reflect currently active contributors. Specifically:

- Add Rick Viscomi (@rviscomi) to the peers list. Rick was granted commit access to the repo, but never formally named as a peer. We ought to resolve this discrepancy.

- Move several names to the emeriti list. These contributors have not recently been active on the project, so probably shouldn't be @-mentioned on issues and PRs. If they'd like to return, they're welcome to ask to be reinstated. In the mean time, we ought to deactivate their elevated repo privileges, as a security precaution.

The governance process requires owners' approval for these changes. I won't merge this without a couple owner approvers (and no objections).