### PR TITLE
Update `wasm-typed-fun-refs` spec URL

### DIFF
--- a/features/wasm-typed-fun-refs.yml
+++ b/features/wasm-typed-fun-refs.yml
@@ -1,6 +1,6 @@
 name: Typed function references (WebAssembly)
 description: A typed function reference can be called directly.
-spec: https://github.com/WebAssembly/function-references/blob/main/proposals/function-references/Overview.md
+spec: https://webassembly.github.io/function-references/core/bikeshed/
 group: webassembly
 compat_features:
   - webassembly.typedFunctionReferences

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -89,10 +89,6 @@ const defaultAllowlist: allowlistItem[] = [
         "Allowed because there is no other specification to link to."
     ],
     [
-        "https://github.com/WebAssembly/function-references/blob/main/proposals/function-references/Overview.md",
-        "Allowed because there is no other specification to link to."
-    ],
-    [
         "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md",
         "Allowed because there is no other specification to link to."
     ],


### PR DESCRIPTION
Proposal now has a rendered Bikeshed spec instead of a bare markdown doc.
