### PR TITLE
`webgpu`: Add unknown limits option

### DIFF
--- a/features/webgpu.yml
+++ b/features/webgpu.yml
@@ -17,6 +17,7 @@ compat_features:
   - api.GPUAdapter.limits
   - api.GPUAdapter.requestDevice
   - api.GPUAdapter.requestDevice.handles_duplicate_calls
+  - api.GPUAdapter.requestDevice.undefined_limits
   - api.GPUAdapterInfo
   - api.GPUAdapterInfo.architecture
   - api.GPUAdapterInfo.description

--- a/features/webgpu.yml.dist
+++ b/features/webgpu.yml.dist
@@ -301,6 +301,7 @@ compat_features:
 
   # baseline: false
   # support: {}
+  - api.GPUAdapter.requestDevice.undefined_limits
   - api.GPUAdapterInfo.subgroupMaxSize
   - api.GPUAdapterInfo.subgroupMinSize
   - api.GPUCanvasContext.configure.toneMapping


### PR DESCRIPTION
Fixes https://github.com/web-platform-dx/web-features/issues/2806

I think it makes sense to park this key with the bulk of WebGPU. Right now, it's one of our big monolithic features with a mix of statuses. Ideally, we'll break this up into smaller pieces. But I think it makes sense to delay this work until later.

Right now, the implementations have [so many caveats](https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API#browser_compatibility) on basic API access that there's not a lot of utility in thinking about the finer points of WebGPU just yet.