### PR TITLE
Avoid `npm@12` while sigstore bug persists

### DIFF
--- a/.github/workflows/publish_next_compute-baseline.yml
+++ b/.github/workflows/publish_next_compute-baseline.yml
@@ -51,9 +51,11 @@ jobs:
       # A two-step install is required to work around a bad `npm` version that
       # comes bundled with Node 22.22.
       # See https://github.com/npm/cli/issues/9151#issuecomment-4129185112
+      # And we can't yet use npm@12 due to a bug:
+      # See https://github.com/npm/cli/issues/9722
       - run: |
           npm install -g 'npm@10'
-          npm install -g 'npm@>=11.5.1'  # required for trusted publishing
+          npm install -g 'npm@^11.5.1'  # required for trusted publishing
 
       - run: npm ci
       - name: Get package.json version

--- a/.github/workflows/publish_next_web-features.yml
+++ b/.github/workflows/publish_next_web-features.yml
@@ -59,9 +59,11 @@ jobs:
       # A two-step install is required to work around a bad `npm` version that
       # comes bundled with Node 22.22.
       # See https://github.com/npm/cli/issues/9151#issuecomment-4129185112
+      # And we can't yet use npm@12 due to a bug:
+      # See https://github.com/npm/cli/issues/9722
       - run: |
           npm install -g 'npm@10'
-          npm install -g 'npm@>=11.5.1'  # required for trusted publishing
+          npm install -g 'npm@^11.5.1'  # required for trusted publishing
       - run: npm ci
 
       - run: npm run build


### PR DESCRIPTION
This fixes publishing errors like https://github.com/web-platform-dx/web-features/actions/runs/29079631174/job/86319527685.

Related issue: https://github.com/npm/cli/issues/9722