### PR TITLE
Add caniuse links to hyphenate-character and hyphenate-limit-chars

### DIFF
--- a/features/hyphenate-character.yml
+++ b/features/hyphenate-character.yml
@@ -1,6 +1,7 @@
 name: Hyphenate character
 description: The `hyphenate-character` CSS property sets the character or string to use at the end of a line before a line break.
 spec: https://drafts.csswg.org/css-text-4/#hyphenate-character
+caniuse: wf-hyphenate-character
 group: text-wrap
 compat_features:
   - css.properties.hyphenate-character

--- a/features/hyphenate-limit-chars.yml
+++ b/features/hyphenate-limit-chars.yml
@@ -1,6 +1,7 @@
 name: Hyphenate limit chars
 description: The `hyphenate-limit-chars` CSS property sets the number of characters in a word before it is hyphenated and the minimum number of characters on either side of the hyphen.
 spec: https://drafts.csswg.org/css-text-4/#hyphenate-char-limits
+caniuse: wf-hyphenate-limit-chars
 group: text-wrap
 compat_features:
   - css.properties.hyphenate-limit-chars


### PR DESCRIPTION
Noticed these were missing while doing some frontend archeology.

There are also dozens of other caniuse links missing. What would be the preferred way to update these? Add them to this PR or create several smaller PRs?