### PR TITLE
Update `wasm-extended-constant-expressions` spec URL

### DIFF
--- a/features/wasm-extended-constant-expressions.yml
+++ b/features/wasm-extended-constant-expressions.yml
@@ -1,6 +1,6 @@
 name: Extended constant expressions (WebAssembly)
 description: The `i32.add`, `i32.sub`, `i32.mul`, `i64.add`, `i64.sub`, and `i64.mul` operations extend constant expressions to include arithmetic.
-spec: https://github.com/WebAssembly/extended-const/blob/main/proposals/extended-const/Overview.md
+spec: https://webassembly.github.io/extended-const/core/bikeshed/
 group: webassembly
 compat_features:
   - webassembly.extended-constant-expressions

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -53,10 +53,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because there is no other specification to link to."
     ],
     [
-        "https://github.com/WebAssembly/extended-const/blob/main/proposals/extended-const/Overview.md",
-        "Allowed because there is no other specification to link to."
-    ],
-    [
         "https://github.com/WebAssembly/multi-memory/blob/main/proposals/multi-memory/Overview.md",
         "Allowed because there is no other specification to link to."
     ],


### PR DESCRIPTION
Proposal now has a rendered Bikeshed spec instead of a bare markdown doc.
