### PR TITLE
Fix container-anchor-position-queries compat data

### DIFF
--- a/features/container-anchor-position-queries.yml
+++ b/features/container-anchor-position-queries.yml
@@ -2,8 +2,8 @@ name: Anchor position container queries
 description: >
   Anchor position container queries with the `@container anchored(fallback: …)` at-rule apply styles to an element based on the element's anchor position.
 spec: https://drafts.csswg.org/css-anchor-position-2/#anchored-container-queries
-# Expected compat_features:
-# - css.properties.container-type.anchored
-# - css.at-rules.container.anchor_position_queries
-# - css.at-rules.container.anchor_position_queries.fallback
-# - css.at-rules.container.anchor_position_queries.fallback.any
+compat_features:
+  - css.properties.container-type.anchored
+  - css.at-rules.container.anchor_position_queries
+  - css.at-rules.container.anchor_position_queries.fallback
+  - css.at-rules.container.anchor_position_queries.fallback.any_value

--- a/features/container-anchor-position-queries.yml.dist
+++ b/features/container-anchor-position-queries.yml.dist
@@ -3,4 +3,12 @@
 
 status:
   baseline: false
-  support: {}
+  support:
+    chrome: "143"
+    chrome_android: "143"
+    edge: "143"
+compat_features:
+  - css.at-rules.container.anchor_position_queries
+  - css.at-rules.container.anchor_position_queries.fallback
+  - css.at-rules.container.anchor_position_queries.fallback.any_value
+  - css.properties.container-type.anchored


### PR DESCRIPTION
Added by @ddbeck in #3578 but commented out as not available in MDN at that time but is now.

Also a slight correction from:
- `css.at-rules.container.anchor_position_queries.fallback.any`
to:
- `css.at-rules.container.anchor_position_queries.fallback.any_value`