### PR TITLE
Update `languagemodel` spec URL

### DIFF
--- a/features/languagemodel.yml
+++ b/features/languagemodel.yml
@@ -1,6 +1,6 @@
 name: LanguageModel
 description: The `LanguageModel` API prompts an on-device language model. Also known as the Prompt API.
-spec: http://webmachinelearning.github.io/prompt-api/
+spec: https://webmachinelearning.github.io/prompt-api/
 compat_features:
   # The follow keys are expected, at the time this feature was authored:
   # - http.headers.Permissions-Policy.language-model

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -193,10 +193,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because the focusgroup spec PR hasn't landed yet. Once the PR merges, remove this and add the spec URL to the focusgroup feature."
     ],
     [
-        "http://webmachinelearning.github.io/prompt-api/",
-        "Allowed because that's where LanguageModel (aka Prompt API) spec currently lives."
-    ],
-    [
         "https://jpeg.org/jpeg/#content",
         "Allowed because it's a spec not tracked in web-specs."
     ],


### PR DESCRIPTION
Was an http:// typo; same spec, correct scheme.
