### PR TITLE
Fix upload of `data.extended.json` artifact for `@next` releases

### DIFF
--- a/.github/workflows/publish_next_web-features.yml
+++ b/.github/workflows/publish_next_web-features.yml
@@ -105,5 +105,6 @@ jobs:
           TAG: ${{ env.dist_tag }}
           NOTES: This is a continuously-updated prerelease generated from `main` (currently at ${{ steps.timestamp_and_hash.outputs.SHORT_HASH }}).
           ARTIFACTS: >
-            schemas/data.schema.json
             ${{ env.package_dir }}/data.json
+            data.extended.json
+            schemas/data.schema.json


### PR DESCRIPTION
The continuously uploaded GitHub release [next](https://github.com/web-platform-dx/web-features/releases/tag/next) stopped getting `data.extended.json` at some point. This fixes it.