### PR TITLE
Update `loading-lazy-media` spec URL

### DIFF
--- a/features/loading-lazy-media.yml
+++ b/features/loading-lazy-media.yml
@@ -1,12 +1,6 @@
 name: Lazy-loading media
 description: |
   The `loading="lazy"` attribute for `<video>` and `<audio>` elements defers loading the media resource until the element is near the viewport. This matches the lazy-loading behavior for `<img>` and `<iframe>` elements.
-spec: https://github.com/whatwg/html/pull/11980
+spec: https://html.spec.whatwg.org/multipage/media.html#attr-media-loading
 caniuse: loading-lazy-media
 group: media-elements
-# Expecting:
-# compat_features:
-#   - api.HTMLAudioElement.loading
-#   - api.HTMLVideoElement.loading
-#   - html.elements.audio.loading
-#   - html.elements.video.loading

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -169,10 +169,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because this spec PR hasn't landed yet. Once the PR merges, change the spec url and remove this exception."
     ],
     [
-        "https://github.com/whatwg/html/pull/11980",
-        "Allowed because this spec PR hasn't landed yet. Once the PR merges, change the spec URL and remove this exception."
-    ],
-    [
         "https://github.com/w3c/manifest/pull/1175",
         "Allowed because there is no spec yet for Web Install."
     ],


### PR DESCRIPTION
whatwg/html#11980 has merged, so point `spec:` at the built HTML spec
anchor instead of the PR.

Drop the "Expecting" placeholder BCD comment: the correct BCD keys
(api.HTMLMediaElement.loading rather than separate HTMLAudioElement
and HTMLVideoElement) are already tagged
web-features:loading-lazy-media in @mdn/browser-compat-data, so
dist.ts derives compat_features from those tags automatically without
needing them listed here too.
