### PR TITLE
Assign a bunch of keys to CSS features

### DIFF
--- a/features/animations-css.yml
+++ b/features/animations-css.yml
@@ -29,6 +29,23 @@ compat_features:
   - css.at-rules.keyframes.named_range_keyframes
   - css.at-rules.keyframes.ignore_important_declarations
   - css.properties.animation
+  - css.properties.animation.alternate
+  - css.properties.animation.alternate-reverse
+  - css.properties.animation.auto
+  - css.properties.animation.backwards
+  - css.properties.animation.both
+  - css.properties.animation.ease
+  - css.properties.animation.ease-in
+  - css.properties.animation.ease-in-out
+  - css.properties.animation.ease-out
+  - css.properties.animation.forwards
+  - css.properties.animation.infinite
+  - css.properties.animation.linear
+  - css.properties.animation.none
+  - css.properties.animation.normal
+  - css.properties.animation.reverse
+  - css.properties.animation.step-end
+  - css.properties.animation.step-start
   - css.properties.animation-delay
   - css.properties.animation-direction
   - css.properties.animation-direction.alternate
@@ -50,5 +67,12 @@ compat_features:
   - css.properties.animation-play-state.paused
   - css.properties.animation-play-state.running
   - css.properties.animation-timing-function
+  - css.properties.animation-timing-function.ease
+  - css.properties.animation-timing-function.ease-in
+  - css.properties.animation-timing-function.ease-in-out
+  - css.properties.animation-timing-function.ease-out
   - css.properties.animation-timing-function.jump
+  - css.properties.animation-timing-function.linear
+  - css.properties.animation-timing-function.step-end
+  - css.properties.animation-timing-function.step-start
   - css.types.time

--- a/features/animations-css.yml.dist
+++ b/features/animations-css.yml.dist
@@ -76,6 +76,30 @@ compat_features:
   - css.properties.animation-play-state.paused
   - css.properties.animation-play-state.running
   - css.properties.animation-timing-function
+  - css.properties.animation-timing-function.ease
+  - css.properties.animation-timing-function.ease-in
+  - css.properties.animation-timing-function.ease-in-out
+  - css.properties.animation-timing-function.ease-out
+  - css.properties.animation-timing-function.linear
+  - css.properties.animation-timing-function.step-end
+  - css.properties.animation-timing-function.step-start
+  - css.properties.animation.alternate
+  - css.properties.animation.alternate-reverse
+  - css.properties.animation.auto
+  - css.properties.animation.backwards
+  - css.properties.animation.both
+  - css.properties.animation.ease
+  - css.properties.animation.ease-in
+  - css.properties.animation.ease-in-out
+  - css.properties.animation.ease-out
+  - css.properties.animation.forwards
+  - css.properties.animation.infinite
+  - css.properties.animation.linear
+  - css.properties.animation.none
+  - css.properties.animation.normal
+  - css.properties.animation.reverse
+  - css.properties.animation.step-end
+  - css.properties.animation.step-start
 
   # baseline: high
   # baseline_low_date: 2016-08-02

--- a/features/background-color.yml
+++ b/features/background-color.yml
@@ -4,3 +4,4 @@ spec: https://drafts.csswg.org/css-backgrounds-3/#background-color
 group: background
 compat_features:
   - css.properties.background-color
+  - css.properties.background-color.transparent

--- a/features/background-color.yml.dist
+++ b/features/background-color.yml.dist
@@ -15,3 +15,4 @@ status:
     safari_ios: "1"
 compat_features:
   - css.properties.background-color
+  - css.properties.background-color.transparent

--- a/features/background.yml
+++ b/features/background.yml
@@ -5,4 +5,14 @@ group: background
 caniuse: multibackgrounds
 compat_features:
   - css.properties.background
+  - css.properties.background.local
   - css.properties.background.multiple_backgrounds
+  - css.properties.background.no-repeat
+  - css.properties.background.none
+  - css.properties.background.repeat
+  - css.properties.background.repeat-x
+  - css.properties.background.repeat-y
+  - css.properties.background.round
+  - css.properties.background.scroll
+  - css.properties.background.space
+  - css.properties.background.transparent

--- a/features/background.yml.dist
+++ b/features/background.yml.dist
@@ -26,6 +26,16 @@ compat_features:
   #   safari: "1"
   #   safari_ios: "1"
   - css.properties.background
+  - css.properties.background.local
+  - css.properties.background.no-repeat
+  - css.properties.background.none
+  - css.properties.background.repeat
+  - css.properties.background.repeat-x
+  - css.properties.background.repeat-y
+  - css.properties.background.round
+  - css.properties.background.scroll
+  - css.properties.background.space
+  - css.properties.background.transparent
 
   # ⬇️ Same status as overall feature ⬇️
   # baseline: high

--- a/features/border-image.yml
+++ b/features/border-image.yml
@@ -7,6 +7,11 @@ status:
   compute_from: css.properties.border-image-repeat.space
 compat_features:
   - css.properties.border-image
+  - css.properties.border-image.none
+  - css.properties.border-image.repeat
+  - css.properties.border-image.round
+  - css.properties.border-image.space
+  - css.properties.border-image.stretch
   - css.properties.border-image-outset
   - css.properties.border-image-repeat
   - css.properties.border-image-repeat.repeat

--- a/features/border-image.yml.dist
+++ b/features/border-image.yml.dist
@@ -56,7 +56,12 @@ compat_features:
   - css.properties.border-image
   - css.properties.border-image-width.auto
   - css.properties.border-image.fill
+  - css.properties.border-image.none
   - css.properties.border-image.optional_border_image_slice
+  - css.properties.border-image.repeat
+  - css.properties.border-image.round
+  - css.properties.border-image.space
+  - css.properties.border-image.stretch
 
   # baseline: high
   # baseline_low_date: 2015-07-29

--- a/features/borders.yml
+++ b/features/borders.yml
@@ -4,19 +4,118 @@ spec: https://drafts.csswg.org/css-backgrounds-3/#borders
 group: borders-outlines
 compat_features:
   - css.properties.border
+  - css.properties.border.dashed
+  - css.properties.border.dotted
+  - css.properties.border.double
+  - css.properties.border.groove
+  - css.properties.border.hidden
+  - css.properties.border.inset
+  - css.properties.border.medium
+  - css.properties.border.none
+  - css.properties.border.outset
+  - css.properties.border.ridge
+  - css.properties.border.solid
+  - css.properties.border.thick
+  - css.properties.border.thin
+  - css.properties.border.transparent
   - css.properties.border-bottom
+  - css.properties.border-bottom.dashed
+  - css.properties.border-bottom.dotted
+  - css.properties.border-bottom.double
+  - css.properties.border-bottom.groove
+  - css.properties.border-bottom.hidden
+  - css.properties.border-bottom.inset
+  - css.properties.border-bottom.medium
+  - css.properties.border-bottom.none
+  - css.properties.border-bottom.outset
+  - css.properties.border-bottom.ridge
+  - css.properties.border-bottom.solid
+  - css.properties.border-bottom.thick
+  - css.properties.border-bottom.thin
+  - css.properties.border-bottom.transparent
   - css.properties.border-bottom-color
+  - css.properties.border-bottom-color.transparent
   - css.properties.border-bottom-style
+  - css.properties.border-bottom-style.dashed
+  - css.properties.border-bottom-style.dotted
+  - css.properties.border-bottom-style.double
+  - css.properties.border-bottom-style.groove
+  - css.properties.border-bottom-style.hidden
+  - css.properties.border-bottom-style.inset
+  - css.properties.border-bottom-style.none
+  - css.properties.border-bottom-style.outset
+  - css.properties.border-bottom-style.ridge
+  - css.properties.border-bottom-style.solid
   - css.properties.border-bottom-width
+  - css.properties.border-bottom-width.medium
+  - css.properties.border-bottom-width.thick
+  - css.properties.border-bottom-width.thin
   - css.properties.border-color
+  - css.properties.border-color.transparent
   - css.properties.border-left
+  - css.properties.border-left.dashed
+  - css.properties.border-left.dotted
+  - css.properties.border-left.double
+  - css.properties.border-left.groove
+  - css.properties.border-left.hidden
+  - css.properties.border-left.inset
+  - css.properties.border-left.medium
+  - css.properties.border-left.none
+  - css.properties.border-left.outset
+  - css.properties.border-left.ridge
+  - css.properties.border-left.solid
+  - css.properties.border-left.thick
+  - css.properties.border-left.thin
+  - css.properties.border-left.transparent
   - css.properties.border-left-color
+  - css.properties.border-left-color.transparent
   - css.properties.border-left-style
+  - css.properties.border-left-style.dashed
+  - css.properties.border-left-style.dotted
+  - css.properties.border-left-style.double
+  - css.properties.border-left-style.groove
+  - css.properties.border-left-style.hidden
+  - css.properties.border-left-style.inset
+  - css.properties.border-left-style.none
+  - css.properties.border-left-style.outset
+  - css.properties.border-left-style.ridge
+  - css.properties.border-left-style.solid
   - css.properties.border-left-width
+  - css.properties.border-left-width.medium
+  - css.properties.border-left-width.thick
+  - css.properties.border-left-width.thin
   - css.properties.border-right
+  - css.properties.border-right.dashed
+  - css.properties.border-right.dotted
+  - css.properties.border-right.double
+  - css.properties.border-right.groove
+  - css.properties.border-right.hidden
+  - css.properties.border-right.inset
+  - css.properties.border-right.medium
+  - css.properties.border-right.none
+  - css.properties.border-right.outset
+  - css.properties.border-right.ridge
+  - css.properties.border-right.solid
+  - css.properties.border-right.thick
+  - css.properties.border-right.thin
+  - css.properties.border-right.transparent
   - css.properties.border-right-color
+  - css.properties.border-right-color.transparent
   - css.properties.border-right-style
+  - css.properties.border-right-style.dashed
+  - css.properties.border-right-style.dotted
+  - css.properties.border-right-style.double
+  - css.properties.border-right-style.groove
+  - css.properties.border-right-style.hidden
+  - css.properties.border-right-style.inset
+  - css.properties.border-right-style.none
+  - css.properties.border-right-style.outset
+  - css.properties.border-right-style.ridge
+  - css.properties.border-right-style.solid
   - css.properties.border-right-width
+  - css.properties.border-right-width.medium
+  - css.properties.border-right-width.thick
+  - css.properties.border-right-width.thin
   - css.properties.border-style
   - css.properties.border-style.dashed
   - css.properties.border-style.dotted
@@ -29,8 +128,39 @@ compat_features:
   - css.properties.border-style.ridge
   - css.properties.border-style.solid
   - css.properties.border-top
+  - css.properties.border-top.dashed
+  - css.properties.border-top.dotted
+  - css.properties.border-top.double
+  - css.properties.border-top.groove
+  - css.properties.border-top.hidden
+  - css.properties.border-top.inset
+  - css.properties.border-top.medium
+  - css.properties.border-top.none
+  - css.properties.border-top.outset
+  - css.properties.border-top.ridge
+  - css.properties.border-top.solid
+  - css.properties.border-top.thick
+  - css.properties.border-top.thin
+  - css.properties.border-top.transparent
   - css.properties.border-top-color
+  - css.properties.border-top-color.transparent
   - css.properties.border-top-style
+  - css.properties.border-top-style.dashed
+  - css.properties.border-top-style.dotted
+  - css.properties.border-top-style.double
+  - css.properties.border-top-style.groove
+  - css.properties.border-top-style.hidden
+  - css.properties.border-top-style.inset
+  - css.properties.border-top-style.none
+  - css.properties.border-top-style.outset
+  - css.properties.border-top-style.ridge
+  - css.properties.border-top-style.solid
   - css.properties.border-top-width
+  - css.properties.border-top-width.medium
+  - css.properties.border-top-width.thick
+  - css.properties.border-top-width.thin
   - css.properties.border-width
+  - css.properties.border-width.medium
+  - css.properties.border-width.thick
+  - css.properties.border-width.thin
   - css.types.line-style

--- a/features/borders.yml.dist
+++ b/features/borders.yml.dist
@@ -28,14 +28,65 @@ compat_features:
   - css.properties.border
   - css.properties.border-bottom
   - css.properties.border-bottom-color
+  - css.properties.border-bottom-color.transparent
   - css.properties.border-bottom-style
+  - css.properties.border-bottom-style.dashed
+  - css.properties.border-bottom-style.dotted
+  - css.properties.border-bottom-style.double
+  - css.properties.border-bottom-style.groove
+  - css.properties.border-bottom-style.hidden
+  - css.properties.border-bottom-style.inset
+  - css.properties.border-bottom-style.none
+  - css.properties.border-bottom-style.outset
+  - css.properties.border-bottom-style.ridge
+  - css.properties.border-bottom-style.solid
   - css.properties.border-bottom-width
+  - css.properties.border-bottom-width.medium
+  - css.properties.border-bottom-width.thick
+  - css.properties.border-bottom-width.thin
+  - css.properties.border-bottom.dashed
+  - css.properties.border-bottom.dotted
+  - css.properties.border-bottom.double
+  - css.properties.border-bottom.groove
+  - css.properties.border-bottom.hidden
+  - css.properties.border-bottom.inset
+  - css.properties.border-bottom.medium
+  - css.properties.border-bottom.none
+  - css.properties.border-bottom.outset
+  - css.properties.border-bottom.ridge
+  - css.properties.border-bottom.solid
+  - css.properties.border-bottom.thick
+  - css.properties.border-bottom.thin
+  - css.properties.border-bottom.transparent
   - css.properties.border-color
+  - css.properties.border-color.transparent
   - css.properties.border-left
   - css.properties.border-left-color
+  - css.properties.border-left-color.transparent
   - css.properties.border-left-width
+  - css.properties.border-left-width.medium
+  - css.properties.border-left-width.thick
+  - css.properties.border-left-width.thin
+  - css.properties.border-left.dashed
+  - css.properties.border-left.dotted
+  - css.properties.border-left.double
+  - css.properties.border-left.groove
+  - css.properties.border-left.hidden
+  - css.properties.border-left.inset
+  - css.properties.border-left.medium
+  - css.properties.border-left.none
+  - css.properties.border-left.outset
+  - css.properties.border-left.ridge
+  - css.properties.border-left.solid
+  - css.properties.border-left.thick
+  - css.properties.border-left.thin
+  - css.properties.border-left.transparent
   - css.properties.border-right-color
+  - css.properties.border-right-color.transparent
   - css.properties.border-right-width
+  - css.properties.border-right-width.medium
+  - css.properties.border-right-width.thick
+  - css.properties.border-right-width.thin
   - css.properties.border-style
   - css.properties.border-style.dashed
   - css.properties.border-style.dotted
@@ -49,8 +100,50 @@ compat_features:
   - css.properties.border-style.solid
   - css.properties.border-top
   - css.properties.border-top-color
+  - css.properties.border-top-color.transparent
   - css.properties.border-top-style
+  - css.properties.border-top-style.dashed
+  - css.properties.border-top-style.dotted
+  - css.properties.border-top-style.double
+  - css.properties.border-top-style.groove
+  - css.properties.border-top-style.hidden
+  - css.properties.border-top-style.inset
+  - css.properties.border-top-style.none
+  - css.properties.border-top-style.outset
+  - css.properties.border-top-style.ridge
+  - css.properties.border-top-style.solid
   - css.properties.border-top-width
+  - css.properties.border-top-width.medium
+  - css.properties.border-top-width.thick
+  - css.properties.border-top-width.thin
+  - css.properties.border-top.dashed
+  - css.properties.border-top.dotted
+  - css.properties.border-top.double
+  - css.properties.border-top.groove
+  - css.properties.border-top.hidden
+  - css.properties.border-top.inset
+  - css.properties.border-top.medium
+  - css.properties.border-top.none
+  - css.properties.border-top.outset
+  - css.properties.border-top.ridge
+  - css.properties.border-top.solid
+  - css.properties.border-top.thick
+  - css.properties.border-top.thin
+  - css.properties.border-top.transparent
+  - css.properties.border.dashed
+  - css.properties.border.dotted
+  - css.properties.border.double
+  - css.properties.border.groove
+  - css.properties.border.hidden
+  - css.properties.border.inset
+  - css.properties.border.medium
+  - css.properties.border.none
+  - css.properties.border.outset
+  - css.properties.border.ridge
+  - css.properties.border.solid
+  - css.properties.border.thick
+  - css.properties.border.thin
+  - css.properties.border.transparent
 
   # baseline: high
   # baseline_low_date: 2015-07-29
@@ -64,6 +157,9 @@ compat_features:
   #   safari: "1"
   #   safari_ios: "3"
   - css.properties.border-width
+  - css.properties.border-width.medium
+  - css.properties.border-width.thick
+  - css.properties.border-width.thin
   - css.types.line-style
 
   # baseline: high
@@ -78,5 +174,39 @@ compat_features:
   #   safari: "1"
   #   safari_ios: "1"
   - css.properties.border-left-style
+  - css.properties.border-left-style.dashed
+  - css.properties.border-left-style.dotted
+  - css.properties.border-left-style.double
+  - css.properties.border-left-style.groove
+  - css.properties.border-left-style.hidden
+  - css.properties.border-left-style.inset
+  - css.properties.border-left-style.none
+  - css.properties.border-left-style.outset
+  - css.properties.border-left-style.ridge
+  - css.properties.border-left-style.solid
   - css.properties.border-right
   - css.properties.border-right-style
+  - css.properties.border-right-style.dashed
+  - css.properties.border-right-style.dotted
+  - css.properties.border-right-style.double
+  - css.properties.border-right-style.groove
+  - css.properties.border-right-style.hidden
+  - css.properties.border-right-style.inset
+  - css.properties.border-right-style.none
+  - css.properties.border-right-style.outset
+  - css.properties.border-right-style.ridge
+  - css.properties.border-right-style.solid
+  - css.properties.border-right.dashed
+  - css.properties.border-right.dotted
+  - css.properties.border-right.double
+  - css.properties.border-right.groove
+  - css.properties.border-right.hidden
+  - css.properties.border-right.inset
+  - css.properties.border-right.medium
+  - css.properties.border-right.none
+  - css.properties.border-right.outset
+  - css.properties.border-right.ridge
+  - css.properties.border-right.solid
+  - css.properties.border-right.thick
+  - css.properties.border-right.thin
+  - css.properties.border-right.transparent

--- a/features/box-shadow.yml
+++ b/features/box-shadow.yml
@@ -7,4 +7,5 @@ compat_features:
   - css.properties.box-shadow
   - css.properties.box-shadow.inset
   - css.properties.box-shadow.multiple_shadows
+  - css.properties.box-shadow.none
   - css.properties.box-shadow.spread_radius

--- a/features/box-shadow.yml.dist
+++ b/features/box-shadow.yml.dist
@@ -17,4 +17,5 @@ compat_features:
   - css.properties.box-shadow
   - css.properties.box-shadow.inset
   - css.properties.box-shadow.multiple_shadows
+  - css.properties.box-shadow.none
   - css.properties.box-shadow.spread_radius

--- a/features/color.yml
+++ b/features/color.yml
@@ -4,4 +4,6 @@ spec: https://drafts.csswg.org/css-color-4/#the-color-property
 group: css
 compat_features:
   - css.properties.color
+  - css.properties.color.transparent
   - css.types.color
+  - css.types.color.transparent

--- a/features/color.yml.dist
+++ b/features/color.yml.dist
@@ -15,4 +15,6 @@ status:
     safari_ios: "1"
 compat_features:
   - css.properties.color
+  - css.properties.color.transparent
   - css.types.color
+  - css.types.color.transparent

--- a/features/content.yml
+++ b/features/content.yml
@@ -6,10 +6,14 @@ status:
   compute_from: css.properties.content
 compat_features:
   - css.properties.content
+  - css.properties.content.close-quote
   - css.properties.content.element_replacement
   - css.properties.content.gradient
+  - css.properties.content.no-close-quote
+  - css.properties.content.no-open-quote
   - css.properties.content.none
   - css.properties.content.none_applies_to_elements
+  - css.properties.content.open-quote
   - css.properties.content.normal
   - css.properties.content.url
   - css.types.string

--- a/features/content.yml.dist
+++ b/features/content.yml.dist
@@ -27,8 +27,12 @@ compat_features:
   #   safari: "1"
   #   safari_ios: "1"
   - css.properties.content
+  - css.properties.content.close-quote
+  - css.properties.content.no-close-quote
+  - css.properties.content.no-open-quote
   - css.properties.content.none
   - css.properties.content.normal
+  - css.properties.content.open-quote
   - css.properties.content.url
   - css.types.string
   - css.types.string.unicode_escaped_characters

--- a/features/float-clear.yml
+++ b/features/float-clear.yml
@@ -8,6 +8,7 @@ compat_features:
   - css.properties.clear
   - css.properties.clear.both
   - css.properties.clear.left
+  - css.properties.clear.none
   - css.properties.clear.right
   - css.properties.float
   - css.properties.float.left

--- a/features/float-clear.yml.dist
+++ b/features/float-clear.yml.dist
@@ -17,6 +17,7 @@ compat_features:
   - css.properties.clear
   - css.properties.clear.both
   - css.properties.clear.left
+  - css.properties.clear.none
   - css.properties.clear.right
   - css.properties.float
   - css.properties.float.left

--- a/features/font-family.yml
+++ b/features/font-family.yml
@@ -4,4 +4,13 @@ spec: https://drafts.csswg.org/css-fonts-4/#font-family-prop
 group: fonts
 compat_features:
   - css.properties.font-family
+  - css.properties.font-family.cursive
+  - css.properties.font-family.fangsong
+  - css.properties.font-family.fantasy
+  - css.properties.font-family.kai
+  - css.properties.font-family.khmer-mul
+  - css.properties.font-family.monospace
+  - css.properties.font-family.nastaliq
+  - css.properties.font-family.sans-serif
+  - css.properties.font-family.serif
   - svg.global_attributes.font-family

--- a/features/font-family.yml.dist
+++ b/features/font-family.yml.dist
@@ -15,4 +15,13 @@ status:
     safari_ios: "1"
 compat_features:
   - css.properties.font-family
+  - css.properties.font-family.cursive
+  - css.properties.font-family.fangsong
+  - css.properties.font-family.fantasy
+  - css.properties.font-family.kai
+  - css.properties.font-family.khmer-mul
+  - css.properties.font-family.monospace
+  - css.properties.font-family.nastaliq
+  - css.properties.font-family.sans-serif
+  - css.properties.font-family.serif
   - svg.global_attributes.font-family

--- a/features/font-style.yml
+++ b/features/font-style.yml
@@ -9,5 +9,6 @@ compat_features:
   - css.properties.font-style
   - css.properties.font-style.italic
   - css.properties.font-style.normal
+  - css.properties.font-style.oblique
   - css.properties.font-style.oblique-angle
   - svg.global_attributes.font-style

--- a/features/font-style.yml.dist
+++ b/features/font-style.yml.dist
@@ -29,6 +29,7 @@ compat_features:
   - css.properties.font-style
   - css.properties.font-style.italic
   - css.properties.font-style.normal
+  - css.properties.font-style.oblique
   - svg.global_attributes.font-style
 
   # baseline: high

--- a/features/list-style.yml
+++ b/features/list-style.yml
@@ -6,6 +6,9 @@ status:
   compute_from: css.properties.list-style
 compat_features:
   - css.properties.list-style
+  - css.properties.list-style.inside
+  - css.properties.list-style.none
+  - css.properties.list-style.outside
   - css.properties.list-style-image
   - css.properties.list-style-image.none
   - css.properties.list-style-position

--- a/features/list-style.yml.dist
+++ b/features/list-style.yml.dist
@@ -53,6 +53,9 @@ compat_features:
   - css.properties.list-style-type.upper-alpha
   - css.properties.list-style-type.upper-latin
   - css.properties.list-style-type.upper-roman
+  - css.properties.list-style.inside
+  - css.properties.list-style.none
+  - css.properties.list-style.outside
 
   # baseline: high
   # baseline_low_date: 2020-01-15

--- a/features/outline.yml
+++ b/features/outline.yml
@@ -3,3 +3,16 @@ description: The `outline` CSS shorthand sets the color, style, and width of a l
 spec: https://drafts.csswg.org/css-ui-4/#outline
 compat_features:
   - css.properties.outline
+  - css.properties.outline.dashed
+  - css.properties.outline.dotted
+  - css.properties.outline.double
+  - css.properties.outline.groove
+  - css.properties.outline.inset
+  - css.properties.outline.medium
+  - css.properties.outline.none
+  - css.properties.outline.outset
+  - css.properties.outline.ridge
+  - css.properties.outline.solid
+  - css.properties.outline.thick
+  - css.properties.outline.thin
+  - css.properties.outline.transparent

--- a/features/outline.yml.dist
+++ b/features/outline.yml.dist
@@ -15,3 +15,16 @@ status:
     safari_ios: "16.4"
 compat_features:
   - css.properties.outline
+  - css.properties.outline.dashed
+  - css.properties.outline.dotted
+  - css.properties.outline.double
+  - css.properties.outline.groove
+  - css.properties.outline.inset
+  - css.properties.outline.medium
+  - css.properties.outline.none
+  - css.properties.outline.outset
+  - css.properties.outline.ridge
+  - css.properties.outline.solid
+  - css.properties.outline.thick
+  - css.properties.outline.thin
+  - css.properties.outline.transparent

--- a/features/outlines.yml
+++ b/features/outlines.yml
@@ -5,6 +5,7 @@ spec: https://drafts.csswg.org/css-ui-4/#outline
 # caniuse: outline
 compat_features:
   - css.properties.outline-color
+  - css.properties.outline-color.transparent
   - css.properties.outline-offset
   - css.properties.outline-style
   - css.properties.outline-style.auto
@@ -18,3 +19,6 @@ compat_features:
   - css.properties.outline-style.ridge
   - css.properties.outline-style.solid
   - css.properties.outline-width
+  - css.properties.outline-width.medium
+  - css.properties.outline-width.thick
+  - css.properties.outline-width.thin

--- a/features/outlines.yml.dist
+++ b/features/outlines.yml.dist
@@ -26,6 +26,7 @@ compat_features:
   #   safari: "1.2"
   #   safari_ios: "1"
   - css.properties.outline-color
+  - css.properties.outline-color.transparent
   - css.properties.outline-style
   - css.properties.outline-style.auto
   - css.properties.outline-style.dashed
@@ -38,6 +39,9 @@ compat_features:
   - css.properties.outline-style.ridge
   - css.properties.outline-style.solid
   - css.properties.outline-width
+  - css.properties.outline-width.medium
+  - css.properties.outline-width.thick
+  - css.properties.outline-width.thin
 
   # ⬇️ Same status as overall feature ⬇️
   # baseline: high

--- a/features/svg-filters.yml
+++ b/features/svg-filters.yml
@@ -214,8 +214,12 @@ compat_features:
   - css.properties.color-interpolation-filters.sRGB
   - css.properties.filter.svg_elements
   - css.properties.flood-color
+  - css.properties.flood-color.currentColor
+  - css.properties.flood-color.transparent
   - css.properties.flood-opacity
   - css.properties.lighting-color
+  - css.properties.lighting-color.currentColor
+  - css.properties.lighting-color.transparent
   - svg.elements.feBlend
   - svg.elements.feBlend.in
   - svg.elements.feBlend.in2

--- a/features/svg-filters.yml.dist
+++ b/features/svg-filters.yml.dist
@@ -179,8 +179,12 @@ compat_features:
   - api.SVGFilterElement.x
   - api.SVGFilterElement.y
   - css.properties.flood-color
+  - css.properties.flood-color.currentColor
+  - css.properties.flood-color.transparent
   - css.properties.flood-opacity
   - css.properties.lighting-color
+  - css.properties.lighting-color.currentColor
+  - css.properties.lighting-color.transparent
   - svg.elements.feColorMatrix
   - svg.elements.feColorMatrix.in
   - svg.elements.feColorMatrix.type

--- a/features/svg.yml
+++ b/features/svg.yml
@@ -292,6 +292,7 @@ compat_features:
   - css.properties.clip-rule.evenodd
   - css.properties.clip-rule.nonzero
   - css.properties.fill
+  - css.properties.fill.none
   - css.properties.fill-rule
   - css.properties.fill-rule.evenodd
   - css.properties.fill-rule.nonzero
@@ -580,23 +581,33 @@ compat_features:
   - svg.global_attributes.color-interpolation.sRGB
   - svg.elements.use.data_uri
   - css.properties.color-interpolation
+  - css.properties.color-interpolation.auto
   - css.properties.color-interpolation.linearGradient
   - css.properties.color-interpolation.sRGB
   - css.properties.cx
   - css.properties.cy
   - css.properties.d
   - css.properties.marker
+  - css.properties.marker.none
   - css.properties.marker-end
+  - css.properties.marker-end.none
   - css.properties.marker-mid
+  - css.properties.marker-mid.none
   - css.properties.marker-start
+  - css.properties.marker-start.none
   - css.properties.r
   - css.properties.rx
   - css.properties.ry
   - css.properties.shape-rendering
+  - css.properties.shape-rendering.auto
   - css.properties.stop-color
   - css.properties.stop-opacity
   - css.properties.stroke
+  - css.properties.stroke.none
   - css.properties.text-anchor
+  - css.properties.text-anchor.end
+  - css.properties.text-anchor.middle
+  - css.properties.text-anchor.start
   - css.properties.text-rendering
   - css.properties.text-rendering.auto
   - css.properties.text-rendering.geometricPrecision

--- a/features/svg.yml.dist
+++ b/features/svg.yml.dist
@@ -865,6 +865,9 @@ compat_features:
   #   safari: "4"
   #   safari_ios: "3.2"
   - css.properties.text-anchor
+  - css.properties.text-anchor.end
+  - css.properties.text-anchor.middle
+  - css.properties.text-anchor.start
 
   # baseline: high
   # baseline_low_date: 2017-01-24
@@ -904,6 +907,7 @@ compat_features:
   - css.properties.stroke-linejoin.round
   - css.properties.stroke-miterlimit
   - css.properties.stroke-width
+  - css.properties.stroke.none
 
   # baseline: high
   # baseline_low_date: ≤2017-04-05
@@ -920,10 +924,15 @@ compat_features:
   - css.properties.fill-rule
   - css.properties.fill-rule.evenodd
   - css.properties.fill-rule.nonzero
+  - css.properties.fill.none
   - css.properties.marker
   - css.properties.marker-end
+  - css.properties.marker-end.none
   - css.properties.marker-mid
+  - css.properties.marker-mid.none
   - css.properties.marker-start
+  - css.properties.marker-start.none
+  - css.properties.marker.none
   - css.properties.stop-color
   - css.properties.stop-opacity
 
@@ -1176,8 +1185,10 @@ compat_features:
   #   safari: "4"
   #   safari_ios: "3.2"
   - css.properties.color-interpolation
+  - css.properties.color-interpolation.auto
   - css.properties.color-interpolation.sRGB
   - css.properties.shape-rendering
+  - css.properties.shape-rendering.auto
 
   # baseline: high
   # baseline_low_date: 2020-01-15

--- a/features/transforms2d.yml
+++ b/features/transforms2d.yml
@@ -19,6 +19,7 @@ compat_features:
   - css.types.transform-function.translateX
   - css.types.transform-function.translateY
   - css.properties.transform
+  - css.properties.transform.none
   - css.properties.transform-origin
   - css.properties.transform-origin.bottom
   - css.properties.transform-origin.center

--- a/features/transforms2d.yml.dist
+++ b/features/transforms2d.yml.dist
@@ -115,3 +115,4 @@ compat_features:
   - css.properties.transform-origin.right
   - css.properties.transform-origin.three_value_syntax
   - css.properties.transform-origin.top
+  - css.properties.transform.none

--- a/features/transitions.yml
+++ b/features/transitions.yml
@@ -18,6 +18,15 @@ compat_features:
   - api.TransitionEvent.pseudoElement
   - api.TransitionEvent.TransitionEvent
   - css.properties.transition
+  - css.properties.transition.all
+  - css.properties.transition.ease
+  - css.properties.transition.ease-in
+  - css.properties.transition.ease-in-out
+  - css.properties.transition.ease-out
+  - css.properties.transition.linear
+  - css.properties.transition.none
+  - css.properties.transition.step-end
+  - css.properties.transition.step-start
   - css.properties.transition-delay
   - css.properties.transition-duration
   - css.properties.transition-property
@@ -25,5 +34,12 @@ compat_features:
   - css.properties.transition-property.IDENT_value
   - css.properties.transition-property.none
   - css.properties.transition-timing-function
+  - css.properties.transition-timing-function.ease
+  - css.properties.transition-timing-function.ease-in
+  - css.properties.transition-timing-function.ease-in-out
+  - css.properties.transition-timing-function.ease-out
   - css.properties.transition-timing-function.jump
+  - css.properties.transition-timing-function.linear
+  - css.properties.transition-timing-function.step-end
+  - css.properties.transition-timing-function.step-start
   - css.properties.transition.gradients_can_animate

--- a/features/transitions.yml.dist
+++ b/features/transitions.yml.dist
@@ -49,6 +49,22 @@ compat_features:
   - css.properties.transition-property.all
   - css.properties.transition-property.none
   - css.properties.transition-timing-function
+  - css.properties.transition-timing-function.ease
+  - css.properties.transition-timing-function.ease-in
+  - css.properties.transition-timing-function.ease-in-out
+  - css.properties.transition-timing-function.ease-out
+  - css.properties.transition-timing-function.linear
+  - css.properties.transition-timing-function.step-end
+  - css.properties.transition-timing-function.step-start
+  - css.properties.transition.all
+  - css.properties.transition.ease
+  - css.properties.transition.ease-in
+  - css.properties.transition.ease-in-out
+  - css.properties.transition.ease-out
+  - css.properties.transition.linear
+  - css.properties.transition.none
+  - css.properties.transition.step-end
+  - css.properties.transition.step-start
 
   # baseline: high
   # baseline_low_date: 2016-08-02


### PR DESCRIPTION
This isn't comprehensive, but it assigns a lot of the longest-implemented CSS keys to features that already exist.

None of these modify headline statuses; these keys are from backfilling activity that happened in BCD recently. See https://github.com/mdn/browser-compat-data/pull/28265