### PR TITLE
Revise `fetch-request-streams` compat keys and description

### DIFF
--- a/features/fetch-request-streams.yml
+++ b/features/fetch-request-streams.yml
@@ -1,6 +1,8 @@
 name: Fetch upload streams
-description: A `fetch()` request uploads a stream of data to the server when a request's `body` property is a `ReadableStream` object.
+description: The `fetch()` method and `Request()` constructor accept a `ReadableStream` object as the request's `body` option, to stream upload data to the server.
 spec: https://fetch.spec.whatwg.org/#concept-body-stream
 group: fetch
 compat_features:
   - api.Request.body
+  - api.fetch.options_parameter.body.accepts_readablestream
+  - api.Request.Request.options_parameter.body.accepts_readablestream

--- a/features/fetch-request-streams.yml.dist
+++ b/features/fetch-request-streams.yml.dist
@@ -7,7 +7,21 @@ status:
     chrome: "105"
     chrome_android: "105"
     edge: "105"
-    safari: "11.1"
-    safari_ios: "11.3"
 compat_features:
+  # baseline: false
+  # support:
+  #   chrome: "105"
+  #   chrome_android: "105"
+  #   edge: "105"
+  #   safari: "11.1"
+  #   safari_ios: "11.3"
   - api.Request.body
+
+  # ⬇️ Same status as overall feature ⬇️
+  # baseline: false
+  # support:
+  #   chrome: "105"
+  #   chrome_android: "105"
+  #   edge: "105"
+  - api.Request.Request.options_parameter.body.accepts_readablestream
+  - api.fetch.options_parameter.body.accepts_readablestream

--- a/features/fetch.yml
+++ b/features/fetch.yml
@@ -28,7 +28,6 @@ compat_features:
   - api.Request.Request.options_parameter.body
   - api.Request.Request.options_parameter.keepalive
   - api.Request.Request.options_parameter.referrer
-  - api.Request.Request.options_parameter.body.accepts_readablestream
   - api.Request.Request.response_body_readablestream
   - api.Request.arrayBuffer
   - api.Request.blob

--- a/features/fetch.yml.dist
+++ b/features/fetch.yml.dist
@@ -426,13 +426,6 @@ compat_features:
 
   # baseline: false
   # support:
-  #   chrome: "105"
-  #   chrome_android: "105"
-  #   edge: "105"
-  - api.Request.Request.options_parameter.body.accepts_readablestream
-
-  # baseline: false
-  # support:
   #   chrome: "131"
   #   edge: "131"
   - api.Request.duplex


### PR DESCRIPTION
This PR assigns keys (one formerly in fetch, one new) to `fetch-request-streams` to more accurately reflect its support in browsers. It also rewrites the description, to more clearly describe the entrypoint into this feature.

This builds on and closes https://github.com/web-platform-dx/web-features/pull/3361/. I've added @jgraham as a coauthor to my commit, to reflect his initial work on this problem.

See https://github.com/web-platform-dx/web-features/pull/3361#issuecomment-4216947419 and https://github.com/mdn/browser-compat-data/pull/29451 for some more background on how this data came to be.