### PR TITLE
`user-agent`: Backfill `api.Navigator.vendorSub` compat key

### DIFF
--- a/features/user-agent-sniffing.yml
+++ b/features/user-agent-sniffing.yml
@@ -15,6 +15,7 @@ compat_features:
   - api.Navigator.product
   - api.Navigator.productSub
   - api.Navigator.vendor
+  - api.Navigator.vendorSub
   - api.WorkerNavigator.userAgent
   - api.WorkerNavigator.appCodeName
   - api.WorkerNavigator.appName

--- a/features/user-agent-sniffing.yml.dist
+++ b/features/user-agent-sniffing.yml.dist
@@ -40,6 +40,19 @@ compat_features:
   # baseline_low_date: 2015-07-29
   # baseline_high_date: 2018-01-29
   # support:
+  #   chrome: "1"
+  #   chrome_android: "18"
+  #   edge: "12"
+  #   firefox: "1"
+  #   firefox_android: "4"
+  #   safari: "3"
+  #   safari_ios: "1"
+  - api.Navigator.vendorSub
+
+  # baseline: high
+  # baseline_low_date: 2015-07-29
+  # baseline_high_date: 2018-01-29
+  # support:
   #   chrome: "4"
   #   chrome_android: "18"
   #   edge: "12"


### PR DESCRIPTION
This adds `api.Navigator.vendorSub`, the last of the Baseline `NavigatorID` API surface, to the `user-agent` feature.

If you want to know why this _isn't_ deprecated, see https://github.com/mdn/browser-compat-data/pull/27342 for the whole sad saga.