### PR TITLE
`url-integrity`: map expected compat key

### DIFF
--- a/features/url-integrity.yml
+++ b/features/url-integrity.yml
@@ -1,6 +1,5 @@
 name: integrity() for url()
 description: The `url()` CSS function accepts an `integrity()` modifier to use subresource integrity to verify the response from the requested URL.
 spec: https://drafts.csswg.org/css-values-5/#typedef-request-url-modifier-integrity-modifier
-# Expected:
-# compat_features:
-# - css.types.url.integrity
+compat_features:
+  - css.types.url.integrity

--- a/features/url-integrity.yml.dist
+++ b/features/url-integrity.yml.dist
@@ -4,3 +4,5 @@
 status:
   baseline: false
   support: {}
+compat_features:
+  - css.types.url.integrity


### PR DESCRIPTION
This feature hasn't been released, so it only moves the unmapped keys by one and zero shipping days. Prompted by https://github.com/web-platform-dx/web-features/issues/3930#issuecomment-4543191391.