### PR TITLE
languagemodel: map expected compat keys

### DIFF
--- a/features/languagemodel.yml
+++ b/features/languagemodel.yml
@@ -3,8 +3,6 @@ description: The `LanguageModel` API prompts an on-device language model. Also k
 spec: http://webmachinelearning.github.io/prompt-api/
 compat_features:
   # The follow keys are expected, at the time this feature was authored:
-  # - api.LanguageModel.destroy
-  # - api.LanguageModel.oncontextoverflow_event
   # - http.headers.Permissions-Policy.language-model
   - api.LanguageModel
   - api.LanguageModel.append
@@ -12,7 +10,9 @@ compat_features:
   - api.LanguageModel.clone
   - api.LanguageModel.contextUsage
   - api.LanguageModel.contextWindow
+  - api.LanguageModel.contextoverflow_event
   - api.LanguageModel.create_static
+  - api.LanguageModel.destroy
   - api.LanguageModel.measureContextUsage
   - api.LanguageModel.prompt
   - api.LanguageModel.promptStreaming

--- a/features/languagemodel.yml.dist
+++ b/features/languagemodel.yml.dist
@@ -12,7 +12,9 @@ compat_features:
   - api.LanguageModel.clone
   - api.LanguageModel.contextUsage
   - api.LanguageModel.contextWindow
+  - api.LanguageModel.contextoverflow_event
   - api.LanguageModel.create_static
+  - api.LanguageModel.destroy
   - api.LanguageModel.measureContextUsage
   - api.LanguageModel.prompt
   - api.LanguageModel.promptStreaming


### PR DESCRIPTION
The authoring comment listed the event as `oncontextoverflow_event`; the actual BCD key is `contextoverflow_event` (BCD names DOM events `<name>_event`, without the on handler prefix), so updated
