### PR TITLE
Don't let `attr()`'s status block on `<url>` type

### DIFF
--- a/features/attr.yml
+++ b/features/attr.yml
@@ -4,21 +4,23 @@ spec: https://drafts.csswg.org/css-values-5/#attr-notation
 caniuse: css3-attr
 group: css
 compat_features:
-  - css.types.attr.declaration-value
-  - css.types.attr.fallback
-  - css.types.attr.type_function
-  - css.types.attr.type_function.angle
-  - css.types.attr.type_function.color
-  - css.types.attr.type_function.custom-ident
-  - css.types.attr.type_function.ident
-  - css.types.attr.type_function.image
-  - css.types.attr.type_function.integer
-  - css.types.attr.type_function.length
-  - css.types.attr.type_function.length-percentage
-  - css.types.attr.type_function.number
-  - css.types.attr.type_function.percentage
-  - css.types.attr.type_function.resolution
-  - css.types.attr.type_function.string
-  - css.types.attr.type_function.time
-  - css.types.attr.type_function.transform-function
-  - css.types.attr.type_function.url
+  core:
+    - css.types.attr.declaration-value
+    - css.types.attr.fallback
+    - css.types.attr.type_function
+    - css.types.attr.type_function.angle
+    - css.types.attr.type_function.color
+    - css.types.attr.type_function.custom-ident
+    - css.types.attr.type_function.ident
+    - css.types.attr.type_function.image
+    - css.types.attr.type_function.integer
+    - css.types.attr.type_function.length
+    - css.types.attr.type_function.length-percentage
+    - css.types.attr.type_function.number
+    - css.types.attr.type_function.percentage
+    - css.types.attr.type_function.resolution
+    - css.types.attr.type_function.string
+    - css.types.attr.type_function.time
+    - css.types.attr.type_function.transform-function
+  spare:
+    - css.types.attr.type_function.url

--- a/features/attr.yml.dist
+++ b/features/attr.yml.dist
@@ -3,7 +3,12 @@
 
 status:
   baseline: false
-  support: {}
+  support:
+    chrome: "133"
+    chrome_android: "133"
+    edge: "133"
+    firefox: "155"
+    firefox_android: "155"
 compat_features:
   # baseline: low
   # baseline_low_date: 2025-03-31
@@ -18,6 +23,7 @@ compat_features:
   - css.types.attr.declaration-value
   - css.types.attr.fallback
 
+  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support:
   #   chrome: "133"
@@ -41,7 +47,6 @@ compat_features:
   - css.types.attr.type_function.time
   - css.types.attr.type_function.transform-function
 
-  # ⬇️ Same status as overall feature ⬇️
   # baseline: false
   # support: {}
   - css.types.attr.type_function.url


### PR DESCRIPTION
The `<url>` type is probably a distinct feature. But since that's going to require a distinct name, description, spec, etc. I thought it would be nice to partly address https://github.com/web-platform-dx/web-features/issues/4329 right away by taking the `css.types.attr.type_function.url` key out of the critical path.