### PR TITLE
📦 Release compute-baseline@0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6755,7 +6755,7 @@
       }
     },
     "packages/compute-baseline": {
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@js-temporal/polyfill": "^0.5.1",

--- a/packages/compute-baseline/package.json
+++ b/packages/compute-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compute-baseline",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A library for computing web-features statuses from browser compatibility data",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Proposed release notes:

```
## What's Changed

* **Breaking**: Node.js ≥22.22.0 is now required. ([#4005](https://github.com/web-platform-dx/web-features/pull/4005))
* `@mdn/browser-compat-data` peer dependency has been updated for v8.0.0. ([#4071](https://github.com/web-platform-dx/web-features/pull/4071))
* The type definition of `computeBaseline({ compatKeys })` has been relaxed from `[string, ...string[]]` to `string[]`. ([#3960](https://github.com/web-platform-dx/web-features/pull/3960/))
```