### PR TITLE
Fix typos in feature descriptions

### DIFF
--- a/features/clipboard-custom-format.yml
+++ b/features/clipboard-custom-format.yml
@@ -1,5 +1,5 @@
 name: Custom formats for clipboard items
-description: The `web ` prefix for `ClipboardItem` data types (also known as MIME types) allows reading and writing ununsanitized custom data from the device clipboard.
+description: The `web ` prefix for `ClipboardItem` data types (also known as MIME types) allows reading and writing unsanitized custom data from the device clipboard.
 spec: https://w3c.github.io/clipboard-apis/#optional-data-types-x
 group: clipboard
 compat_features:

--- a/features/del.yml
+++ b/features/del.yml
@@ -1,5 +1,5 @@
 name: <del>
-description: The `<del>` element element represents a range of text that has been deleted from a document, styling text as strikethrough by default.
+description: The `<del>` element represents a range of text that has been deleted from a document, styling text as strikethrough by default.
 spec: https://html.spec.whatwg.org/multipage/edits.html#the-del-element
 group: html-elements
 compat_features:

--- a/features/form-associated-custom-elements.yml
+++ b/features/form-associated-custom-elements.yml
@@ -1,5 +1,5 @@
 name: Form-associated custom elements
-description: Custom elements may act like built-in form elements, via the the `attachInternals()` method of `HTMLElement` and the `ElementInternals` API.
+description: Custom elements may act like built-in form elements, via the `attachInternals()` method of `HTMLElement` and the `ElementInternals` API.
 spec: https://html.spec.whatwg.org/multipage/custom-elements.html#form-associated-custom-elements
 group:
   - custom-elements

--- a/features/ins.yml
+++ b/features/ins.yml
@@ -1,5 +1,5 @@
 name: <ins>
-description: The `<ins>` element element represents a range of text that has been inserted into a document, styling text as underlined by default.
+description: The `<ins>` element represents a range of text that has been inserted into a document, styling text as underlined by default.
 spec: https://html.spec.whatwg.org/multipage/edits.html#the-ins-element
 group: html-elements
 # TODO - Removed until #1173 is resolved, these APIs are currently listed

--- a/features/optional-catch-binding.yml
+++ b/features/optional-catch-binding.yml
@@ -1,5 +1,5 @@
 name: Optional catch binding
-description: Omit the the binding parameter of a `catch` clause when you don't need information about the exception in a `try ... catch` statement.
+description: Omit the binding parameter of a `catch` clause when you don't need information about the exception in a `try ... catch` statement.
 spec: https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-try-statement
 group: javascript
 snapshot: ecmascript-2019

--- a/features/print-events.yml
+++ b/features/print-events.yml
@@ -1,5 +1,5 @@
 name: Print events
-description: An alternative to `@media print` queries, the `beforeprint` and `afterprint` events allow you to change the page for printing and and restore the page after printing.
+description: An alternative to `@media print` queries, the `beforeprint` and `afterprint` events allow you to change the page for printing and restore the page after printing.
 group: print
 spec:
   - https://html.spec.whatwg.org/multipage/indices.html#event-afterprint


### PR DESCRIPTION
Fixes a handful of typos spotted in feature descriptions:

- `clipboard-custom-format`: `ununsanitized` → `unsanitized`
- `print-events`: `and and` → `and`
- `form-associated-custom-elements`: `the the` → `the`
- `optional-catch-binding`: `the the` → `the`
- `del`: `element element` → `element`
- `ins`: `element element` → `element`