### PR TITLE
Add more compat keys to `setinterval` and `settimeout`

### DIFF
--- a/features/setinterval.yml
+++ b/features/setinterval.yml
@@ -3,6 +3,7 @@ description: "The `setInterval()` global function repeatedly executes provided c
 spec: https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers
 compat_features:
   - api.setInterval
+  - api.setInterval.supports_parameters_for_callback
   - api.setInterval.worker_support
   - api.clearInterval
   - api.clearInterval.worker_support

--- a/features/setinterval.yml.dist
+++ b/features/setinterval.yml.dist
@@ -28,6 +28,19 @@ compat_features:
   - api.clearInterval
   - api.setInterval
 
+  # baseline: high
+  # baseline_low_date: 2015-07-29
+  # baseline_high_date: 2018-01-29
+  # support:
+  #   chrome: "1"
+  #   chrome_android: "18"
+  #   edge: "12"
+  #   firefox: "1"
+  #   firefox_android: "4"
+  #   safari: "1.2"
+  #   safari_ios: "1"
+  - api.setInterval.supports_parameters_for_callback
+
   # ⬇️ Same status as overall feature ⬇️
   # baseline: high
   # baseline_low_date: 2015-07-29

--- a/features/settimeout.yml
+++ b/features/settimeout.yml
@@ -3,6 +3,7 @@ description: "The `setTimeout()` global function executes provided code after a 
 spec: https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers
 compat_features:
   - api.setTimeout
+  - api.setTimeout.supports_parameters_for_callback
   - api.setTimeout.worker_support
   - api.clearTimeout
   - api.clearTimeout.worker_support

--- a/features/settimeout.yml.dist
+++ b/features/settimeout.yml.dist
@@ -36,6 +36,19 @@ compat_features:
   #   edge: "12"
   #   firefox: "1"
   #   firefox_android: "4"
+  #   safari: "1.2"
+  #   safari_ios: "1"
+  - api.setTimeout.supports_parameters_for_callback
+
+  # baseline: high
+  # baseline_low_date: 2015-07-29
+  # baseline_high_date: 2018-01-29
+  # support:
+  #   chrome: "1"
+  #   chrome_android: "18"
+  #   edge: "12"
+  #   firefox: "1"
+  #   firefox_android: "4"
   #   safari: "4"
   #   safari_ios: "1"
   - api.clearTimeout


### PR DESCRIPTION
This maps some very old keys into existing features. There are no status changes. This improves our coverage of BCD by 87 670 shipping days.