### PR TITLE
Remove Markdown from `input-color-alpha` feature name

### DIFF
--- a/features/input-color-alpha.yml
+++ b/features/input-color-alpha.yml
@@ -1,4 +1,4 @@
-name: "`alpha` and `colorspace` attributes for `<input type=color>`"
+name: alpha and colorspace attributes for <input type=color>
 description: The ability to control the opacity of a color picked using `<input type="color">` and determine the colorspace of the selected color.
 spec: https://html.spec.whatwg.org/multipage/input.html#attr-input-alpha
 group:


### PR DESCRIPTION
As per the project's contribution guidelines, the "name" field is is intended to be formatted as a plain text string.

---

See also https://github.com/web-platform-dx/web-features/issues/2018