### PR TITLE
Upgrade and simplify root tsconfig for Node.js 22

### DIFF
--- a/assertions.test.ts
+++ b/assertions.test.ts
@@ -2,9 +2,9 @@ import assert from "node:assert/strict";
 import {
   assertCompatSetConsistency,
   assertValidFeatureReference,
-} from "./assertions";
-import { ParsedAuthoredData } from "./parse";
-import { Status } from "./types";
+} from "./assertions.ts";
+import type { ParsedAuthoredData } from "./parse.ts";
+import type { Status } from "./types.ts";
 
 describe("assertValidReference()", function () {
   it("throws if target ID is a move", function () {

--- a/assertions.ts
+++ b/assertions.ts
@@ -1,8 +1,8 @@
 import { Temporal } from "@js-temporal/polyfill";
-import { ParsedAuthoredData } from "./parse";
-import { isOrdinaryFeatureData } from "./type-guards";
-import { BaselineHighLow, FeatureData, Status } from "./types";
-import { WebFeaturesData } from "./types.quicktype";
+import type { ParsedAuthoredData } from "./parse.ts";
+import { isOrdinaryFeatureData } from "./type-guards.ts";
+import type { WebFeaturesData } from "./types.quicktype.ts";
+import type { BaselineHighLow, FeatureData, Status } from "./types.ts";
 
 /**
  * Assert that a reference from one feature to another is an ordinary feature

--- a/index.ts
+++ b/index.ts
@@ -4,14 +4,14 @@ import path from 'path';
 import { Temporal } from '@js-temporal/polyfill';
 import { fdir } from 'fdir';
 import YAML from 'yaml';
-import { convertMarkdown } from "./text";
-import { GroupData, SnapshotData, WebFeaturesData } from './types';
+import { convertMarkdown } from "./text.ts";
+import type { GroupData, SnapshotData, WebFeaturesData } from './types.ts';
 
 import { BASELINE_LOW_TO_HIGH_DURATION, coreBrowserSet, getStatus, parseRangedDateString } from 'compute-baseline';
 import { Compat } from 'compute-baseline/browser-compat-data';
-import { assertCompatSetConsistency, assertRequiredRemovalDateSet, assertValidFeatureReference } from './assertions';
-import { isMoved, isOrdinaryFeatureData, isSplit } from './type-guards';
-import { parseAuthoring, ParsedAuthoredData } from './parse';
+import { assertCompatSetConsistency, assertRequiredRemovalDateSet, assertValidFeatureReference } from './assertions.ts';
+import { parseAuthoring, type ParsedAuthoredData } from './parse.ts';
+import { isMoved, isOrdinaryFeatureData, isSplit } from './type-guards.ts';
 
 // The longest name allowed, to allow for compact display.
 const nameMaxLength = 80;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@js-temporal/polyfill": "^0.5.1",
         "@mdn/browser-compat-data": "7.3.17",
         "@octokit/rest": "^22.0.1",
+        "@tsconfig/node-ts": "^23.6.4",
+        "@tsconfig/node22": "^22.0.5",
         "@types/caniuse-lite": "^1.0.4",
         "@types/node": "^22.19.19",
         "@types/yargs": "^17.0.35",
@@ -1215,6 +1217,13 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/@tsconfig/node-ts": {
+      "version": "23.6.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node-ts/-/node-ts-23.6.4.tgz",
+      "integrity": "sha512-37BMJvNQZ+vTgd1xG2TGBkJ6ENeT4eO4Wh2CHrnn0IwH7ybLFCzh4Uc//kc7UIvqiRac4uGdIc1meKOjMSlKzw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -1240,6 +1249,13 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
+      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "@js-temporal/polyfill": "^0.5.1",
     "@mdn/browser-compat-data": "7.3.17",
     "@octokit/rest": "^22.0.1",
+    "@tsconfig/node-ts": "^23.6.4",
+    "@tsconfig/node22": "^22.0.5",
     "@types/caniuse-lite": "^1.0.4",
     "@types/node": "^22.19.19",
     "@types/yargs": "^17.0.35",

--- a/parse.test.ts
+++ b/parse.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { makeCompatSets, parseAuthoring } from "./parse";
+import { makeCompatSets, parseAuthoring } from "./parse.ts";
 
 describe("makeCompatSets", function () {
   it("from explicit compat sets", function () {

--- a/parse.ts
+++ b/parse.ts
@@ -1,6 +1,6 @@
 import winston from "winston";
-import { tagsToFeatures } from "./compat-helpers";
-import { FeatureData } from "./types";
+import { tagsToFeatures } from "./compat-helpers.ts";
+import type { FeatureData } from "./types.ts";
 
 const logger = winston.createLogger({
   level: "error",

--- a/scripts/audit-consumers.ts
+++ b/scripts/audit-consumers.ts
@@ -1,7 +1,7 @@
 import { Octokit } from "@octokit/rest";
 import * as cheerio from "cheerio";
 
-import { features as webFeatures } from "../index.js";
+import { features as webFeatures } from "../index.ts";
 
 interface Report {
   heading: string;

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,14 +1,14 @@
-import { DefinedError } from "ajv";
+import type { DefinedError } from "ajv";
 import stringify from "fast-json-stable-stringify";
+import { fdir } from "fdir";
 import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import winston from "winston";
-import yargs from "yargs";
-import * as data from "../index.js";
-import { validate, validateProposed } from "./validate.js";
-import { fdir } from "fdir";
 import YAML from "yaml";
+import yargs from "yargs";
+import * as data from "../index.ts";
+import { validate, validateProposed } from "./validate.ts";
 
 const logger = winston.createLogger({
   format: winston.format.combine(

--- a/scripts/caniuse.ts
+++ b/scripts/caniuse.ts
@@ -1,8 +1,8 @@
 import lite from "caniuse-lite";
 import { fileURLToPath } from "node:url";
 import winston from "winston";
-import { features } from "../index.js";
-import { isOrdinaryFeatureData } from "../type-guards.js";
+import { features } from "../index.ts";
+import { isOrdinaryFeatureData } from "../type-guards.ts";
 
 const logger = winston.createLogger({
   format: winston.format.printf(({ message }) => `${message}`),

--- a/scripts/dist.ts
+++ b/scripts/dist.ts
@@ -14,9 +14,13 @@ import { isDeepStrictEqual } from "node:util";
 import winston from "winston";
 import YAML, { Document, Scalar, YAMLSeq } from "yaml";
 import yargs from "yargs";
-import { checkForStaleCompat, tagsToFeatures } from "../compat-helpers";
-import { parseAuthoring } from "../parse";
-import type { FeatureData, FeatureMovedData, FeatureSplitData } from "../types";
+import { checkForStaleCompat, tagsToFeatures } from "../compat-helpers.ts";
+import { parseAuthoring } from "../parse.ts";
+import type {
+  FeatureData,
+  FeatureMovedData,
+  FeatureSplitData,
+} from "../types.ts";
 
 const argv = yargs(process.argv.slice(2))
   .scriptName("dist")

--- a/scripts/find-ranged-headline-statuses.ts
+++ b/scripts/find-ranged-headline-statuses.ts
@@ -1,5 +1,5 @@
-import { features } from "../index";
-import { isOrdinaryFeatureData } from "../type-guards";
+import { features } from "../index.ts";
+import { isOrdinaryFeatureData } from "../type-guards.ts";
 
 for (const [key, data] of Object.entries(features)) {
   if (isOrdinaryFeatureData(data)) {

--- a/scripts/inspect-feature.ts
+++ b/scripts/inspect-feature.ts
@@ -1,4 +1,9 @@
 import { coreBrowserSet, getStatus } from "compute-baseline";
+import {
+  Compat,
+  feature,
+  SupportStatement,
+} from "compute-baseline/browser-compat-data";
 import escapeHtml from "escape-html";
 import fs from "node:fs";
 import path from "node:path";
@@ -6,12 +11,11 @@ import { fileURLToPath } from "node:url";
 import winston from "winston";
 import YAML from "yaml";
 import yargs from "yargs";
-import { features } from "..";
-import { defaultCompat } from "../packages/compute-baseline/dist/browser-compat-data/compat";
-import { feature } from "../packages/compute-baseline/dist/browser-compat-data/feature";
-import { SupportStatement } from "../packages/compute-baseline/dist/browser-compat-data/supportStatements";
-import { convertHTML } from "../text";
-import { FeatureData } from "../types";
+import { features } from "../index.ts";
+import { convertHTML } from "../text.ts";
+import type { FeatureData } from "../types.ts";
+
+const compat = new Compat();
 
 const argv = yargs(process.argv.slice(2))
   .scriptName("dist")
@@ -94,7 +98,7 @@ function getNotes(compatKey: string): Map<string, string[]> {
   const f = feature(compatKey);
   for (const browserKey of coreBrowserSet) {
     const statements = f
-      .supportStatements(defaultCompat.browser(browserKey))
+      .supportStatements(compat.browser(browserKey))
       .filter(isEligibleStatement);
     for (const statement of statements) {
       const notes = Array.isArray(statement.data.notes!)

--- a/scripts/remove-tagged-compat-features.ts
+++ b/scripts/remove-tagged-compat-features.ts
@@ -8,7 +8,7 @@ import { isDeepStrictEqual } from "node:util";
 import winston from "winston";
 import YAML from "yaml";
 import yargs from "yargs";
-import { checkForStaleCompat } from "../compat-helpers";
+import { checkForStaleCompat } from "../compat-helpers.ts";
 
 const compat = new Compat();
 

--- a/scripts/schema.ts
+++ b/scripts/schema.ts
@@ -3,9 +3,9 @@ import fs from "node:fs";
 import path from "node:path";
 import url from 'url';
 
-import { DefinedError } from "ajv";
-import * as data from '../index.js';
-import { validate } from "./validate.js";
+import type { DefinedError } from "ajv";
+import * as data from '../index.ts';
+import { validate } from "./validate.ts";
 
 let status: 0 | 1 = 0;
 

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -3,8 +3,8 @@ import assert from "node:assert/strict";
 import webSpecs from 'web-specs' with { type: 'json' };
 import winston from "winston";
 
-import { features } from '../index.js';
-import { isOrdinaryFeatureData } from "../type-guards.js";
+import { features } from '../index.ts';
+import { isOrdinaryFeatureData } from "../type-guards.ts";
 
 const logger = winston.createLogger({
   level: "warn",

--- a/scripts/stats.ts
+++ b/scripts/stats.ts
@@ -1,8 +1,8 @@
 import { Compat } from "compute-baseline/browser-compat-data";
 import { fileURLToPath } from "node:url";
 import yargs from "yargs";
-import { features } from "../index.js";
-import { isOrdinaryFeatureData } from "../type-guards.js";
+import { features } from "../index.ts";
+import { isOrdinaryFeatureData } from "../type-guards.ts";
 
 yargs(process.argv.slice(2))
   .scriptName("stats")

--- a/scripts/unmapped-compat-keys.ts
+++ b/scripts/unmapped-compat-keys.ts
@@ -3,9 +3,9 @@ import { coreBrowserSet } from "compute-baseline";
 import { Compat, Feature } from "compute-baseline/browser-compat-data";
 import winston from "winston";
 import yargs from "yargs";
-import { features } from "../index.js";
+import { features } from "../index.ts";
 import { support } from "../packages/compute-baseline/dist/baseline/support.js";
-import { isOrdinaryFeatureData } from "../type-guards.js";
+import { isOrdinaryFeatureData } from "../type-guards.ts";
 
 const compat = new Compat();
 const browsers = coreBrowserSet.map((b) => compat.browser(b));

--- a/scripts/update-drafts.ts
+++ b/scripts/update-drafts.ts
@@ -10,9 +10,9 @@ import winston from "winston";
 import { Document, parse } from "yaml";
 import yargs from "yargs";
 
-import { features } from "../index.js";
-import { isOrdinaryFeatureData } from "../type-guards.js";
-import { FeatureData } from "../types.js";
+import { features } from "../index.ts";
+import { isOrdinaryFeatureData } from "../type-guards.ts";
+import type { FeatureData } from "../types.ts";
 
 type WebSpecsSpec = (typeof webSpecs)[number];
 

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -1,8 +1,9 @@
-import Ajv from "ajv";
+import ajvmodule from "ajv";
 import assert from "node:assert/strict";
-
-import * as schema from "../schemas/data.schema.json" with { type: "json" };
 import * as proposedSchema from "../schemas/data.proposed.schema.json" with { type: "json" };
+import * as schema from "../schemas/data.schema.json" with { type: "json" };
+
+const Ajv = ajvmodule.default;
 
 const ajv = new Ajv({ allErrors: true, allowUnionTypes: true });
 // TODO: turn on strictNullChecks, fix all the errors, and replace this with:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,12 @@
 {
+  "extends": [
+    "@tsconfig/node22/tsconfig.json",
+    "@tsconfig/node-ts/tsconfig.json"
+  ],
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "Bundler",
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
     "noEmit": true,
-    "lib": ["ES2023"],
     "types": ["node", "mocha"],
     "strict": false
   },
-  "exclude": ["packages/", "gh-pages/"]
+  "exclude": ["packages/"]
 }

--- a/type-guards.ts
+++ b/type-guards.ts
@@ -1,4 +1,8 @@
-import type { FeatureData, FeatureMovedData, FeatureSplitData } from "./types";
+import type {
+  FeatureData,
+  FeatureMovedData,
+  FeatureSplitData,
+} from "./types.ts";
 
 export function isOrdinaryFeatureData(x: unknown): x is FeatureData {
   return (

--- a/types.ts
+++ b/types.ts
@@ -18,7 +18,7 @@ import type {
   Release,
   SnapshotData,
   Support,
-} from "./types.quicktype";
+} from "./types.quicktype.ts";
 
 // Passthrough types
 export type {


### PR DESCRIPTION
## Summary

This turns on some JavaScript language features and cleans up some longstanding quirks in our TypeScript config.

## Background

[When we upgraded to Node.js 22](https://github.com/web-platform-dx/web-features/pull/4005), we didn't change the TypeScript config, so the type checker won't actually let you use any of the new JavaScript niceties in this version of Node.

On top of that, our root `tsconfig.json` file is a little unconventional (there are other PRs and issues open about this, though this PR doesn't address all of it).

## What's new here

This PR does a few little things:

- To minimize weirdness, uses Microsoft's recommended base configurations from [tsconfig/bases](https://github.com/tsconfig/bases) for Node.js 22 and Node.js + Typescript, so the things that we're doing that are unusual stand out in the `tsconfig.json` file. Then, as a consequence, the three following things.
- Uses `.ts` import extensions, exclusively, in our project scripts.
- Uses explicit `type` imports, where applicable. This is more explicit and will help us drop a dependency in the future.
- Fixes the remaining type errors that resulted.

Finally, this _only_ touches the root `tsconfig.json`. There is some related work to do in the `packages/` directories, but to make this PR easier to review, I elected to do those in follow up PRs.

## Related PRs

- This unblocks https://github.com/web-platform-dx/web-features/pull/4030.
- This will eliminate some work seen in other PRs, especially https://github.com/web-platform-dx/web-features/pull/3879.