### PR TITLE
`script`: Backfill compat keys

### DIFF
--- a/features/script.yml
+++ b/features/script.yml
@@ -12,6 +12,7 @@ compat_features:
   - api.HTMLScriptElement.src
   - api.HTMLScriptElement.supports_static
   - api.HTMLScriptElement.text
+  - api.HTMLScriptElement.textContent
   - api.HTMLScriptElement.type
   - html.elements.script
   - html.elements.script.async

--- a/features/script.yml
+++ b/features/script.yml
@@ -9,6 +9,7 @@ compat_features:
   - api.HTMLScriptElement.async
   - api.HTMLScriptElement.crossOrigin
   - api.HTMLScriptElement.defer
+  - api.HTMLScriptElement.innerText
   - api.HTMLScriptElement.src
   - api.HTMLScriptElement.supports_static
   - api.HTMLScriptElement.text

--- a/features/script.yml.dist
+++ b/features/script.yml.dist
@@ -113,6 +113,19 @@ compat_features:
   - api.HTMLScriptElement.async
 
   # baseline: high
+  # baseline_low_date: 2016-03-08
+  # baseline_high_date: 2018-09-08
+  # support:
+  #   chrome: "1"
+  #   chrome_android: "18"
+  #   edge: "12"
+  #   firefox: "45"
+  #   firefox_android: "45"
+  #   safari: "3"
+  #   safari_ios: "2"
+  - api.HTMLScriptElement.innerText
+
+  # baseline: high
   # baseline_low_date: 2016-08-02
   # baseline_high_date: 2019-02-02
   # support:

--- a/features/script.yml.dist
+++ b/features/script.yml.dist
@@ -28,6 +28,7 @@ compat_features:
   - api.HTMLScriptElement
   - api.HTMLScriptElement.src
   - api.HTMLScriptElement.text
+  - api.HTMLScriptElement.textContent
   - api.HTMLScriptElement.type
 
   # ⬇️ Same status as overall feature ⬇️


### PR DESCRIPTION
Add the `api.HTMLScriptElement.textContent` and `innerText` keys to the `<script>` element feature.

Improves BCD coverage by 78 709 shipping days.