### PR TITLE
`tabindex`: aggregate keys for SVG and MathML

### DIFF
--- a/features/mathml.yml
+++ b/features/mathml.yml
@@ -11,7 +11,6 @@ compat_features:
   - api.MathMLElement.focus
   - api.MathMLElement.nonce
   - api.MathMLElement.style
-  - api.MathMLElement.tabIndex
   - css.properties.display.math
   - css.properties.font-size.math
   - css.properties.math-depth

--- a/features/mathml.yml.dist
+++ b/features/mathml.yml.dist
@@ -228,7 +228,6 @@ compat_features:
   - api.MathMLElement.blur
   - api.MathMLElement.focus
   - api.MathMLElement.style
-  - api.MathMLElement.tabIndex
 
   # baseline: high
   # baseline_low_date: 2023-01-12

--- a/features/svg.yml
+++ b/features/svg.yml
@@ -38,7 +38,6 @@ compat_features:
   - api.SVGElement.nonce
   - api.SVGElement.ownerSVGElement
   - api.SVGElement.style
-  - api.SVGElement.tabIndex
   - api.SVGElement.viewportElement
   - api.SVGEllipseElement
   - api.SVGEllipseElement.cx
@@ -523,7 +522,6 @@ compat_features:
   - svg.global_attributes.stroke-miterlimit
   - svg.global_attributes.stroke-width
   - svg.global_attributes.style
-  - svg.global_attributes.tabindex
   - svg.global_attributes.text-anchor
   - svg.global_attributes.text-decoration
   - svg.global_attributes.text-rendering

--- a/features/svg.yml.dist
+++ b/features/svg.yml.dist
@@ -870,19 +870,6 @@ compat_features:
   - css.properties.text-anchor.start
 
   # baseline: high
-  # baseline_low_date: 2017-01-24
-  # baseline_high_date: 2019-07-24
-  # support:
-  #   chrome: "1"
-  #   chrome_android: "18"
-  #   edge: "12"
-  #   firefox: "51"
-  #   firefox_android: "51"
-  #   safari: ≤4
-  #   safari_ios: ≤3.2
-  - svg.global_attributes.tabindex
-
-  # baseline: high
   # baseline_low_date: ≤2017-04-05
   # baseline_high_date: ≤2019-10-05
   # support:
@@ -962,19 +949,6 @@ compat_features:
   #   safari: "9"
   #   safari_ios: "9"
   - css.properties.transform-origin.svg_elements
-
-  # baseline: high
-  # baseline_low_date: 2018-04-30
-  # baseline_high_date: 2020-10-30
-  # support:
-  #   chrome: "36"
-  #   chrome_android: "36"
-  #   edge: "17"
-  #   firefox: "51"
-  #   firefox_android: "51"
-  #   safari: "8"
-  #   safari_ios: "8"
-  - api.SVGElement.tabIndex
 
   # baseline: high
   # baseline_low_date: ≤2018-10-02

--- a/features/tabindex.yml
+++ b/features/tabindex.yml
@@ -3,3 +3,13 @@ description: The `tabindex` HTML attribute make an element focusable, and sets t
 spec: https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex
 group: html
 caniuse: tabindex-attr
+status:
+  compute_from:
+    - api.HTMLElement.tabIndex
+    - html.global_attributes.tabindex
+compat_features:
+  - api.HTMLElement.tabIndex
+  - api.MathMLElement.tabIndex
+  - api.SVGElement.tabIndex
+  - html.global_attributes.tabindex
+  - svg.global_attributes.tabindex

--- a/features/tabindex.yml.dist
+++ b/features/tabindex.yml.dist
@@ -28,6 +28,32 @@ compat_features:
   - html.global_attributes.tabindex
 
   # baseline: high
+  # baseline_low_date: 2017-01-24
+  # baseline_high_date: 2019-07-24
+  # support:
+  #   chrome: "1"
+  #   chrome_android: "18"
+  #   edge: "12"
+  #   firefox: "51"
+  #   firefox_android: "51"
+  #   safari: ≤4
+  #   safari_ios: ≤3.2
+  - svg.global_attributes.tabindex
+
+  # baseline: high
+  # baseline_low_date: 2018-04-30
+  # baseline_high_date: 2020-10-30
+  # support:
+  #   chrome: "36"
+  #   chrome_android: "36"
+  #   edge: "17"
+  #   firefox: "51"
+  #   firefox_android: "51"
+  #   safari: "8"
+  #   safari_ios: "8"
+  - api.SVGElement.tabIndex
+
+  # baseline: high
   # baseline_low_date: 2018-10-02
   # baseline_high_date: 2021-04-02
   # support:
@@ -39,3 +65,16 @@ compat_features:
   #   safari: "3.1"
   #   safari_ios: "2"
   - api.HTMLElement.tabIndex
+
+  # baseline: high
+  # baseline_low_date: 2023-01-12
+  # baseline_high_date: 2025-07-12
+  # support:
+  #   chrome: "109"
+  #   chrome_android: "109"
+  #   edge: "109"
+  #   firefox: "71"
+  #   firefox_android: "79"
+  #   safari: "13.1"
+  #   safari_ios: "13.4"
+  - api.MathMLElement.tabIndex


### PR DESCRIPTION
I'm not sure if this is the right thing to do exactly, but I thought it would make for a good discussion to help crystalize a guideline. The main question raised by this PR is something like:

**Should we treat global HTML attributes as inclusive of their SVG and MathML counterparts?**

In other words, should we regard SVG and MathML features as if they're (implicitly) "SVG in HTML" or "MathML in HTML"? Or are they their own distinct document types and thus deserving of something like `svg-tabindex` or `mathml-tabindex`?

Inspired by: https://github.com/web-platform-dx/web-features/pull/3843