### PR TITLE
`text-decoration`: backfill compat keys

### DIFF
--- a/features/text-decoration.yml
+++ b/features/text-decoration.yml
@@ -6,6 +6,10 @@ status:
   compute_from: css.properties.text-decoration
 compat_features:
   - css.properties.text-decoration
+  - css.properties.text-decoration.line-through
+  - css.properties.text-decoration.none
+  - css.properties.text-decoration.overline
+  - css.properties.text-decoration.underline
   - css.properties.text-decoration.currentColor
   - css.properties.text-decoration.transparent
   - css.properties.text-decoration-color

--- a/features/text-decoration.yml.dist
+++ b/features/text-decoration.yml.dist
@@ -29,6 +29,22 @@ compat_features:
   - css.properties.text-decoration
 
   # baseline: high
+  # baseline_low_date: 2015-07-29
+  # baseline_high_date: 2018-01-29
+  # support:
+  #   chrome: "1"
+  #   chrome_android: "18"
+  #   edge: "12"
+  #   firefox: "3"
+  #   firefox_android: "4"
+  #   safari: "1"
+  #   safari_ios: "1"
+  - css.properties.text-decoration.line-through
+  - css.properties.text-decoration.none
+  - css.properties.text-decoration.overline
+  - css.properties.text-decoration.underline
+
+  # baseline: high
   # baseline_low_date: 2020-01-15
   # baseline_high_date: 2022-07-15
   # support:


### PR DESCRIPTION
This assigns a few very old keys to `text-decoration`. This improves our coverage of BCD by ~171 000 shipping days.