### PR TITLE
Update `install` spec URL

### DIFF
--- a/features/install.yml
+++ b/features/install.yml
@@ -1,4 +1,4 @@
 name: <install>
 description: The `<install>` HTML element represents a button that, upon activation, prompts the user to choose whether to install a progressive web app.
 group: progressive-web-app
-spec: https://github.com/WICG/install-element
+spec: https://wicg.github.io/install-element/

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -185,10 +185,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because feature policy was replaced by permissions policy."
     ],
     [
-        "https://github.com/WICG/install-element",
-        "Allowed because the <install> element is available in Chrome/Edge as an origin trial."
-    ],
-    [
         "https://github.com/whatwg/html/pull/11723",
         "Allowed because the focusgroup spec PR hasn't landed yet. Once the PR merges, remove this and add the spec URL to the focusgroup feature."
     ],


### PR DESCRIPTION
Was linking the GitHub repo instead of the rendered spec page.
