### PR TITLE
Work around broken `npm` in publishing workflows

### DIFF
--- a/.github/workflows/publish_next_compute-baseline.yml
+++ b/.github/workflows/publish_next_compute-baseline.yml
@@ -47,7 +47,14 @@ jobs:
           node-version-file: .node-version
           cache: npm
           registry-url: "https://registry.npmjs.org"
-      - run: npm install -g 'npm@>=11.5.1'  # required for trusted publishing
+
+      # A two-step install is required to work around a bad `npm` version that
+      # comes bundled with Node 22.22.
+      # See https://github.com/npm/cli/issues/9151#issuecomment-4129185112
+      - run: |
+          npm install -g 'npm@10'
+          npm install -g 'npm@>=11.5.1'  # required for trusted publishing
+
       - run: npm ci
       - name: Get package.json version
         id: version

--- a/.github/workflows/publish_next_web-features.yml
+++ b/.github/workflows/publish_next_web-features.yml
@@ -56,7 +56,12 @@ jobs:
           cache: npm
           registry-url: "https://registry.npmjs.org"
 
-      - run: npm install -g 'npm@>=11.5.1'  # required for trusted publishing
+      # A two-step install is required to work around a bad `npm` version that
+      # comes bundled with Node 22.22.
+      # See https://github.com/npm/cli/issues/9151#issuecomment-4129185112
+      - run: |
+          npm install -g 'npm@10'
+          npm install -g 'npm@>=11.5.1'  # required for trusted publishing
       - run: npm ci
 
       - run: npm run build


### PR DESCRIPTION
The specific `npm` version that comes bundled with the latest 22 release of Node.js is broken, so it can't bootstrap itself to the next major version. When I upgraded us to that version in https://github.com/web-platform-dx/web-features/pull/4005, we were exposed to this bug and it broke our workflow.

See https://github.com/npm/cli/issues/9151#issuecomment-4129185112 for the inspiration for this workaround.