### PR TITLE
Remove `compute_from` from anchor positioning

### DIFF
--- a/features/anchor-positioning.yml
+++ b/features/anchor-positioning.yml
@@ -2,11 +2,6 @@ name: Anchor positioning
 description: Anchor positioning places an element based on the position of another element. For example, you can place a tooltip next to the content it references.
 spec: https://drafts.csswg.org/css-anchor-position-1/#anchoring
 caniuse: css-anchor-positioning
-status:
-  compute_from:
-    - css.properties.anchor-name
-    - css.properties.position-anchor
-    - css.types.anchor
 compat_features:
   - api.CSSPositionTryDescriptors
   - api.CSSPositionTryDescriptors.align-self

--- a/features/anchor-positioning.yml.dist
+++ b/features/anchor-positioning.yml.dist
@@ -3,14 +3,8 @@
 
 status:
   baseline: false
-  support:
-    chrome: "125"
-    chrome_android: "125"
-    edge: "125"
-    safari: "26"
-    safari_ios: "26"
+  support: {}
 compat_features:
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   chrome: "125"
@@ -285,6 +279,7 @@ compat_features:
   - css.properties.position-area.y-end
   - css.properties.position-area.y-start
 
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support: {}
   - css.properties.position-area.self-x-end


### PR DESCRIPTION
This would show no (complete) implementers of anchor positioning, preventing it from reaching Baseline status even if/when Firefox ships it. See https://github.com/web-platform-dx/web-features/issues/3558 for discussion.