### PR TITLE
Update `wasm-jspi` spec URL

### DIFF
--- a/features/wasm-jspi.yml
+++ b/features/wasm-jspi.yml
@@ -1,6 +1,6 @@
 name: JavaScript promise integration (WebAssembly)
 description: The JavaScript promise integration (JSPI) suspends a WebAssembly module when it calls a JavaScript method that returns a promise. The module resumes when the promise is resolved. You can use this to call asynchronous Web APIs from synchronous WebAssembly.
-spec: https://github.com/WebAssembly/js-promise-integration/blob/main/proposals/js-promise-integration/Overview.md
+spec: https://webassembly.github.io/js-promise-integration/js-api/
 group: webassembly
 compat_features:
   - webassembly.jspi

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -105,10 +105,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because there is no other specification to link to."
     ],
     [
-        "https://github.com/WebAssembly/js-promise-integration/blob/main/proposals/js-promise-integration/Overview.md",
-        "Allowed because there is no other specification to link to."
-    ],
-    [
         "https://immersive-web.github.io/webvr/spec/1.1/",
         "Allowed because this is the legacy spec that defines WebVR."
     ],


### PR DESCRIPTION
Proposal now has a rendered Bikeshed spec instead of a bare markdown doc.
