### PR TITLE
try to link data to field-sizing

### DIFF
--- a/features/field-sizing.yml
+++ b/features/field-sizing.yml
@@ -2,3 +2,6 @@ name: field-sizing
 spec: https://drafts.csswg.org/css-ui-4/#field-sizing
 description: The `field-sizing` CSS property allows form controls such as `<textarea>` to be sized based on their content.
 group: css
+status:
+  compute_from:
+    - css.properties.field-sizing


### PR DESCRIPTION
Field Sizing should be baseline newly available, but Firefox is marked as limited support. This aims to fix that by linking the BCD fields to the field-sizing.yml. I'm not sure if this is the right way to go about this, but Firefox has supported since 152 so this should be marked newly available.