### PR TITLE
Update `wasm-bulk-memory` spec URL

### DIFF
--- a/features/wasm-bulk-memory.yml
+++ b/features/wasm-bulk-memory.yml
@@ -1,6 +1,6 @@
 name: Bulk memory operations (WebAssembly)
 description: Bulk memory operations, such as `copy` and `init`, mirror the efficiency of native `memcpy` and `memmove` operations.
-spec: https://github.com/WebAssembly/spec/blob/main/proposals/bulk-memory-operations/Overview.md
+spec: https://webassembly.github.io/spec/core/bikeshed/
 caniuse: wasm-bulk-memory
 group: webassembly
 compat_features:

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -45,10 +45,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because this URL actually serves the same content as the Editor Draft URL, and because the ED URL is a bit verbose. See https://github.com/mdn/browser-compat-data/pull/22569#issuecomment-1992632118."
     ],
     [
-        "https://github.com/WebAssembly/spec/blob/main/proposals/bulk-memory-operations/Overview.md",
-        "Allowed because there is no other specification to link to."
-    ],
-    [
         "https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/Exceptions.md",
         "Allowed because there is no other specification to link to."
     ],


### PR DESCRIPTION
Bulk memory operations have been merged into the core WebAssembly spec.
