### PR TITLE
Update `wasm-branch-hinting` spec URL

### DIFF
--- a/features/wasm-branch-hinting.yml
+++ b/features/wasm-branch-hinting.yml
@@ -1,6 +1,6 @@
 name: Branch hinting (WebAssembly)
 description: Branch hints in WebAssembly allows a browser to optimize performance when a branch is a likely to take a specific path.
-spec: https://github.com/WebAssembly/branch-hinting/blob/main/proposals/branch-hinting/Overview.md
+spec: https://webassembly.github.io/branch-hinting/core/bikeshed/
 group: webassembly
 compat_features:
   - webassembly.branch-hinting

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -177,10 +177,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because there is no spec yet for Web Install."
     ],
     [
-        "https://github.com/WebAssembly/branch-hinting/blob/main/proposals/branch-hinting/Overview.md",
-        "Allowed because there is no other specification to link to."
-    ],
-    [
         "https://www.w3.org/TR/2019/WD-feature-policy-1-20190416/",
         "Allowed because feature policy was replaced by permissions policy."
     ],


### PR DESCRIPTION
Proposal now has a rendered Bikeshed spec instead of a bare markdown doc.
