### PR TITLE
Migrate tsconfig.json from ESNext to NodeNext

### DIFF
--- a/assertions.test.ts
+++ b/assertions.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { assertValidFeatureReference } from "./assertions";
+import { assertValidFeatureReference } from "./assertions.js";
 
 describe("assertValidReference()", function () {
   it("throws if target ID is a move", function () {

--- a/assertions.ts
+++ b/assertions.ts
@@ -1,6 +1,6 @@
-import { isOrdinaryFeatureData } from "./type-guards";
-import { FeatureData } from "./types";
-import { WebFeaturesData } from "./types.quicktype";
+import { isOrdinaryFeatureData } from "./type-guards.js";
+import { FeatureData } from "./types.js";
+import { WebFeaturesData } from "./types.quicktype.js";
 
 /**
  * Assert that a reference from one feature to another is an ordinary feature

--- a/index.ts
+++ b/index.ts
@@ -4,13 +4,13 @@ import path from 'path';
 import { Temporal } from '@js-temporal/polyfill';
 import { fdir } from 'fdir';
 import YAML from 'yaml';
-import { convertMarkdown } from "./text";
-import { GroupData, SnapshotData, WebFeaturesData } from './types';
+import { convertMarkdown } from "./text.js";
+import { GroupData, SnapshotData, WebFeaturesData } from './types.js';
 
 import { BASELINE_LOW_TO_HIGH_DURATION, coreBrowserSet, getStatus, parseRangedDateString } from 'compute-baseline';
 import { Compat } from 'compute-baseline/browser-compat-data';
-import { assertRequiredRemovalDateSet, assertValidFeatureReference } from './assertions';
-import { isMoved, isOrdinaryFeatureData, isSplit } from './type-guards';
+import { assertRequiredRemovalDateSet, assertValidFeatureReference } from './assertions.js';
+import { isMoved, isOrdinaryFeatureData, isSplit } from './type-guards.js';
 
 // The longest name allowed, to allow for compact display.
 const nameMaxLength = 80;

--- a/scripts/dist.ts
+++ b/scripts/dist.ts
@@ -14,7 +14,11 @@ import { isDeepStrictEqual } from "node:util";
 import winston from "winston";
 import YAML, { Document, Scalar, YAMLSeq } from "yaml";
 import yargs from "yargs";
-import type { FeatureData, FeatureMovedData, FeatureSplitData } from "../types";
+import type {
+  FeatureData,
+  FeatureMovedData,
+  FeatureSplitData,
+} from "../types.js";
 
 const compat = new Compat();
 

--- a/scripts/find-ranged-headline-statuses.ts
+++ b/scripts/find-ranged-headline-statuses.ts
@@ -1,5 +1,5 @@
-import { features } from "../index";
-import { isOrdinaryFeatureData } from "../type-guards";
+import { features } from "../index.js";
+import { isOrdinaryFeatureData } from "../type-guards.js";
 
 for (const [key, data] of Object.entries(features)) {
   if (isOrdinaryFeatureData(data)) {

--- a/scripts/inspect-feature.ts
+++ b/scripts/inspect-feature.ts
@@ -6,12 +6,12 @@ import { fileURLToPath } from "node:url";
 import winston from "winston";
 import YAML from "yaml";
 import yargs from "yargs";
-import { features } from "..";
-import { defaultCompat } from "../packages/compute-baseline/dist/browser-compat-data/compat";
-import { feature } from "../packages/compute-baseline/dist/browser-compat-data/feature";
-import { SupportStatement } from "../packages/compute-baseline/dist/browser-compat-data/supportStatements";
-import { convertHTML } from "../text";
-import { FeatureData } from "../types";
+import { features } from "../index.js";
+import { defaultCompat } from "../packages/compute-baseline/dist/browser-compat-data/compat.js";
+import { feature } from "../packages/compute-baseline/dist/browser-compat-data/feature.js";
+import { SupportStatement } from "../packages/compute-baseline/dist/browser-compat-data/supportStatements.js";
+import { convertHTML } from "../text.js";
+import { FeatureData } from "../types.js";
 
 const argv = yargs(process.argv.slice(2))
   .scriptName("dist")

--- a/scripts/remove-tagged-compat-features.ts
+++ b/scripts/remove-tagged-compat-features.ts
@@ -8,7 +8,7 @@ import { isDeepStrictEqual } from "node:util";
 import winston from "winston";
 import YAML from "yaml";
 import yargs from "yargs";
-import { checkForStaleCompat } from "./dist";
+import { checkForStaleCompat } from "./dist.js";
 
 const compat = new Compat();
 

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -1,4 +1,4 @@
-import Ajv from "ajv";
+import { Ajv } from "ajv";
 import assert from "node:assert/strict";
 
 import * as schema from "../schemas/data.schema.json" with { type: "json" };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "Bundler",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "noEmit": true

--- a/type-guards.ts
+++ b/type-guards.ts
@@ -1,4 +1,8 @@
-import type { FeatureData, FeatureMovedData, FeatureSplitData } from "./types";
+import type {
+  FeatureData,
+  FeatureMovedData,
+  FeatureSplitData,
+} from "./types.js";
 
 export function isOrdinaryFeatureData(x: unknown): x is FeatureData {
   return typeof x === "object" && "kind" in x && x.kind === "feature";

--- a/types.ts
+++ b/types.ts
@@ -18,7 +18,7 @@ import type {
   Release,
   SnapshotData,
   Support,
-} from "./types.quicktype";
+} from "./types.quicktype.js";
 
 // Passthrough types
 export type {


### PR DESCRIPTION
Migrates `tsconfig.json` from `module: esnext` to `module: nodenext`.

This implies the following changes:

- Add file extensions on imports.
- Use the named Ajv export.

Fixes https://github.com/web-platform-dx/web-features/issues/3878.