### PR TITLE
Add modern-css.com to Baseline in the wild

### DIFF
--- a/gh-pages/src/baseline-in-the-wild.md
+++ b/gh-pages/src/baseline-in-the-wild.md
@@ -38,6 +38,7 @@ You can find web-features and Baseline data in the places listed below. If you s
 - [Web Platform Features](https://web-features.lttr.cz/), a visualization of the web-features data with filters and fuzzy search capabilities.
 - [Microsoft Edge - 2024 web platform top developer needs](https://microsoftedge.github.io/TopDeveloperNeeds/), a list of web features that developers need, based on data from the Microsoft Edge team.
 - [cssdb](https://cssdb.org/) is a list of CSS features and their positions in the process of becoming implemented web standards.
+- [modern-css.com](https://modern-css.com/), modern CSS snippets with Baseline status for each feature, showing native solutions next to old hacks.
 
 ## Presentations
 


### PR DESCRIPTION
Adds modern-css.com to the “Baseline in the wild” list. The site shows Baseline status on each snippet and compares native CSS features with older workarounds.