### PR TITLE
Demo: merge authoring

### DIFF
--- a/features/grid-animation.yml
+++ b/features/grid-animation.yml
@@ -1,3 +1,5 @@
+kind: merged
+redirect_target: grid
 name: Grid animation
 description: Grid animation allows you to animate the `grid-template-columns` and `grid-template-rows` CSS properties.
 spec: https://drafts.csswg.org/css-grid-2/#track-sizing

--- a/features/grid.yml
+++ b/features/grid.yml
@@ -1,3 +1,4 @@
+# @merges grid-animation
 name: Grid
 description: CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
 spec: https://drafts.csswg.org/css-grid-3/

--- a/features/grid.yml
+++ b/features/grid.yml
@@ -3,5 +3,68 @@ description: CSS grid is a two-dimensional layout system, which lays content out
 spec: https://drafts.csswg.org/css-grid-3/
 group: grid
 caniuse: css-grid
-status:
-  compute_from: css.properties.grid
+compat_features:
+  core:
+    - css.properties.align-content.grid_context
+    - css.properties.align-items.grid_context
+    - css.properties.align-self.grid_context
+    - css.properties.display.grid
+    - css.properties.display.inline-grid
+    - css.properties.gap
+    - css.properties.gap.normal
+    - css.properties.grid # former compute_from
+    - css.properties.grid-area
+    - css.properties.grid-auto-flow
+    - css.properties.grid-column
+    - css.properties.grid-column-end
+    - css.properties.grid-column-start
+    - css.properties.grid-row
+    - css.properties.grid-row-end
+    - css.properties.grid-row-start
+    - css.properties.grid-template
+    - css.properties.grid-template-areas
+    - css.properties.grid-template-columns
+    - css.properties.grid-template-columns.fit-content
+    - css.properties.grid-template-columns.minmax
+    - css.properties.grid-template-rows
+    - css.properties.grid-template-rows.fit-content
+    - css.properties.grid-template-rows.minmax
+    - css.properties.justify-content.grid_context
+    - css.properties.justify-items.grid_context
+    - css.properties.justify-self
+    - css.properties.justify-self.grid_context
+    - css.properties.row-gap
+    - css.properties.row-gap.normal
+    - css.types.flex
+  modifier:
+    - css.properties.align-items.grid_context.start_end
+    - css.properties.column-gap.grid_context
+    - css.properties.gap.grid_context
+    - css.properties.gap.grid_context.calc_values
+    - css.properties.gap.grid_context.percentage_values
+    - css.properties.grid-auto-columns
+    - css.properties.grid-auto-flow.column
+    - css.properties.grid-auto-flow.dense
+    - css.properties.grid-auto-flow.row
+    - css.properties.grid-auto-rows
+    - css.properties.grid-template-areas.none
+    - css.properties.grid-template-columns.auto
+    - css.properties.grid-template-columns.max-content
+    - css.properties.grid-template-columns.min-content
+    - css.properties.grid-template-columns.none
+    - css.properties.grid-template-columns.repeat
+    - css.properties.grid-template-rows.auto
+    - css.properties.grid-template-rows.max-content
+    - css.properties.grid-template-rows.min-content
+    - css.properties.grid-template-rows.none
+    - css.properties.grid-template-rows.repeat
+    - css.properties.grid-template.none
+    - css.properties.justify-self.auto
+    - css.properties.justify-self.left
+    - css.properties.justify-self.normal
+    - css.properties.justify-self.right
+    - css.properties.justify-self.stretch
+    - css.properties.place-content.grid_context
+    - css.properties.place-items.grid_context
+    - css.properties.place-self.grid_context
+    - css.properties.row-gap.grid_context

--- a/features/grid.yml.dist
+++ b/features/grid.yml.dist
@@ -244,3 +244,17 @@ compat_features:
   #   safari_ios: "10.3"
   - css.properties.grid-template-columns.repeat
   - css.properties.grid-template-rows.repeat
+
+  # baseline: high
+  # baseline_low_date: 2022-10-27
+  # baseline_high_date: 2025-04-27
+  # support:
+  #   chrome: "107"
+  #   chrome_android: "107"
+  #   edge: "107"
+  #   firefox: "66"
+  #   firefox_android: "66"
+  #   safari: "16"
+  #   safari_ios: "16"
+  - css.properties.grid-template-columns.animation
+  - css.properties.grid-template-rows.animation


### PR DESCRIPTION
This PR demonstrates one way to author merges, as part of the aspects project work. It assumes compatibility with https://github.com/web-platform-dx/web-features/pull/4034 and https://github.com/web-platform-dx/web-features/pull/4079; if you haven't seen those, you should review them first!

**Because this PR is partly based on https://github.com/web-platform-dx/web-features/pull/4079, reviewing 075fac94594e71ff47492572be31902dd2f06965 shows the actual authoring differences.** I'll rebase this PR as soon as the other one merges.

## Synopsis

Merges are declared by adding `kind: merged` and `redirect_target: <target-feature-id>` to a feature description. That's the authoring change.

As a convenience to authors, we'll add (generated) comments to the merge targets, to note when other features have been merged into it.

Merged features' BCD keys are _implicitly_ shared into the target feature; you can see the result of this in the `.dist` file. The "promotion" of keys into merge targets will be subject to some guidelines and automatic enforcement, the most important of which is that you can't merge a feature with a lower status into a feature with a higher status.

## Feedback I'm looking for

- Does this authoring communicate a relationship between two features, the merged and merge target?
- Does this authoring look familiar or new, clear or ambiguous?
- Can you imagine yourself writing this or using a tool to generate it? If not, what would you imagine writing?

## What about….?

- **Baseline dates.** In this regime, Baseline dates don't change upon merging. A feature's "birth date" holds steady, even if other features merge into it. The use of compat sets means that we have the possibility of changing this behavior in the future (e.g., to generate a rolling Baseline date and a historic inception date), but until we have an actual consumer for such data, I am not planning to implement it.

- **Merge metadata.** We might want additional information about the merge, such as a reason or merge date. I'm not rejecting them, but the authoring story for such data is not new and interesting (compare with discouraged features), so I didn't think it would be very helpful to demonstrate them here.

- **Merging this feature, specifically.** I pulled an example from our open issues (specifically, https://github.com/web-platform-dx/web-features/issues/2441). Is this a good idea, specifically? I think this is an easy case, but this is a demo of authoring only—I do not intend to merge this PR. We might ultimately adopt merge guidelines that prevent merging `grid-animation` (e.g., we might wish to wait some longer interval before merging the feature or to consult with consumers ahead of merging). But it will be easier to demo possible enforcement and guidelines with some of our more complicated cases _after_ we have a notation for feature merging.

- **Alternatives**. I tried out other authoring formats, such as inverting merges (e.g., adding a `subsumed` array to the merge target and using convenience comments on the merged features). This was more cumbersome to write and hid the main consequence of merging a feature: changing a feature's `kind` from the default implicit `"feature"` value.