### PR TITLE
`xslt`: mark as discouraged

### DIFF
--- a/features/xslt.yml
+++ b/features/xslt.yml
@@ -2,6 +2,11 @@
 name: XSLT
 description: The `XSLTProcessor` API transforms XML documents into new XML or HTML documents, using XSLT stylesheets. You can use XSLT to convert data between different XML schemas or to convert XML data into web pages or PDF documents. Also known as Extensible Stylesheet Language Transformations.
 spec: https://dom.spec.whatwg.org/#xslt
+discouraged:
+  reason: XSLT is a candidate for removal from browsers because browser implementations are highly susceptible to memory safety vulnerabilities.
+  according_to:
+    - https://html.spec.whatwg.org/#interactions-with-xpath-and-xslt
+    - https://dom.spec.whatwg.org/#xslt
 group: xml
 compat_features:
   - api.XSLTProcessor


### PR DESCRIPTION
XSLT is now formally discouraged by specification (a big thank you to @mfreed7 on this).

Specs:

- [HTML deprecation notice](https://html.spec.whatwg.org/#interactions-with-xpath-and-xslt)
- [DOM deprecation notice](https://dom.spec.whatwg.org/#xslt)

Related issues and PRs:
- https://github.com/web-platform-dx/web-features/issues/4253
- https://github.com/mdn/browser-compat-data/pull/30342
- https://github.com/whatwg/html/issues/11523
- https://github.com/whatwg/dom/pull/1499
- https://github.com/whatwg/html/pull/12805