### PR TITLE
Update `arianotify` spec URL

### DIFF
--- a/features/arianotify.yml
+++ b/features/arianotify.yml
@@ -1,6 +1,6 @@
 name: ariaNotify()
 description: The `ariaNotify()` method of `Element` and `Document` requests assistive technology software, if activated, to announce a message to the user. This can help make dynamic content changes more accessible to users.
-spec: https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Accessibility/AriaNotify/explainer.md
+spec: https://w3c.github.io/aria/#ARIANotifyMixin
 compat_features:
   - api.Element.ariaNotify
   - api.Document.ariaNotify

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -161,10 +161,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because the Topics API isn't on a standards track yet. Remove this exception when it is."
     ],
     [
-        "https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Accessibility/AriaNotify/explainer.md",
-        "Allowed because the ariaNotify() method is not yet in a formal spec. Remove this exception when a formal spec is available."
-    ],
-    [
         "https://github.com/whatwg/html/pull/11006",
         "Allowed because this spec PR hasn't landed yet. Once the PR merges, change the spec url and remove this exception."
     ],


### PR DESCRIPTION
ariaNotify() has since been adopted into the normative WAI-ARIA spec.
