### PR TITLE
`stats.ts`: fix error-able versions matching

### DIFF
--- a/scripts/stats.ts
+++ b/scripts/stats.ts
@@ -254,7 +254,7 @@ function parseReleaseTag(tag: string): SupportedReleaseTag {
     throw new Error("Release tags must be in SemVer-like vX.Y.Z format");
   }
 
-  if (major <= 3 && minor <= 35) {
+  if ((major == 3 && minor <= 35) || major <= 2) {
     throw new Error(
       "This script can't handle releases at or before v3.36.0. If you need such stats, then file an issue.",
     );


### PR DESCRIPTION
The previous iteration of this code matched versions like `2.34` but _not_ `2.36`. It should reject _all_ versions before v3.35.

Prequel to https://github.com/web-platform-dx/web-features/pull/4294.