### PR TITLE
Update `wasm-memory64` spec URL

### DIFF
--- a/features/wasm-memory64.yml
+++ b/features/wasm-memory64.yml
@@ -1,6 +1,6 @@
 name: Memory64 (WebAssembly)
 description: Instructions accept 64-bit memory indexes.
-spec: https://github.com/WebAssembly/memory64/blob/main/proposals/memory64/Overview.md
+spec: https://webassembly.github.io/memory64/core/bikeshed/
 group: webassembly
 compat_features:
   - webassembly.memory64

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -97,10 +97,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because there is no other specification to link to."
     ],
     [
-        "https://github.com/WebAssembly/memory64/blob/main/proposals/memory64/Overview.md",
-        "Allowed because there is no other specification to link to."
-    ],
-    [
         "https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/legacy/Exceptions.md",
         "Allowed because there is no other specification to link to."
     ],


### PR DESCRIPTION
Proposal now has a rendered Bikeshed spec instead of a bare markdown doc.
