### PR TITLE
Migrate `next`-tagged releases to trusted publishing

### DIFF
--- a/.github/workflows/publish_next_compute-baseline.yml
+++ b/.github/workflows/publish_next_compute-baseline.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - packages/compute-baseline/**
 
+permissions: {}
+
 env:
   package: "compute-baseline"
   package_dir: "packages/compute-baseline"
@@ -15,6 +17,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -27,6 +31,12 @@ jobs:
     if: github.repository == 'web-platform-dx/web-features'
     runs-on: ubuntu-latest
     needs: "test"
+    permissions:
+      contents: read
+      # Required for OIDC and trusted publishing. See:
+      # - https://docs.npmjs.com/trusted-publishers
+      # - https://docs.github.com/en/actions/concepts/security/openid-connect
+      id-token: write
     steps:
       - name: Get timestamp
         id: timestamp
@@ -37,6 +47,7 @@ jobs:
           node-version-file: .node-version
           cache: npm
           registry-url: "https://registry.npmjs.org"
+      - run: npm install -g 'npm@>=11.5.1  # required for trusted publishing
       - run: npm ci
       - name: Get package.json version
         id: version
@@ -49,5 +60,3 @@ jobs:
           VERSION: ${{ steps.version.outputs.VERSION }}
           TIMESTAMP: ${{ steps.timestamp.outputs.TIMESTAMP }}
       - run: npm publish --workspace=${{ env.package }} --tag ${{ env.dist_tag }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_next_web-features.yml
+++ b/.github/workflows/publish_next_web-features.yml
@@ -12,8 +12,7 @@ on:
       - index.ts
       - scripts/build.ts
 
-permissions:
-  contents: write
+permissions: {}
 
 env:
   package: "web-features"
@@ -23,6 +22,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -35,6 +36,12 @@ jobs:
     if: github.repository == 'web-platform-dx/web-features'
     runs-on: ubuntu-latest
     needs: "test"
+    permissions:
+      contents: write
+      # Required for OIDC and trusted publishing. See:
+      # - https://docs.npmjs.com/trusted-publishers
+      # - https://docs.github.com/en/actions/concepts/security/openid-connect
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - name: Get timestamp and short hash
@@ -48,6 +55,8 @@ jobs:
           node-version-file: .node-version
           cache: npm
           registry-url: "https://registry.npmjs.org"
+
+      - run: npm install -g 'npm@>=11.5.1'  # required for trusted publishing
       - run: npm ci
 
       - run: npm run build
@@ -67,11 +76,8 @@ jobs:
           VERSION: ${{ steps.version.outputs.VERSION }}
           TIMESTAMP: ${{ steps.timestamp_and_hash.outputs.TIMESTAMP }}
           SHORT_HASH: ${{ steps.timestamp_and_hash.outputs.SHORT_HASH }}
-      - if: ${{ env.NODE_AUTH_TOKEN }}
-        run: npm publish --tag ${{ env.dist_tag }}
+      - run: npm publish --tag ${{ env.dist_tag }}
         working-directory: ${{ env.package_dir }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Set existing release to draft
         run: gh release edit --draft "$TAG"


### PR DESCRIPTION
GitHub and npm are [moving to a package publishing model](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/) that uses OIDC instead of npm tokens. If we switch to this, we would not need to periodically reissue tokens ([as described in our publishing docs](https://github.com/web-platform-dx/web-features/blob/main/docs/publishing.md#secrets)). This was inspired by me having to reissue tokens today.

This PR migrates the `compute-baseline` and `web-features` `next`-tagged releases to this publishing workflow. If this works well, we can refactor the `latest`-tagged publishing workflows to use the same method ((un)fortunately, each package on npm may only have one blessed workflow, so we'll have to consolidate the publishing workflows).

Upon merging, the packages need configuration in npmjs.com (see [this section of the npm docs](https://docs.npmjs.com/trusted-publishers#for-github-actions) and [this area](https://www.npmjs.com/package/web-features/access) in the npm UI, if you have access). If you're not ready to do this yourself, then please approve and leave unmerged. Thank you!