### PR TITLE
Update `usermedia` spec URL

### DIFF
--- a/features/usermedia.yml
+++ b/features/usermedia.yml
@@ -2,7 +2,7 @@ name: <usermedia>
 description: >
   The `<usermedia>` HTML element represents a button that, upon activation, toggles camera or microphone streams.
   If needed, it may prompt the user to choose whether to grant the page access to the camera and microphone.
-spec: https://github.com/WICG/PEPC/blob/main/usermedia_element.md
+spec: https://w3c.github.io/mediacapture-extensions/#the-usermedia-html-element
 # Expected:
 # compat_features:
 #   - api.HTMLUserMediaElement

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -229,10 +229,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Discontinued spec allowed for discouraged feature."
     ],
     [
-        "https://github.com/WICG/PEPC/blob/main/usermedia_element.md",
-        "Replace with https://w3c.github.io/mediacapture-extensions/#the-usermedia-html-element when https://github.com/w3c/mediacapture-extensions/pull/168 merges."
-    ],
-    [
         "https://github.com/WICG/privacy-preserving-ads",
         "Discontinued spec allowed for discouraged feature."
     ],


### PR DESCRIPTION
The <usermedia> element is now normatively defined in the Media Capture Extensions spec.
