### PR TITLE
computeBaseline for WebViews - add WebViews to compat_keys

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ import YAML from 'yaml';
 import { convertMarkdown } from "./text";
 import { GroupData, SnapshotData, WebFeaturesData } from './types';
 
-import { BASELINE_LOW_TO_HIGH_DURATION, coreBrowserSet, getStatus, parseRangedDateString } from 'compute-baseline';
+import { BASELINE_LOW_TO_HIGH_DURATION, allIdentifiers, getStatus, parseRangedDateString } from 'compute-baseline';
 import { Compat } from 'compute-baseline/browser-compat-data';
 import { assertRequiredRemovalDateSet, assertValidFeatureReference } from './assertions';
 import { isMoved, isOrdinaryFeatureData, isSplit } from './type-guards';
@@ -262,7 +262,7 @@ for (const [id, feature] of Object.entries(features)) {
 
 const compat = new Compat();
 const browsers: Partial<WebFeaturesData["browsers"]> = {};
-for (const browser of coreBrowserSet.map(identifier => compat.browser(identifier))) {
+for (const browser of allIdentifiers.map(identifier => compat.browser(identifier))) {
     const { id, name } = browser;
     const releases = browser.releases.filter(release => !release.isPrerelease()).map(release => ({
         version: release.version,

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ import YAML from 'yaml';
 import { convertMarkdown } from "./text";
 import { GroupData, SnapshotData, WebFeaturesData } from './types';
 
-import { BASELINE_LOW_TO_HIGH_DURATION, allIdentifiers, getStatus, parseRangedDateString } from 'compute-baseline';
+import { BASELINE_LOW_TO_HIGH_DURATION, coreBrowserSet, getStatus, parseRangedDateString } from 'compute-baseline';
 import { Compat } from 'compute-baseline/browser-compat-data';
 import { assertRequiredRemovalDateSet, assertValidFeatureReference } from './assertions';
 import { isMoved, isOrdinaryFeatureData, isSplit } from './type-guards';
@@ -262,7 +262,7 @@ for (const [id, feature] of Object.entries(features)) {
 
 const compat = new Compat();
 const browsers: Partial<WebFeaturesData["browsers"]> = {};
-for (const browser of allIdentifiers.map(identifier => compat.browser(identifier))) {
+for (const browser of coreBrowserSet.map(identifier => compat.browser(identifier))) {
     const { id, name } = browser;
     const releases = browser.releases.filter(release => !release.isPrerelease()).map(release => ({
         version: release.version,

--- a/packages/compute-baseline/src/baseline/core-browser-set.ts
+++ b/packages/compute-baseline/src/baseline/core-browser-set.ts
@@ -10,6 +10,16 @@ export const identifiers = [
   "safari_ios",
 ];
 
+export const webViewIdentifiers = ["webview_android", "webview_ios"];
+
 export function browsers(compat: Compat) {
   return identifiers.map((b) => compat.browser(b));
+}
+
+export function webViews(compat: Compat) {
+  return webViewIdentifiers.map((b) => compat.browser(b));
+}
+
+export function allBrowsers(compat: Compat) {
+  return [...browsers(compat), ...webViews(compat)];
 }

--- a/packages/compute-baseline/src/baseline/core-browser-set.ts
+++ b/packages/compute-baseline/src/baseline/core-browser-set.ts
@@ -12,6 +12,8 @@ export const identifiers = [
 
 export const webViewIdentifiers = ["webview_android", "webview_ios"];
 
+export const allIdentifiers = [...identifiers, ...webViewIdentifiers];
+
 export function browsers(compat: Compat) {
   return identifiers.map((b) => compat.browser(b));
 }

--- a/packages/compute-baseline/src/baseline/core-browser-set.ts
+++ b/packages/compute-baseline/src/baseline/core-browser-set.ts
@@ -12,16 +12,10 @@ export const identifiers = [
 
 export const webViewIdentifiers = ["webview_android", "webview_ios"];
 
-export const allIdentifiers = [...identifiers, ...webViewIdentifiers];
-
 export function browsers(compat: Compat) {
   return identifiers.map((b) => compat.browser(b));
 }
 
 export function webViews(compat: Compat) {
   return webViewIdentifiers.map((b) => compat.browser(b));
-}
-
-export function allBrowsers(compat: Compat) {
-  return [...browsers(compat), ...webViews(compat)];
 }

--- a/packages/compute-baseline/src/baseline/index.test.ts
+++ b/packages/compute-baseline/src/baseline/index.test.ts
@@ -175,6 +175,29 @@ describe("computeBaseline", function () {
     });
     assert.equal(actual.baseline, false);
   });
+
+  it("computes support data for android and ios webviews", function () {
+    const result = computeBaseline({
+      compatKeys: ["css.properties.border-color"],
+      checkAncestors: true,
+    });
+
+    const androidWebview = [...result.support.keys()].find(
+      (b) => b.id === "webview_android",
+    );
+    const iosWebview = [...result.support.keys()].find(
+      (b) => b.id === "webview_ios",
+    );
+
+    assert(androidWebview, "android_webview should be present in support data");
+    assert(iosWebview, "ios_webview should be present in support data");
+
+    const androidWebviewSupport = result.support.get(androidWebview);
+    const iosWebviewSupport = result.support.get(iosWebview);
+
+    assert(androidWebviewSupport, "android_webview should have support data");
+    assert(iosWebviewSupport, "ios_webview should have support data");
+  });
 });
 
 describe("keystoneDateToStatus()", function () {

--- a/packages/compute-baseline/src/baseline/index.test.ts
+++ b/packages/compute-baseline/src/baseline/index.test.ts
@@ -198,6 +198,29 @@ describe("computeBaseline", function () {
     assert(androidWebviewSupport, "android_webview should have support data");
     assert(iosWebviewSupport, "ios_webview should have support data");
   });
+
+  it("shows no support for android and ios webviews", function () {
+    const result = computeBaseline({
+      compatKeys: ["api.ServiceWorkerRegistration.backgroundFetch"],
+      checkAncestors: true,
+    });
+
+      const androidWebview = [...result.support.keys()].find(
+      (b) => b.id === "webview_android",
+    );
+    const iosWebview = [...result.support.keys()].find(
+      (b) => b.id === "webview_ios",
+    );
+
+    assert(androidWebview, "android_webview should be present in support data");
+    assert(iosWebview, "ios_webview should be present in support data");
+
+    const androidWebviewSupport = result.support.get(androidWebview);
+    const iosWebviewSupport = result.support.get(iosWebview);
+
+    assert(!androidWebviewSupport, "android_webview should have no support data");
+    assert(!iosWebviewSupport, "ios_webview should have no support data");
+  });
 });
 
 describe("keystoneDateToStatus()", function () {

--- a/packages/compute-baseline/src/baseline/index.test.ts
+++ b/packages/compute-baseline/src/baseline/index.test.ts
@@ -205,7 +205,7 @@ describe("computeBaseline", function () {
       checkAncestors: true,
     });
 
-      const androidWebview = [...result.support.keys()].find(
+    const androidWebview = [...result.support.keys()].find(
       (b) => b.id === "webview_android",
     );
     const iosWebview = [...result.support.keys()].find(
@@ -218,7 +218,10 @@ describe("computeBaseline", function () {
     const androidWebviewSupport = result.support.get(androidWebview);
     const iosWebviewSupport = result.support.get(iosWebview);
 
-    assert(!androidWebviewSupport, "android_webview should have no support data");
+    assert(
+      !androidWebviewSupport,
+      "android_webview should have no support data",
+    );
     assert(!iosWebviewSupport, "ios_webview should have no support data");
   });
 });

--- a/packages/compute-baseline/src/baseline/index.test.ts
+++ b/packages/compute-baseline/src/baseline/index.test.ts
@@ -182,18 +182,18 @@ describe("computeBaseline", function () {
       checkAncestors: true,
     });
 
-    const androidWebview = [...result.support.keys()].find(
+    const androidWebview = [...result.ecosystem_support.keys()].find(
       (b) => b.id === "webview_android",
     );
-    const iosWebview = [...result.support.keys()].find(
+    const iosWebview = [...result.ecosystem_support.keys()].find(
       (b) => b.id === "webview_ios",
     );
 
     assert(androidWebview, "android_webview should be present in support data");
     assert(iosWebview, "ios_webview should be present in support data");
 
-    const androidWebviewSupport = result.support.get(androidWebview);
-    const iosWebviewSupport = result.support.get(iosWebview);
+    const androidWebviewSupport = result.ecosystem_support.get(androidWebview);
+    const iosWebviewSupport = result.ecosystem_support.get(iosWebview);
 
     assert(androidWebviewSupport, "android_webview should have support data");
     assert(iosWebviewSupport, "ios_webview should have support data");
@@ -205,18 +205,18 @@ describe("computeBaseline", function () {
       checkAncestors: true,
     });
 
-    const androidWebview = [...result.support.keys()].find(
+    const androidWebview = [...result.ecosystem_support.keys()].find(
       (b) => b.id === "webview_android",
     );
-    const iosWebview = [...result.support.keys()].find(
+    const iosWebview = [...result.ecosystem_support.keys()].find(
       (b) => b.id === "webview_ios",
     );
 
     assert(androidWebview, "android_webview should be present in support data");
     assert(iosWebview, "ios_webview should be present in support data");
 
-    const androidWebviewSupport = result.support.get(androidWebview);
-    const iosWebviewSupport = result.support.get(iosWebview);
+    const androidWebviewSupport = result.ecosystem_support.get(androidWebview);
+    const iosWebviewSupport = result.ecosystem_support.get(iosWebview);
 
     assert(
       !androidWebviewSupport,

--- a/packages/compute-baseline/src/baseline/index.test.ts.snap
+++ b/packages/compute-baseline/src/baseline/index.test.ts.snap
@@ -6,6 +6,9 @@ exports[`computeBaseline disregards support that's been removed 1`] = `
   \\"support\\": {
     \\"safari\\": \\"8\\",
     \\"safari_ios\\": \\"8\\"
+  },
+  \\"ecosystem_support\\": {
+    \\"webview_ios\\": \\"8\\"
   }
 }"
 `;
@@ -23,6 +26,9 @@ exports[`computeBaseline finds discrepancies with ancestors (checkAncestors) 1`]
     \\"firefox_android\\": \\"64\\",
     \\"safari\\": \\"16.4\\",
     \\"safari_ios\\": \\"16.4\\"
+  },
+  \\"ecosystem_support\\": {
+    \\"webview_android\\": \\"69\\"
   }
 }"
 `;
@@ -37,6 +43,9 @@ exports[`computeBaseline finds discrepancies with ancestors (checkAncestors) 2`]
     \\"firefox\\": \\"64\\",
     \\"firefox_android\\": \\"64\\",
     \\"safari\\": \\"16.4\\"
+  },
+  \\"ecosystem_support\\": {
+    \\"webview_android\\": \\"71\\"
   }
 }"
 `;
@@ -51,6 +60,9 @@ exports[`computeBaseline finds discrepancies with ancestors (checkAncestors) 3`]
     \\"firefox\\": \\"64\\",
     \\"firefox_android\\": \\"64\\",
     \\"safari\\": \\"16.4\\"
+  },
+  \\"ecosystem_support\\": {
+    \\"webview_android\\": \\"71\\"
   }
 }"
 `;
@@ -62,7 +74,8 @@ Object {
   \\"support\\": {
     \\"firefox\\": \\"82\\",
     \\"firefox_android\\": \\"82\\"
-  }
+  },
+  \\"ecosystem_support\\": {}
 }",
   "html.elements.form.target": "{
   \\"baseline\\": \\"high\\",
@@ -76,6 +89,10 @@ Object {
     \\"firefox_android\\": \\"4\\",
     \\"safari\\": \\"3\\",
     \\"safari_ios\\": \\"2\\"
+  },
+  \\"ecosystem_support\\": {
+    \\"webview_android\\": \\"4.4\\",
+    \\"webview_ios\\": \\"2\\"
   }
 }",
   "html.global_attributes.exportparts": "{
@@ -90,6 +107,10 @@ Object {
     \\"firefox_android\\": \\"79\\",
     \\"safari\\": \\"13.1\\",
     \\"safari_ios\\": \\"13.4\\"
+  },
+  \\"ecosystem_support\\": {
+    \\"webview_android\\": \\"73\\",
+    \\"webview_ios\\": \\"13.4\\"
   }
 }",
 }
@@ -109,6 +130,10 @@ Object {
     \\"firefox_android\\": \\"33\\",
     \\"safari\\": \\"11\\",
     \\"safari_ios\\": \\"11\\"
+  },
+  \\"ecosystem_support\\": {
+    \\"webview_android\\": \\"61\\",
+    \\"webview_ios\\": \\"11\\"
   }
 }",
   "api.Document.visibilitychange_event": "{
@@ -123,6 +148,10 @@ Object {
     \\"firefox_android\\": \\"56\\",
     \\"safari\\": \\"14.1\\",
     \\"safari_ios\\": \\"14.5\\"
+  },
+  \\"ecosystem_support\\": {
+    \\"webview_android\\": \\"62\\",
+    \\"webview_ios\\": \\"14.5\\"
   }
 }",
   "css.types.basic-shape.path": "{
@@ -137,6 +166,10 @@ Object {
     \\"firefox_android\\": \\"79\\",
     \\"safari\\": \\"13.1\\",
     \\"safari_ios\\": \\"13\\"
+  },
+  \\"ecosystem_support\\": {
+    \\"webview_android\\": \\"52\\",
+    \\"webview_ios\\": \\"13\\"
   }
 }",
   "css.types.image.cross-fade": "{
@@ -144,6 +177,9 @@ Object {
   \\"support\\": {
     \\"safari\\": \\"10\\",
     \\"safari_ios\\": \\"9.3\\"
+  },
+  \\"ecosystem_support\\": {
+    \\"webview_ios\\": \\"9.3\\"
   }
 }",
 }
@@ -154,6 +190,10 @@ Object {
   "baseline": "high",
   "baseline_high_date": "2019-09-27",
   "baseline_low_date": "2017-03-27",
+  "ecosystem_support": Object {
+    "webview_android": "42",
+    "webview_ios": "10.3",
+  },
   "support": Object {
     "chrome": "42",
     "chrome_android": "42",

--- a/packages/compute-baseline/src/baseline/index.ts
+++ b/packages/compute-baseline/src/baseline/index.ts
@@ -16,7 +16,7 @@ import {
 } from "./support.js";
 
 // Include this in the public API
-export { identifiers as coreBrowserSet } from "./core-browser-set.js";
+export { identifiers as coreBrowserSet, allIdentifiers } from "./core-browser-set.js";
 export { allBrowsers } from "./core-browser-set.js";
 export { parseRangedDateString } from "./date-utils.js";
 
@@ -119,6 +119,8 @@ export function computeBaseline(
     statuses.map((status) => status.supportForBaseline),
   );
   const support = collateSupport(statuses.map((status) => status.support));
+
+  //console.debug(support);
 
   const keystoneDate = findKeystoneDate(
     [...supportForBaseline.values()],
@@ -295,6 +297,7 @@ function jsonify(status: SupportDetails): string {
 
   for (const [browser, initialSupport] of status.support.entries()) {
     if (initialSupport !== undefined) {
+      //console.debug(`Browser ${browser} has initial support:`, initialSupport);
       support[browser.id] = initialSupport.text;
     }
   }

--- a/packages/compute-baseline/src/baseline/index.ts
+++ b/packages/compute-baseline/src/baseline/index.ts
@@ -2,7 +2,7 @@ import { Temporal } from "@js-temporal/polyfill";
 import { Browser } from "../browser-compat-data/browser.js";
 import { Compat, defaultCompat } from "../browser-compat-data/compat.js";
 import { feature } from "../browser-compat-data/feature.js";
-import { browsers } from "./core-browser-set.js";
+import { browsers, allBrowsers } from "./core-browser-set.js";
 import {
   parseRangedDateString,
   toHighDate,
@@ -17,6 +17,7 @@ import {
 
 // Include this in the public API
 export { identifiers as coreBrowserSet } from "./core-browser-set.js";
+export { allBrowsers } from "./core-browser-set.js";
 export { parseRangedDateString } from "./date-utils.js";
 
 interface Logger {
@@ -113,10 +114,14 @@ export function computeBaseline(
     : compatKeys;
 
   const statuses = keys.map((key) => calculate(key, compat));
+  // For baseline status, use only core browsers; for support map, include all browsers (including webviews)
+  const supportForBaseline = collateSupport(
+    statuses.map((status) => status.supportForBaseline),
+  );
   const support = collateSupport(statuses.map((status) => status.support));
 
   const keystoneDate = findKeystoneDate(
-    statuses.flatMap((s) => [...s.support.values()]),
+    [...supportForBaseline.values()],
   );
   const discouraged = statuses.some((s) => s.discouraged);
   const { baseline, baseline_low_date, baseline_high_date } =
@@ -143,7 +148,8 @@ function calculate(compatKey: string, compat: Compat) {
 
   return {
     discouraged: f.deprecated ?? false,
-    support: support(f, browsers(compat)),
+    supportForBaseline: support(f, browsers(compat)),
+    support: support(f, allBrowsers(compat)),
   };
 }
 

--- a/packages/compute-baseline/src/baseline/index.ts
+++ b/packages/compute-baseline/src/baseline/index.ts
@@ -2,7 +2,7 @@ import { Temporal } from "@js-temporal/polyfill";
 import { Browser } from "../browser-compat-data/browser.js";
 import { Compat, defaultCompat } from "../browser-compat-data/compat.js";
 import { feature } from "../browser-compat-data/feature.js";
-import { browsers, allBrowsers } from "./core-browser-set.js";
+import { browsers, webViews } from "./core-browser-set.js";
 import {
   parseRangedDateString,
   toHighDate,
@@ -16,8 +16,7 @@ import {
 } from "./support.js";
 
 // Include this in the public API
-export { identifiers as coreBrowserSet, allIdentifiers } from "./core-browser-set.js";
-export { allBrowsers } from "./core-browser-set.js";
+export { identifiers as coreBrowserSet, webViews } from "./core-browser-set.js";
 export { parseRangedDateString } from "./date-utils.js";
 
 interface Logger {
@@ -51,6 +50,7 @@ interface SupportDetails {
   baseline_high_date: BaselineDate;
   discouraged: boolean;
   support: Map<Browser, InitialSupport | undefined>;
+  ecosystem_support: Map<Browser, InitialSupport | undefined>;
   toJSON: () => string;
 }
 
@@ -60,6 +60,7 @@ interface SupportStatus {
   baseline_low_date: string;
   baseline_high_date?: string;
   support: Record<string, string>;
+  ecosystem_support?: Record<string, string>;
 }
 
 /**
@@ -114,16 +115,11 @@ export function computeBaseline(
     : compatKeys;
 
   const statuses = keys.map((key) => calculate(key, compat));
-  // For baseline status, use only core browsers; for support map, include all browsers (including webviews)
-  const supportForBaseline = collateSupport(
-    statuses.map((status) => status.supportForBaseline),
-  );
   const support = collateSupport(statuses.map((status) => status.support));
-
-  //console.debug(support);
+  const ecosystem_support = collateSupport(statuses.map((status) => status.ecosystem_support));
 
   const keystoneDate = findKeystoneDate(
-    [...supportForBaseline.values()],
+    statuses.flatMap((s) => [...s.support.values()]),
   );
   const discouraged = statuses.some((s) => s.discouraged);
   const { baseline, baseline_low_date, baseline_high_date } =
@@ -135,6 +131,7 @@ export function computeBaseline(
     baseline_high_date,
     discouraged,
     support,
+    ecosystem_support,
     toJSON: function () {
       return jsonify(this);
     },
@@ -151,7 +148,8 @@ function calculate(compatKey: string, compat: Compat) {
   return {
     discouraged: f.deprecated ?? false,
     supportForBaseline: support(f, browsers(compat)),
-    support: support(f, allBrowsers(compat)),
+    support: support(f, browsers(compat)),
+    ecosystem_support: support(f, webViews(compat)),
   };
 }
 
@@ -294,11 +292,17 @@ function findKeystoneDate(
 function jsonify(status: SupportDetails): string {
   const { baseline_low_date, baseline_high_date } = status;
   const support: Record<string, string> = {};
+  const ecosystem_support: Record<string, string> = {};
 
   for (const [browser, initialSupport] of status.support.entries()) {
     if (initialSupport !== undefined) {
-      //console.debug(`Browser ${browser} has initial support:`, initialSupport);
       support[browser.id] = initialSupport.text;
+    }
+  }
+
+  for (const [browser, initialSupport] of status.ecosystem_support.entries()) {
+    if (initialSupport !== undefined) {
+      ecosystem_support[browser.id] = initialSupport.text;
     }
   }
 
@@ -309,6 +313,7 @@ function jsonify(status: SupportDetails): string {
         baseline_low_date,
         baseline_high_date,
         support,
+        ecosystem_support
       },
       undefined,
       2,
@@ -321,6 +326,7 @@ function jsonify(status: SupportDetails): string {
         baseline: status.baseline,
         baseline_low_date,
         support,
+        ecosystem_support
       },
       undefined,
       2,
@@ -331,6 +337,7 @@ function jsonify(status: SupportDetails): string {
     {
       baseline: status.baseline,
       support,
+      ecosystem_support
     },
     undefined,
     2,

--- a/schemas/data.schema.json
+++ b/schemas/data.schema.json
@@ -27,6 +27,12 @@
         },
         "safari_ios": {
           "$ref": "#/definitions/BrowserData"
+        },
+        "webview_android": {
+          "$ref": "#/definitions/BrowserData"
+        },
+        "webview_ios": {
+          "$ref": "#/definitions/BrowserData"
         }
       },
       "required": [
@@ -36,7 +42,9 @@
         "firefox",
         "firefox_android",
         "safari",
-        "safari_ios"
+        "safari_ios",
+        "webview_android",
+        "webview_ios"
       ],
       "additionalProperties": false
     },
@@ -294,6 +302,12 @@
               "type": "string"
             },
             "safari_ios": {
+              "type": "string"
+            },
+            "webview_android": {
+              "type": "string"
+            },
+            "webview_ios": {
               "type": "string"
             }
           },

--- a/schemas/data.schema.json
+++ b/schemas/data.schema.json
@@ -27,12 +27,6 @@
         },
         "safari_ios": {
           "$ref": "#/definitions/BrowserData"
-        },
-        "webview_android": {
-          "$ref": "#/definitions/BrowserData"
-        },
-        "webview_ios": {
-          "$ref": "#/definitions/BrowserData"
         }
       },
       "required": [
@@ -42,9 +36,7 @@
         "firefox",
         "firefox_android",
         "safari",
-        "safari_ios",
-        "webview_android",
-        "webview_ios"
+        "safari_ios"
       ],
       "additionalProperties": false
     },
@@ -303,7 +295,14 @@
             },
             "safari_ios": {
               "type": "string"
-            },
+            }
+          },
+          "additionalProperties": false
+        },
+        "ecosystem_support": {
+          "description": "Support in user agents that are not part of the core browser set.",
+          "type": "object",
+          "properties": {
             "webview_android": {
               "type": "string"
             },
@@ -324,6 +323,7 @@
         "baseline_high_date": {},
         "baseline_low_date": {},
         "support": {},
+        "ecosystem_support": {},
         "by_compat_key": {
           "description": "Statuses for each key in the feature's compat_features list, if applicable.",
           "type": "object",

--- a/scripts/dist.ts
+++ b/scripts/dist.ts
@@ -282,6 +282,7 @@ function toDist(sourcePath: string): YAML.Document {
   }
 
   computedStatus = JSON.parse(computedStatus.toJSON());
+  delete computedStatus.ecosystem_support;
 
   if (source.status) {
     if (isDeepStrictEqual(source.status, computedStatus)) {
@@ -294,7 +295,8 @@ function toDist(sourcePath: string): YAML.Document {
   // Map between status object and BCD keys with that computed status.
   const groups = new Map<SupportStatus, string[]>();
   for (const key of compatFeatures) {
-    const status = getStatus(id, key);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { ecosystem_support: _, ...status } = getStatus(id, key);
     let added = false;
     for (const [existingKey, list] of groups.entries()) {
       if (isDeepStrictEqual(status, existingKey)) {

--- a/types.quicktype.ts
+++ b/types.quicktype.ts
@@ -31,6 +31,8 @@ export interface Browsers {
   firefox_android: BrowserData;
   safari: BrowserData;
   safari_ios: BrowserData;
+  webview_android: BrowserData;
+  webview_ios: BrowserData;
 }
 
 /**
@@ -210,6 +212,8 @@ export interface Support {
   firefox_android?: string;
   safari?: string;
   safari_ios?: string;
+  webview_android?: string;
+  webview_ios?: string;
 }
 
 export interface GroupData {

--- a/types.quicktype.ts
+++ b/types.quicktype.ts
@@ -31,8 +31,6 @@ export interface Browsers {
   firefox_android: BrowserData;
   safari: BrowserData;
   safari_ios: BrowserData;
-  webview_android: BrowserData;
-  webview_ios: BrowserData;
 }
 
 /**
@@ -174,6 +172,10 @@ export interface StatusHeadline {
    */
   by_compat_key?: { [key: string]: Status };
   /**
+   * Support in user agents that are not part of the core browser set.
+   */
+  ecosystem_support?: EcosystemSupport;
+  /**
    * Browser versions that most-recently introduced the feature
    */
   support: Support;
@@ -195,10 +197,22 @@ export interface Status {
    */
   baseline_low_date?: string;
   /**
+   * Support in user agents that are not part of the core browser set.
+   */
+  ecosystem_support?: EcosystemSupport;
+  /**
    * Browser versions that most-recently introduced the feature
    */
   support: Support;
   [property: string]: any;
+}
+
+/**
+ * Support in user agents that are not part of the core browser set.
+ */
+export interface EcosystemSupport {
+  webview_android?: string;
+  webview_ios?: string;
 }
 
 /**
@@ -212,8 +226,6 @@ export interface Support {
   firefox_android?: string;
   safari?: string;
   safari_ios?: string;
-  webview_android?: string;
-  webview_ios?: string;
 }
 
 export interface GroupData {


### PR DESCRIPTION
This PR adds WebViews to the `by_compat_key` items for each web-features. For caniwebview.com this is really useful as we can now use computeBaseline for web-features to show the status on the site.

Here is a built version of the data.json file: 
[data.extended.json](https://github.com/user-attachments/files/25586256/data.extended.json)

_Should WebViews be included in the top-level browsers key and their status in the web-features?_

Closes #3553