### PR TITLE
fix: add explicit extensions to web-features

### DIFF
--- a/packages/web-features/index.ts
+++ b/packages/web-features/index.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { WebFeaturesData } from "./types";
+import { WebFeaturesData } from "./types.js";
 
 const jsonPath = fileURLToPath(new URL("./data.json", import.meta.url));
 const { browsers, features, groups, snapshots } = JSON.parse(

--- a/packages/web-features/tsconfig.json
+++ b/packages/web-features/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2016",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "node18",
+    "moduleResolution": "node16",
     "typeRoots": ["./node_modules/@types"],
     "declaration": true,
     "types": ["node"]


### PR DESCRIPTION
Importing `web-features` in a project which uses node16 resolution
currently fails since it can't resolve `"./types"`. This means the types
we get are basically `Record<string, any>` rather than `Record<string,
FeatureData>`.

Given that this package requires a node-like runtime (it imports `node:fs`),
I think it makes sense to set the `module` to `node18` and the
`moduleResolution` to `node16`.

This should basically enforce things like file extensions, respecting export
maps, etc.
