### PR TITLE
Update `wasm-non-trapping-float-to-int` spec URL

### DIFF
--- a/features/wasm-non-trapping-float-to-int.yml
+++ b/features/wasm-non-trapping-float-to-int.yml
@@ -1,6 +1,6 @@
 name: Non-trapping float-to-int conversion (WebAssembly)
 description: Saturating floating-point to integer conversion operators return the maximum or minimum integer value on overflow instead of trapping.
-spec: https://github.com/WebAssembly/spec/blob/main/proposals/nontrapping-float-to-int-conversion/Overview.md
+spec: https://webassembly.github.io/spec/core/bikeshed/
 group: webassembly
 caniuse: wasm-nontrapping-fptoint
 compat_features:

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -65,10 +65,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because there is no other specification to link to."
     ],
     [
-        "https://github.com/WebAssembly/spec/blob/main/proposals/nontrapping-float-to-int-conversion/Overview.md",
-        "Allowed because there is no other specification to link to."
-    ],
-    [
         "https://github.com/WebAssembly/spec/blob/main/proposals/reference-types/Overview.md",
         "Allowed because there is no other specification to link to."
     ],


### PR DESCRIPTION
Non-trapping float-to-int has been merged into the core WebAssembly spec.
