### PR TITLE
`view-transitions-element-scoped`: add compat keys

### DIFF
--- a/features/draft/spec/css-view-transitions-2.yml
+++ b/features/draft/spec/css-view-transitions-2.yml
@@ -4,17 +4,11 @@ description: TODO
 spec: https://drafts.csswg.org/css-view-transitions-2/
 compat_features:
   - api.Document.activeViewTransition
-  - api.Element.activeViewTransition
-  - api.Element.startViewTransition
-  - api.ViewTransition.transitionRoot
   - api.ViewTransition.waitUntil
   - css.properties.view-transition-group
   - css.properties.view-transition-group.contain
   - css.properties.view-transition-group.nearest
   - css.properties.view-transition-group.normal
-  - css.properties.view-transition-scope
-  - css.properties.view-transition-scope.all
-  - css.properties.view-transition-scope.none
   - css.selectors.view-transition-group-children
 
 # The following features in the spec are already part of web-features:
@@ -23,6 +17,13 @@ compat_features:
 #   - api.CSSViewTransitionRule.navigation
 #   - api.CSSViewTransitionRule.types
 #   - css.at-rules.view-transition
+# - Element-scoped view transitions:
+#   - api.Element.activeViewTransition
+#   - api.Element.startViewTransition
+#   - api.ViewTransition.transitionRoot
+#   - css.properties.view-transition-scope
+#   - css.properties.view-transition-scope.all
+#   - css.properties.view-transition-scope.none
 # - View transitions:
 #   - api.Document.startViewTransition
 #   - api.Document.startViewTransition.options_parameter

--- a/features/draft/spec/css-view-transitions-2.yml.dist
+++ b/features/draft/spec/css-view-transitions-2.yml.dist
@@ -4,9 +4,9 @@
 status:
   baseline: false
   support:
-    chrome: "147"
-    chrome_android: "147"
-    edge: "147"
+    chrome: "144"
+    chrome_android: "144"
+    edge: "144"
 compat_features:
   # baseline: low
   # baseline_low_date: 2026-01-13
@@ -31,22 +31,10 @@ compat_features:
   - css.properties.view-transition-group.normal
   - css.selectors.view-transition-group-children
 
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   chrome: "144"
   #   chrome_android: "144"
   #   edge: "144"
   - api.ViewTransition.waitUntil
-
-  # ⬇️ Same status as overall feature ⬇️
-  # baseline: false
-  # support:
-  #   chrome: "147"
-  #   chrome_android: "147"
-  #   edge: "147"
-  - api.Element.activeViewTransition
-  - api.Element.startViewTransition
-  - api.ViewTransition.transitionRoot
-  - css.properties.view-transition-scope
-  - css.properties.view-transition-scope.all
-  - css.properties.view-transition-scope.none

--- a/features/view-transitions-element-scoped.yml
+++ b/features/view-transitions-element-scoped.yml
@@ -1,13 +1,16 @@
 name: Element-scoped view transitions
 description: >
   The `startViewTransition()` method of an `Element` object starts a view transition that affects only that element's DOM tree.
-  The `contain: view-transition` CSS declaration contains the layout of the tree to be transitioned.
+  The `view-transition-scope` CSS property limits `view-transition-name` discovery to the element and its flat-tree descendants.
   You can use this to run separate elements' transitions concurrently.
-spec: https://github.com/WICG/view-transitions/blob/main/scoped-transitions.md
+spec: https://drafts.csswg.org/css-view-transitions-2/#scoped-vt
 group: view-transitions
-# Expecting:
-# compat_features:
-#  - api.Element.startViewTransition
-#  - css.properties.contain.view-transition
+compat_features:
+  - api.Element.activeViewTransition
+  - api.Element.startViewTransition
+  - api.ViewTransition.transitionRoot
+  - css.properties.view-transition-scope
+  - css.properties.view-transition-scope.all
+  - css.properties.view-transition-scope.none
 # This feature is subordinate to view-transitions. It should probably merge into
 # it one day.

--- a/features/view-transitions-element-scoped.yml
+++ b/features/view-transitions-element-scoped.yml
@@ -1,7 +1,7 @@
 name: Element-scoped view transitions
 description: >
   The `startViewTransition()` method of an `Element` object starts a view transition that affects only that element's DOM tree.
-  The `view-transition-scope` CSS property limits `view-transition-name` discovery to the element and its flat-tree descendants.
+  The `view-transition-scope` CSS property limits `view-transition-name` discovery to this element's subtree.
   You can use this to run separate elements' transitions concurrently.
 spec: https://drafts.csswg.org/css-view-transitions-2/#scoped-vt
 group: view-transitions

--- a/features/view-transitions-element-scoped.yml
+++ b/features/view-transitions-element-scoped.yml
@@ -1,7 +1,6 @@
 name: Element-scoped view transitions
 description: >
   The `startViewTransition()` method of an `Element` object starts a view transition that affects only that element's DOM tree.
-  The `view-transition-scope` CSS property limits `view-transition-name` discovery to this element's subtree.
   You can use this to run separate elements' transitions concurrently.
 spec: https://drafts.csswg.org/css-view-transitions-2/#scoped-vt
 group: view-transitions

--- a/features/view-transitions-element-scoped.yml.dist
+++ b/features/view-transitions-element-scoped.yml.dist
@@ -3,4 +3,14 @@
 
 status:
   baseline: false
-  support: {}
+  support:
+    chrome: "147"
+    chrome_android: "147"
+    edge: "147"
+compat_features:
+  - api.Element.activeViewTransition
+  - api.Element.startViewTransition
+  - api.ViewTransition.transitionRoot
+  - css.properties.view-transition-scope
+  - css.properties.view-transition-scope.all
+  - css.properties.view-transition-scope.none

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -185,10 +185,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because feature policy was replaced by permissions policy."
     ],
     [
-        "https://github.com/WICG/view-transitions/blob/main/scoped-transitions.md",
-        "Allowed until there's proper spec text. Follow https://github.com/w3c/csswg-drafts/issues/9890 for details."
-    ],
-    [
         "https://github.com/WICG/install-element",
         "Allowed because the <install> element is available in Chrome/Edge as an origin trial."
     ],


### PR DESCRIPTION
Updates `view-transitions-element-scoped` now that scoped view transitions are specified in CSS View Transitions Level 2 and the corresponding BCD keys are available

Changes:
- Replace the stale `contain: view-transition` placeholder with current BCD compat keys.
- Move the scoped view transitions keys out of the CSS View Transitions Level 2 draft bucket.

References:
- CSSWG issue: https://github.com/w3c/csswg-drafts/issues/9890
- CSSWG spec PR for `view-transition-scope`: https://github.com/w3c/csswg-drafts/pull/13390
- BCD Chrome 147 PR: https://github.com/mdn/browser-compat-data/pull/29244
- Spec: https://drafts.csswg.org/css-view-transitions-2/#scoped-vt
