### PR TITLE
Add `compat_features` for the `<geolocation>` element

### DIFF
--- a/features/geolocation-element.yml
+++ b/features/geolocation-element.yml
@@ -4,20 +4,21 @@ spec: https://wicg.github.io/PEPC/geolocation-element.html
 group:
   - html-elements
   - geolocation
-# Expected
-# compat_features:
-#   - html.elements.geolocation
-#   - html.elements.geolocation.autolocate
-#   - html.elements.geolocation.watch
-#   - api.HTMLGeolocationElement.HTMLGeolocationElement
-#   - api.HTMLGeolocationElement.position
-#   - api.HTMLGeolocationElement.error
-#   - api.HTMLGeolocationElement.autolocate
-#   - api.HTMLGeolocationElement.watch
-#   - api.HTMLGeolocationElement.isValid
-#   - api.HTMLGeolocationElement.invalidReason
-#   - api.HTMLGeolocationElement.initialPermissionStatus
-#   - api.HTMLGeolocationElement.permissionStatus
-#   - api.HTMLGeolocationElement.promptaction_event
-#   - api.HTMLGeolocationElement.promptdismiss_event
-#   - api.HTMLGeolocationElement.validationstatuschange_event
+compat_features:
+  - api.HTMLGeolocationElement
+  - api.HTMLGeolocationElement.HTMLGeolocationElement
+  - api.HTMLGeolocationElement.autolocate
+  - api.HTMLGeolocationElement.error
+  - api.HTMLGeolocationElement.initialPermissionStatus
+  - api.HTMLGeolocationElement.invalidReason
+  - api.HTMLGeolocationElement.isValid
+  - api.HTMLGeolocationElement.location_event
+  - api.HTMLGeolocationElement.permissionStatus
+  - api.HTMLGeolocationElement.position
+  - api.HTMLGeolocationElement.promptaction_event
+  - api.HTMLGeolocationElement.promptdismiss_event
+  - api.HTMLGeolocationElement.validationstatuschange_event
+  - api.HTMLGeolocationElement.watch
+  - html.elements.geolocation
+  - html.elements.geolocation.autolocate
+  - html.elements.geolocation.watch

--- a/features/geolocation-element.yml.dist
+++ b/features/geolocation-element.yml.dist
@@ -3,4 +3,25 @@
 
 status:
   baseline: false
-  support: {}
+  support:
+    chrome: "144"
+    chrome_android: "144"
+    edge: "144"
+compat_features:
+  - api.HTMLGeolocationElement
+  - api.HTMLGeolocationElement.HTMLGeolocationElement
+  - api.HTMLGeolocationElement.autolocate
+  - api.HTMLGeolocationElement.error
+  - api.HTMLGeolocationElement.initialPermissionStatus
+  - api.HTMLGeolocationElement.invalidReason
+  - api.HTMLGeolocationElement.isValid
+  - api.HTMLGeolocationElement.location_event
+  - api.HTMLGeolocationElement.permissionStatus
+  - api.HTMLGeolocationElement.position
+  - api.HTMLGeolocationElement.promptaction_event
+  - api.HTMLGeolocationElement.promptdismiss_event
+  - api.HTMLGeolocationElement.validationstatuschange_event
+  - api.HTMLGeolocationElement.watch
+  - html.elements.geolocation
+  - html.elements.geolocation.autolocate
+  - html.elements.geolocation.watch


### PR DESCRIPTION
This adds `compat_features` for the `<geolocation>` element

Background:
- #3757 added the feature with expected BCD keys left as comments
- #3851 later generated a concrete `compat_features` mapping