### PR TITLE
Update `wasm-string-builtins` spec URL

### DIFF
--- a/features/wasm-string-builtins.yml
+++ b/features/wasm-string-builtins.yml
@@ -1,6 +1,6 @@
 name: String builtins (WebAssembly)
 description: The WebAssembly builtin string functions mirror a subset of the JavaScript `String` API and adapt it to be efficiently callable without JavaScript glue code.
-spec: https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md
+spec: https://webassembly.github.io/js-string-builtins/js-api/
 group: webassembly
 compat_features:
   - webassembly.jsStringBuiltins

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -93,10 +93,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because there is no other specification to link to."
     ],
     [
-        "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md",
-        "Allowed because there is no other specification to link to."
-    ],
-    [
         "https://github.com/WebAssembly/memory64/blob/main/proposals/memory64/Overview.md",
         "Allowed because there is no other specification to link to."
     ],


### PR DESCRIPTION
Proposal now has a rendered spec instead of a bare markdown doc.
