### PR TITLE
Update `wasm-multi-value` spec URL

### DIFF
--- a/features/wasm-multi-value.yml
+++ b/features/wasm-multi-value.yml
@@ -1,6 +1,6 @@
 name: Multi-value (WebAssembly)
 description: Instructions and blocks can produce multiple result values.
-spec: https://github.com/WebAssembly/spec/blob/main/proposals/multi-value/Overview.md
+spec: https://webassembly.github.io/spec/core/bikeshed/
 group: webassembly
 caniuse: wasm-multi-value
 compat_features:

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -61,10 +61,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because there is no other specification to link to."
     ],
     [
-        "https://github.com/WebAssembly/spec/blob/main/proposals/multi-value/Overview.md",
-        "Allowed because there is no other specification to link to."
-    ],
-    [
         "https://github.com/WebAssembly/spec/blob/main/proposals/nontrapping-float-to-int-conversion/Overview.md",
         "Allowed because there is no other specification to link to."
     ],


### PR DESCRIPTION
Multi-value has been merged into the core WebAssembly spec.
