### PR TITLE
Simplify the names of two CSS function features

### DIFF
--- a/features/exp-functions.yml
+++ b/features/exp-functions.yml
@@ -1,4 +1,4 @@
-name: pow(), sqrt(), hypot(), log(), and exp()
+name: Exponential functions (CSS)
 description: The `pow()`, `sqrt()`, `hypot()`, `log()`, and `exp()` CSS functions compute various exponential functions.
 spec: https://drafts.csswg.org/css-values-4/#exponent-funcs
 group: css

--- a/features/trig-functions.yml
+++ b/features/trig-functions.yml
@@ -1,4 +1,4 @@
-name: sin(), cos(), tan(), asin(), acos(), atan(), and atan2() (CSS)
+name: Trigonometric functions (CSS)
 description: The `sin()`, `cos()`, `tan()`, `asin()`, `acos()`, `atan()`, and `atan2()` CSS functions compute various trigonometric functions.
 spec: https://drafts.csswg.org/css-values-4/#trig-funcs
 group: css


### PR DESCRIPTION
I found an old branch with this commit and thought it was still a good idea.