### PR TITLE
Update `wasm-tail-call-optimization` spec URL

### DIFF
--- a/features/wasm-tail-call-optimization.yml
+++ b/features/wasm-tail-call-optimization.yml
@@ -1,6 +1,6 @@
 name: Tail call optimization (WebAssembly)
 description: Tail call optimization discards a caller frame and replaces the call with a jump instruction.
-spec: https://github.com/WebAssembly/tail-call/blob/main/proposals/tail-call/Overview.md
+spec: https://webassembly.github.io/tail-call/core/bikeshed/
 group: webassembly
 compat_features:
   - webassembly.tail-calls

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -81,10 +81,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because there is no other specification to link to."
     ],
     [
-        "https://github.com/WebAssembly/tail-call/blob/main/proposals/tail-call/Overview.md",
-        "Allowed because there is no other specification to link to."
-    ],
-    [
         "https://github.com/WebAssembly/threads/blob/main/proposals/threads/Overview.md",
         "Allowed because there is no other specification to link to."
     ],


### PR DESCRIPTION
Proposal now has a rendered Bikeshed spec instead of a bare markdown doc.
