### PR TITLE
`fencedframe`: mark privacy sandbox as discouraged, pending removal

### DIFF
--- a/features/fencedframe.yml
+++ b/features/fencedframe.yml
@@ -1,8 +1,12 @@
 name: <fencedframe>
 description: The `<fencedframe>` element embeds another HTML page into the current page in a more secure and privacy-preserving way than `<iframe>` elements.
 spec: https://wicg.github.io/fenced-frame/
-status:
-  compute_from: html.elements.fencedframe
+discouraged:
+  removal_date: 2026-09-09
+  reason: Following the announcement that Chrome will maintain its current approach to third-party cookies, Chrome decided to withdraw certain Privacy Sandbox features including the `<fencedframe>` element and related APIs.
+  according_to:
+    - https://groups.google.com/a/chromium.org/g/blink-dev/c/c9w5uH3eSuo/m/KcvocvF1DQAJ
+    - https://chromestatus.com/feature/6366274495053824
 compat_features:
   - api.Fence
   - api.Fence.getNestedConfigs

--- a/features/fencedframe.yml.dist
+++ b/features/fencedframe.yml.dist
@@ -4,11 +4,10 @@
 status:
   baseline: false
   support:
-    chrome: "126"
-    chrome_android: "126"
-    edge: "126"
+    chrome: "128"
+    chrome_android: "128"
+    edge: "128"
 compat_features:
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   chrome: "126"
@@ -35,6 +34,7 @@ compat_features:
   - http.headers.Content-Security-Policy.fenced-frame-src
   - http.headers.Sec-Fetch-Dest.fencedframe
 
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   chrome: "128"


### PR DESCRIPTION
This is like the other privacy sandbox features, though only caught now thanks to https://github.com/mdn/browser-compat-data/pull/30242 and https://github.com/web-platform-dx/web-features/pull/4258. I adapted the reason text from other privacy sandbox features.

For the removal date, I used the date given by the Chrome status dashboard for Chrome 154. It's probably not perfect, since Edge will probably follow on a later date. At some point, we should validate such dates; for that, I've filed https://github.com/web-platform-dx/web-features/issues/4259.

- Chrome status entry: https://chromestatus.com/feature/6366274495053824
- Intent-to-ship: https://groups.google.com/a/chromium.org/g/blink-dev/c/c9w5uH3eSuo/m/KcvocvF1DQAJ