### PR TITLE
Add cooldowns to GitHub Actions Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,3 +43,5 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
A follow up to https://github.com/web-platform-dx/web-features/pull/3575. This has worked really well for npm upgrades and I'd like to extend it to GitHub Actions.