### PR TITLE
`stats.ts`: fix miscalculation in mapped keys counts

### DIFF
--- a/scripts/stats.ts
+++ b/scripts/stats.ts
@@ -1,4 +1,5 @@
 import { Compat } from "compute-baseline/browser-compat-data";
+import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import yargs from "yargs";
@@ -118,12 +119,22 @@ export function stats(previous: Partial<Result>): Result {
   const unmappedNormalCompatKeysCount = unmappedKeys.difference(
     discourageableCompatKeys,
   ).size;
-  const mappedNormalCompatKeysCount =
-    mappedCompatKeysCount - unmappedNormalCompatKeysCount;
+  const mappedNormalCompatKeysCount = mappedCompatKeys.difference(
+    discourageableCompatKeys,
+  ).size;
   const unmappedDiscourageableCompatKeysCount =
     unmappedKeys.difference(normalCompatKeys).size;
   const mappedDiscourageableCompatKeysCount =
-    discourageableCompatKeysCount - unmappedDiscourageableCompatKeysCount;
+    mappedCompatKeys.difference(normalCompatKeys).size;
+
+  assert.equal(
+    mappedCompatKeysCount,
+    mappedNormalCompatKeysCount + mappedDiscourageableCompatKeysCount,
+  );
+  assert.equal(
+    unmappedCompatKeysCount,
+    unmappedNormalCompatKeysCount + unmappedDiscourageableCompatKeysCount,
+  );
 
   const featuresToDays = compatFeaturesToCumulativeDaysShipped();
   const unmappedDiscourageableCompatKeysCumulativeShippingDays = Array.from(


### PR DESCRIPTION
While doing some follow up work, I found an error in the calculation for the number of keys unmapped. This uses the set notation (and an `assert()` with arithmetic) to make sure that the figures add up properly.

See also: the sequel https://github.com/web-platform-dx/web-features/pull/4290.