### PR TITLE
Update `wasm-multi-memory` spec URL

### DIFF
--- a/features/wasm-multi-memory.yml
+++ b/features/wasm-multi-memory.yml
@@ -1,6 +1,6 @@
 name: Multi-memory (WebAssembly)
 description: A single module in WebAssembly can have multiple memories.
-spec: https://github.com/WebAssembly/multi-memory/blob/main/proposals/multi-memory/Overview.md
+spec: https://webassembly.github.io/multi-memory/core/bikeshed/
 group: webassembly
 compat_features:
   - webassembly.multiMemory

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -57,10 +57,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because there is no other specification to link to."
     ],
     [
-        "https://github.com/WebAssembly/multi-memory/blob/main/proposals/multi-memory/Overview.md",
-        "Allowed because there is no other specification to link to."
-    ],
-    [
         "https://github.com/WebAssembly/spec/blob/main/proposals/multi-value/Overview.md",
         "Allowed because there is no other specification to link to."
     ],


### PR DESCRIPTION
Proposal now has a rendered Bikeshed spec instead of a bare markdown doc.
