### PR TITLE
Add missing keys to interest invokers

### DIFF
--- a/features/interest-invokers.yml
+++ b/features/interest-invokers.yml
@@ -12,6 +12,8 @@ compat_features:
   - api.InterestEvent.InterestEvent
   - api.InterestEvent.source
   - api.SVGAElement.interestForElement
+  - css.selectors.interest-source
+  - css.selectors.interest-target
   - html.elements.a.interestfor
   - html.elements.area.interestfor
   - html.elements.button.interestfor

--- a/features/interest-invokers.yml.dist
+++ b/features/interest-invokers.yml.dist
@@ -17,6 +17,8 @@ compat_features:
   - api.InterestEvent.InterestEvent
   - api.InterestEvent.source
   - api.SVGAElement.interestForElement
+  - css.selectors.interest-source
+  - css.selectors.interest-target
   - html.elements.a.interestfor
   - html.elements.area.interestfor
   - html.elements.button.interestfor


### PR DESCRIPTION
This adds some CSS keys to `interest-invokers`, which were previously missing.