### PR TITLE
Add caniuse alias to customizable-select

### DIFF
--- a/features/customizable-select.yml
+++ b/features/customizable-select.yml
@@ -1,6 +1,7 @@
 name: Customizable <select>
 description: The `<select>` element's appearance, including the button, selected option, picker dropdown, and options, can be customized using CSS.
 spec: https://open-ui.org/components/customizableselect/
+caniuse: customizable-select
 group:
   - forms
   - html-elements
@@ -10,4 +11,3 @@ compat_features:
   - css.selectors.picker-icon
   - css.selectors.picker
   - html.elements.selectedcontent
-caniuse: customizable-select


### PR DESCRIPTION
This used to have the id "selectlist" but I renamed it and re-described the feature to help avoid confusion. Now support should match the web feature.