### PR TITLE
Fix casing on OkLCh, remove incorrect function

### DIFF
--- a/features/oklab.yml
+++ b/features/oklab.yml
@@ -1,5 +1,5 @@
 name: Oklab and OkLCh
-description: "The Oklab color space expresses colors in terms of lightness and how red/green and blue/yellow a color is, aiming to match how humans perceive colors. OkLCh is a variant of Oklab with polar coordinates. These color spaces can be used with the CSS `oklab()`, and `oklch()` functions."
+description: "The Oklab color space expresses colors in terms of lightness and how red/green and blue/yellow a color is, aiming to match how humans perceive colors. OkLCh is a variant of Oklab with polar coordinates. These color spaces can be used with the CSS `oklab()` and `oklch()` functions."
 spec: https://drafts.csswg.org/css-color-4/#ok-lab
 group: color-types
 # TODO: The behavior of lightness gradients requiring gamut mapping is a


### PR DESCRIPTION
AFAIK, there isn't a way to use `color(oklab ...)`, so I removed that mention.

Perhaps more controversially, I fixed the casing on OkLCh to match the [creator's casing](https://bottosson.github.io/posts/colorpicker/#okhsv), as well as the [spec](https://drafts.csswg.org/css-color-4/#ok-lab). MDN [also uses](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/oklch) this casing when referring to it (expect when it is a function, which is the majority of the time). I also had a conversation with Chris Lilley (author of the spec) who confirmed this was the correct casing.


