### PR TITLE
New feature issue template: suggest more browser support sources

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-feature.yml
+++ b/.github/ISSUE_TEMPLATE/new-feature.yml
@@ -29,4 +29,4 @@ body:
 - type: textarea
   attributes:
     label: Browser support
-    description: If you have a caniuse.com link or other information about browser support, please share here.
+    description: If you have a caniuse.com, Chrome Platform Status, implementation bug, or other URL to help understand browser support, add it here.

--- a/.github/ISSUE_TEMPLATE/new-feature.yml
+++ b/.github/ISSUE_TEMPLATE/new-feature.yml
@@ -29,4 +29,4 @@ body:
 - type: textarea
   attributes:
     label: Browser support
-    description: If you have a caniuse.com, Chrome Platform Status, implementation bug, or other URL to help understand browser support, add it here.
+    description: If you have a caniuse.com link, chromestatus.com link, implementation bug, or other URL to help understand browser support, add it here.


### PR DESCRIPTION
When I triage new feature requests, they often don't have (useful) information about implementation progress for the feature. This is my attempt to get issue submitters to share that info with me.