### PR TITLE
Use file extensions in web-features package type declarations

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,21 +1,26 @@
 import newWithError from "eslint-plugin-new-with-error";
+import { defineConfig, globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(tseslint.configs.base, {
-  plugins: { newWithError },
-  rules: {
-    "@typescript-eslint/no-unused-vars": [
-      "error",
-      {
-        caughtErrors: "none",
-      },
-    ],
-    "newWithError/new-with-error": "error",
-    "no-duplicate-imports": "error",
-    "no-throw-literal": "error",
+export default defineConfig(
+  tseslint.configs.base,
+  {
+    plugins: { newWithError },
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          caughtErrors: "none",
+        },
+      ],
+      "newWithError/new-with-error": "error",
+      "no-duplicate-imports": "error",
+      "no-throw-literal": "error",
+    },
+    files: ["**/*.ts"],
   },
-  files: ["**/*.ts"],
-});
+  globalIgnores(["packages/web-features/**/*.js"]),
+);
 
 // TODO: do linting more comprehensively, something like:
 // import eslint from "@eslint/js";

--- a/packages/web-features/index.ts
+++ b/packages/web-features/index.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { WebFeaturesData } from "./types";
+import { WebFeaturesData } from "./types.js";
 
 const jsonPath = fileURLToPath(new URL("./data.json", import.meta.url));
 const { browsers, features, groups, snapshots } = JSON.parse(

--- a/packages/web-features/tsconfig.json
+++ b/packages/web-features/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2016",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "typeRoots": ["./node_modules/@types"],
     "declaration": true
   }

--- a/types.ts
+++ b/types.ts
@@ -18,7 +18,7 @@ import type {
   Release,
   SnapshotData,
   Support,
-} from "./types.quicktype";
+} from "./types.quicktype.js";
 
 // Passthrough types
 export type {


### PR DESCRIPTION
Toward https://github.com/web-platform-dx/web-features/issues/3878 and a companion to https://github.com/web-platform-dx/web-features/pull/3879.

This PR narrowly fixes the problem reported by @caugner in #3878 and updates the `tsconfig.json` for `web-features`. Claas's PR differs in that it applies the fix to the entire project, which I think is a good idea but slightly odd in not actually changing the config for the package that is the problem.

Incidentally, by using a file extension, it caused eslint to check the built files. There's no need to check files we're not actually authoring, so I've ignored those files. In another bit of yak shaving, I had to upgrade to eslint's current config format, thus the oversize diff.