### PR TITLE
Allow `computeBaseline()` with no keys, formally

### DIFF
--- a/packages/compute-baseline/src/baseline/index.test.ts
+++ b/packages/compute-baseline/src/baseline/index.test.ts
@@ -175,6 +175,15 @@ describe("computeBaseline", function () {
     });
     assert.equal(actual.baseline, false);
   });
+
+  it("returns no support for no keys", function () {
+    const actual = computeBaseline({
+      compatKeys: [],
+      checkAncestors: false,
+    });
+    assert.equal(actual.baseline, false);
+    assert.equal(actual.support.size, 0);
+  });
 });
 
 describe("keystoneDateToStatus()", function () {

--- a/packages/compute-baseline/src/baseline/index.ts
+++ b/packages/compute-baseline/src/baseline/index.ts
@@ -94,7 +94,7 @@ export function getStatus(
  */
 export function computeBaseline(
   featureSelector: {
-    compatKeys: [string, ...string[]];
+    compatKeys: string[];
     checkAncestors?: boolean;
   },
   compat: Compat = defaultCompat,


### PR DESCRIPTION
~~This is blocked by https://github.com/web-platform-dx/web-features/pull/3938.~~

We rely on the behavior of calling `computeBaseline()` without any compat keys. That is, we treat no keys as meaning no (calculable) support. Rather than paper over this with a type assertion, this changes the types to allow this and adds a test to make the requirement for this explicit.