### PR TITLE
caniuse mappings: add helpful error message for `wf-` IDs

### DIFF
--- a/scripts/caniuse.ts
+++ b/scripts/caniuse.ts
@@ -30,6 +30,11 @@ export const caniuseToWebFeaturesId: Map<string, string | null> = (() => {
       continue;
     }
     for (const caniuseId of data.caniuse) {
+      if (caniuseId.startsWith("wf-")) {
+        throw new Error(
+          `Invalid caniuse ID used for ${id}: self-referential wf- feature IDs are not allowed`,
+        );
+      }
       if (!mapping.has(caniuseId)) {
         throw new Error(`Invalid caniuse ID used for ${id}: ${caniuseId}`);
       }


### PR DESCRIPTION
Inspired-by: https://github.com/web-platform-dx/web-features/pull/4343