### PR TITLE
Assign compat keys from BCD 7.3.12 for existing features

### DIFF
--- a/features/declarative-shadow-dom.yml
+++ b/features/declarative-shadow-dom.yml
@@ -13,8 +13,13 @@ compat_features:
   - api.HTMLTemplateElement.shadowRootMode
   - api.HTMLTemplateElement.shadowRootDelegatesFocus
   - api.HTMLTemplateElement.shadowRootSerializable
-  - api.HTMLTemplateElement.shadowRootSlotAssignment
   - html.elements.template.shadowrootmode
   - html.elements.template.shadowrootclonable
   - html.elements.template.shadowrootdelegatesfocus
   - html.elements.template.shadowrootserializable
+
+  # This key was added later, but it's not a distinct feature. Rather, a spec
+  # contributor regarded it as an unintended "omission" from the original
+  # specification. See the intent-to-ship for background:
+  # https://groups.google.com/a/mozilla.org/g/dev-platform/c/8qxAHE9-Xdo
+  - api.HTMLTemplateElement.shadowRootSlotAssignment

--- a/features/declarative-shadow-dom.yml
+++ b/features/declarative-shadow-dom.yml
@@ -13,6 +13,7 @@ compat_features:
   - api.HTMLTemplateElement.shadowRootMode
   - api.HTMLTemplateElement.shadowRootDelegatesFocus
   - api.HTMLTemplateElement.shadowRootSerializable
+  - api.HTMLTemplateElement.shadowRootSlotAssignment
   - html.elements.template.shadowrootmode
   - html.elements.template.shadowrootclonable
   - html.elements.template.shadowrootdelegatesfocus

--- a/features/declarative-shadow-dom.yml.dist
+++ b/features/declarative-shadow-dom.yml.dist
@@ -95,3 +95,7 @@ compat_features:
   #   safari: "18"
   #   safari_ios: "18"
   - html.elements.template.shadowrootserializable
+
+  # baseline: false
+  # support: {}
+  - api.HTMLTemplateElement.shadowRootSlotAssignment

--- a/features/hanging-punctuation.yml
+++ b/features/hanging-punctuation.yml
@@ -6,5 +6,6 @@ compat_features:
   - css.properties.hanging-punctuation
   - css.properties.hanging-punctuation.allow-end
   - css.properties.hanging-punctuation.first
+  - css.properties.hanging-punctuation.force-end
   - css.properties.hanging-punctuation.last
   - css.properties.hanging-punctuation.none

--- a/features/hanging-punctuation.yml.dist
+++ b/features/hanging-punctuation.yml.dist
@@ -8,5 +8,6 @@ compat_features:
   - css.properties.hanging-punctuation
   - css.properties.hanging-punctuation.allow-end
   - css.properties.hanging-punctuation.first
+  - css.properties.hanging-punctuation.force-end
   - css.properties.hanging-punctuation.last
   - css.properties.hanging-punctuation.none

--- a/features/meta-text-scale.yml
+++ b/features/meta-text-scale.yml
@@ -3,6 +3,5 @@ description: >
   The `<meta name="text-scale" content="scale" />` HTML element allows the browser's initial font size to be affected by the operating system text scale settings.
   The `<meta name="text-scale" content="legacy" />` element is the default behavior that respects only browser font-size settings.
 spec: https://drafts.csswg.org/css-fonts-5/#text-scale-meta
-# Expected:
-# compat_features:
-#   - html.elements.meta.name.text-scale
+compat_features:
+  - html.elements.meta.name.text-scale

--- a/features/meta-text-scale.yml.dist
+++ b/features/meta-text-scale.yml.dist
@@ -3,4 +3,9 @@
 
 status:
   baseline: false
-  support: {}
+  support:
+    chrome: "146"
+    chrome_android: "146"
+    edge: "146"
+compat_features:
+  - html.elements.meta.name.text-scale


### PR DESCRIPTION
This assigns new keys from `@mdn/browser-compat-data@7.3.12` (https://github.com/web-platform-dx/web-features/pull/3966) where there's an existing feature.