### PR TITLE
Add cooldowns to non-data Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
       - gh-pages
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
+      exclude:
+        # Data packages are excluded from cooldowns, since we want those more urgently
+        - "@mdn/browser-compat-data"
+        - "caniuse-lite"
+        - "web-specs"
     ignore:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
This will make Dependabot less noisy for non-data updates. (And it's [a potential security benefit](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns).)