### PR TITLE
Add stats to release artifacts

### DIFF
--- a/.github/workflows/publish_next_web-features.yml
+++ b/.github/workflows/publish_next_web-features.yml
@@ -67,6 +67,7 @@ jobs:
       - run: npm ci
 
       - run: npm run build
+      - run: npm run stats --silent -- > stats.json
 
       - name: Get package.json version
         id: version
@@ -123,3 +124,4 @@ jobs:
             schemas/data.schema.json
             data.proposed.json
             schemas/data.proposed.schema.json
+            stats.json

--- a/.github/workflows/publish_web-features.yml
+++ b/.github/workflows/publish_web-features.yml
@@ -33,9 +33,17 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
       - run: npm run build
-      - run: gh release upload ${{ github.ref_name }} packages/web-features/data.json data.extended.json schemas/data.schema.json data.proposed.json schemas/data.proposed.schema.json
+      - run: gh release upload ${{ github.ref_name }}
         env:
           GH_TOKEN: ${{ github.token }}
+          ARTIFACTS: >
+            ${{ env.package_dir }}/data.json
+            data.extended.json
+            schemas/data.schema.json
+            data.proposed.json
+            schemas/data.proposed.schema.json
+            stats.json
+
   publish:
     if: github.repository == 'web-platform-dx/web-features'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Towards https://github.com/web-platform-dx/web-features/issues/3510.

This PR adds `stats.json` as release artifacts (for both `next`-tagged releases and the regular stable releases).