### PR TITLE
Create a `resource-hints` group

### DIFF
--- a/features/fetch-priority.yml
+++ b/features/fetch-priority.yml
@@ -3,5 +3,6 @@ description: The `fetch()` `priority` option and the `fetchpriority` HTML attrib
 spec:
   - https://fetch.spec.whatwg.org/#request-priority
   - https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attributes
+group: resource-hints
 status:
   compute_from: http.headers.Link.fetchpriority

--- a/features/link-rel-dns-prefetch.yml
+++ b/features/link-rel-dns-prefetch.yml
@@ -2,6 +2,7 @@ name: '<link rel="dns-prefetch">'
 description: The `rel="dns-prefetch"` attribute for the `<link>` HTML element is a hint to the browser that the page or user is likely to request resources from another domain, so the browser should preemptively resolve DNS for the `href` value's domain.
 spec: https://html.spec.whatwg.org/multipage/links.html#link-type-dns-prefetch
 caniuse: link-rel-dns-prefetch
+group: resource-hints
 compat_features:
   - html.elements.link.rel.dns-prefetch
 # TODO: https://github.com/web-platform-dx/web-features/issues/1971

--- a/features/link-rel-preconnect.yml
+++ b/features/link-rel-preconnect.yml
@@ -1,5 +1,6 @@
 name: '<link rel="preconnect">'
 description: The `rel="preconnect"` attribute for the `<link>` HTML element is a hint to the browser that the page or user is likely to request resources from another origin, so the browser should preemptively start a connection to the `href` value's origin.
 spec: https://html.spec.whatwg.org/multipage/links.html#link-type-preconnect
+group: resource-hints
 compat_features:
   - html.elements.link.rel.preconnect

--- a/features/link-rel-prefetch.yml
+++ b/features/link-rel-prefetch.yml
@@ -2,6 +2,7 @@ name: '<link rel="prefetch">'
 description: The `rel="prefetch"` attribute for the `<link>` HTML element is a hint to the browser that the user is likely to navigate to a resource, so the browser should preemptively fetch and cache the resource.
 spec: https://html.spec.whatwg.org/multipage/links.html#link-type-prefetch
 caniuse: link-rel-prefetch
+group: resource-hints
 status:
   compute_from: html.elements.link.rel.prefetch
 compat_features:

--- a/features/link-rel-preload.yml
+++ b/features/link-rel-preload.yml
@@ -2,6 +2,7 @@ name: '<link rel="preload">'
 description: The `rel="preload"` attribute for the `<link>` HTML element requests resources, such as images or style sheets, that the page needs soon, so the browser may prioritize them for loading before rendering begins.
 spec: https://html.spec.whatwg.org/multipage/links.html#link-type-preload
 caniuse: link-rel-preload
+group: resource-hints
 status:
   compute_from: html.elements.link.rel.preload
 compat_features:

--- a/groups/resource-hints.yml
+++ b/groups/resource-hints.yml
@@ -1,0 +1,1 @@
+name: Resource hints


### PR DESCRIPTION
This came out of https://github.com/web-platform-dx/web-features/issues/1624#issuecomment-3511959764. I don't feel strongly about this, but it seemed like a plausible thing to have.